### PR TITLE
Improve modeling of `Child` in CodeGeneration

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Child.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Child.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+
 /// The kind of token a node can contain. Either a token of a specific kind or a
 /// keyword with the given text.
 public enum TokenChoice: Equatable {
@@ -77,16 +79,16 @@ public class Child {
   }
 
   /// A name of this child that's suitable to be used for variable or enum case names.
-  public var varName: String {
-    return lowercaseFirstWord(name: name)
+  public var varOrCaseName: TokenSyntax {
+    return .identifier(lowercaseFirstWord(name: name))
   }
 
   /// The deprecated name of this child that's suitable to be used for variable or enum case names.
-  public var deprecatedVarName: String? {
+  public var deprecatedVarName: TokenSyntax? {
     guard let deprecatedName = deprecatedName else {
       return nil
     }
-    return lowercaseFirstWord(name: deprecatedName)
+    return .identifier(lowercaseFirstWord(name: deprecatedName))
   }
 
   /// If the child ends with "token" in the kind, it's considered a token node.

--- a/CodeGeneration/Sources/SyntaxSupport/Child.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Child.swift
@@ -58,12 +58,32 @@ public enum ChildKind {
 /// A child of a node, that may be declared optional or a token with a
 /// restricted subset of acceptable kinds or texts.
 public class Child {
+  /// The name of the child.
+  ///
+  /// The first character of the name is always uppercase.
   public let name: String
+
+  /// If the child has been renamed, its old, now deprecated, name.
+  ///
+  /// This is used to generate deprecated compatibility layers.
   public let deprecatedName: String?
+
+  /// The kind of the child (node, token, collection, ...)
   public let kind: ChildKind
-  public let nameForDiagnostics: String?
-  public let documentation: String?
+
+  /// Whether this child is optional and can be `nil`.
   public let isOptional: Bool
+
+  /// A name of this child that can be shown in diagnostics.
+  ///
+  /// This is used to e.g. describe the child if all of its tokens are missing in the source file.
+  public let nameForDiagnostics: String?
+
+  /// A doc comment describing the child.
+  public let documentation: SwiftSyntax.Trivia
+
+  /// The first line of the child's documentation
+  public let documentationAbstract: String
 
   public var syntaxNodeKind: SyntaxNodeKind {
     switch kind {
@@ -148,12 +168,6 @@ public class Child {
     }
   }
 
-  /// Returns `true` if this child's type is one of the base syntax kinds and
-  /// it's optional.
-  public var hasOptionalBaseType: Bool {
-    return hasBaseType && isOptional
-  }
-
   /// If a classification is passed, it specifies the color identifiers in
   /// that subtree should inherit for syntax coloring. Must be a member of
   /// ``SyntaxClassification``.
@@ -174,7 +188,8 @@ public class Child {
     self.deprecatedName = deprecatedName
     self.kind = kind
     self.nameForDiagnostics = nameForDiagnostics
-    self.documentation = documentation
+    self.documentation = docCommentTrivia(from: documentation)
+    self.documentationAbstract = String(documentation?.split(whereSeparator: \.isNewline).first ?? "")
     self.isOptional = isOptional
   }
 }

--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -181,6 +181,7 @@ public let COMMON_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#decl#>`, that can be inserted into the source code to represent the missing declaration.
+
           This token should always have `presence = .missing`.
           """
       ),
@@ -201,6 +202,7 @@ public let COMMON_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression.
+
           This token should always have `presence = .missing`.
           """
       )
@@ -221,6 +223,7 @@ public let COMMON_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#pattern#>`, that can be inserted into the source code to represent the missing pattern.
+
           This token should always have `presence = .missing`.
           """
       )
@@ -241,6 +244,7 @@ public let COMMON_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern.
+
           This token should always have `presence = .missing`.
           """
       )
@@ -261,6 +265,7 @@ public let COMMON_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern.
+
           This token should always have `presence = .missing`
           """
       )
@@ -280,7 +285,9 @@ public let COMMON_NODES: [Node] = [
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
-          A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
+          A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type.
+
+          This token should always have `presence = .missing`.
           """
       )
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -57,7 +57,7 @@ struct GrammarGenerator {
     return
       children
       .filter { !$0.isUnexpectedNodes }
-      .map { " - `\($0.varName)`: \(generator.grammar(for: $0))" }
+      .map { " - `\($0.varOrCaseName)`: \(generator.grammar(for: $0))" }
       .joined(separator: "\n")
   }
 }

--- a/CodeGeneration/Sources/SyntaxSupport/Utils.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Utils.swift
@@ -65,3 +65,15 @@ public extension Collection {
     }
   }
 }
+
+public extension TokenSyntax {
+  var backtickedIfNeeded: TokenSyntax {
+    if KEYWORDS.contains(where: {
+      $0.name == self.description && $0.isLexerClassified
+    }) {
+      return "`\(self)`"
+    } else {
+      return self
+    }
+  }
+}

--- a/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
@@ -39,18 +39,18 @@ extension LayoutNode {
         }
       }
 
-      let parameterName: String
+      let parameterName: TokenSyntax
 
       if useDeprecatedChildName, let deprecatedVarName = child.deprecatedVarName {
         parameterName = deprecatedVarName
       } else {
-        parameterName = child.varName
+        parameterName = child.varOrCaseName
       }
 
       return FunctionParameterSyntax(
         leadingTrivia: .newline,
-        firstName: child.isUnexpectedNodes ? .wildcardToken(trailingTrivia: .space) : .identifier(parameterName),
-        secondName: child.isUnexpectedNodes ? .identifier(parameterName) : nil,
+        firstName: child.isUnexpectedNodes ? .wildcardToken(trailingTrivia: .space) : parameterName,
+        secondName: child.isUnexpectedNodes ? parameterName : nil,
         colon: .colonToken(),
         type: paramType,
         defaultArgument: child.defaultInitialization
@@ -83,7 +83,7 @@ extension LayoutNode {
         return nil
       }
 
-      return "  - \(child.varName): \(firstLine)"
+      return "  - \(child.varOrCaseName): \(firstLine)"
     }
 
     let formattedParams = """
@@ -114,12 +114,12 @@ extension LayoutNode {
     for child in children {
       /// The expression that is used to call the default initializer defined above.
       let produceExpr: ExprSyntax
-      let childName: String
+      let childName: TokenSyntax
 
       if useDeprecatedChildName, let deprecatedVarName = child.deprecatedVarName {
         childName = deprecatedVarName
       } else {
-        childName = child.varName
+        childName = child.varOrCaseName
       }
 
       if child.type.isBuilderInitializable {
@@ -129,12 +129,12 @@ extension LayoutNode {
         if child.type.builderInitializableType != child.type {
           let param = Node.from(type: child.type).layoutNode!.singleNonDefaultedChild
           if child.isOptional {
-            produceExpr = ExprSyntax("\(raw: childName)Builder().map { \(raw: child.type.syntaxBaseName)(\(raw: param.varName): $0) }")
+            produceExpr = ExprSyntax("\(childName)Builder().map { \(raw: child.type.syntaxBaseName)(\(param.varOrCaseName): $0) }")
           } else {
-            produceExpr = ExprSyntax("\(raw: child.type.syntaxBaseName)(\(raw: param.varName): \(raw: childName)Builder())")
+            produceExpr = ExprSyntax("\(raw: child.type.syntaxBaseName)(\(param.varOrCaseName): \(childName)Builder())")
           }
         } else {
-          produceExpr = ExprSyntax("\(raw: childName)Builder()")
+          produceExpr = ExprSyntax("\(childName)Builder()")
         }
         builderParameters.append(
           FunctionParameterSyntax(
@@ -145,14 +145,20 @@ extension LayoutNode {
         produceExpr = convertFromSyntaxProtocolToSyntaxType(child: child, useDeprecatedChildName: useDeprecatedChildName)
         normalParameters.append(
           FunctionParameterSyntax(
-            firstName: .identifier(childName),
+            firstName: childName,
             colon: .colonToken(),
             type: child.parameterType,
             defaultArgument: child.defaultInitialization
           )
         )
       }
-      delegatedInitArgs.append(TupleExprElementSyntax(label: child.isUnexpectedNodes ? nil : child.varName, expression: produceExpr))
+      delegatedInitArgs.append(
+        TupleExprElementSyntax(
+          label: child.isUnexpectedNodes ? nil : child.varOrCaseName,
+          colon: child.isUnexpectedNodes ? nil : .colonToken(),
+          expression: produceExpr
+        )
+      )
     }
 
     guard shouldCreateInitializer else {
@@ -185,11 +191,11 @@ extension LayoutNode {
 }
 
 fileprivate func convertFromSyntaxProtocolToSyntaxType(child: Child, useDeprecatedChildName: Bool = false) -> ExprSyntax {
-  let childName: String
+  let childName: TokenSyntax
   if useDeprecatedChildName, let deprecatedVarName = child.deprecatedVarName {
     childName = deprecatedVarName
   } else {
-    childName = child.varName
+    childName = child.varOrCaseName
   }
 
   if child.type.isBaseType && !child.kind.isNodeChoices {

--- a/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
@@ -77,13 +77,10 @@ extension LayoutNode {
 
   func generateInitializerDocComment() -> SwiftSyntax.Trivia {
     func generateParamDocComment(for child: Child) -> String? {
-      guard let documentation = child.documentation,
-        let firstLine = documentation.split(whereSeparator: \.isNewline).first
-      else {
+      if child.documentationAbstract.isEmpty {
         return nil
       }
-
-      return "  - \(child.varOrCaseName): \(firstLine)"
+      return "  - \(child.varOrCaseName): \(child.documentationAbstract)"
     }
 
     let formattedParams = """

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/ChildNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/ChildNameForDiagnosticsFile.swift
@@ -25,7 +25,7 @@ let childNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader
       for node in NON_BASE_SYNTAX_NODES.compactMap(\.layoutNode) {
         for child in node.children {
           if let nameForDiagnostics = child.nameForDiagnostics {
-            SwitchCaseSyntax("case \\\(raw: node.type.syntaxBaseName).\(raw: child.varName):") {
+            SwitchCaseSyntax("case \\\(raw: node.type.syntaxBaseName).\(child.varOrCaseName):") {
               StmtSyntax(#"return "\#(raw: nameForDiagnostics)""#)
             }
           }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/ChildNameForKeyPathFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/ChildNameForKeyPathFile.swift
@@ -29,8 +29,8 @@ let childNameForKeyPathFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         for child in node.children {
           SwitchCaseSyntax(
             """
-            case \\\(raw: node.type.syntaxBaseName).\(raw: child.varName):
-              return \(literal: child.varName)
+            case \\\(raw: node.type.syntaxBaseName).\(child.varOrCaseName):
+              return \(literal: child.varOrCaseName.description)
             """
           )
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
@@ -25,13 +25,13 @@ let renamedChildrenCompatibilityFile = try! SourceFileSyntax(leadingTrivia: copy
 
           DeclSyntax(
             """
-            @available(*, deprecated, renamed: "\(raw: child.varName)")
+            @available(*, deprecated, renamed: "\(child.varOrCaseName)")
             public var \(raw: deprecatedVarName): \(raw: type) {
               get {
-                return \(raw: child.varName.backtickedIfNeeded)
+                return \(child.varOrCaseName.backtickedIfNeeded)
               }
               set {
-                \(raw: child.varName.backtickedIfNeeded) = newValue
+                \(child.varOrCaseName.backtickedIfNeeded) = newValue
               }
             }
             """
@@ -57,7 +57,7 @@ let renamedChildrenCompatibilityFile = try! SourceFileSyntax(leadingTrivia: copy
 
       let deprecatedNames = layoutNode.children
         .filter { !$0.isUnexpectedNodes && $0.deprecatedName != nil }
-        .map { $0.varName }
+        .map { $0.varOrCaseName.description }
         .joined(separator: ", ")
 
       try! InitializerDeclSyntax(
@@ -71,9 +71,13 @@ let renamedChildrenCompatibilityFile = try! SourceFileSyntax(leadingTrivia: copy
           TupleExprElementSyntax(label: "leadingTrivia", expression: ExprSyntax("leadingTrivia"))
           for child in layoutNode.children {
             if child.isUnexpectedNodes {
-              TupleExprElementSyntax(expression: ExprSyntax("\(raw: child.deprecatedVarName ?? child.varName)"))
+              TupleExprElementSyntax(expression: ExprSyntax("\(raw: child.deprecatedVarName ?? child.varOrCaseName)"))
             } else {
-              TupleExprElementSyntax(label: "\(child.varName)", expression: ExprSyntax("\(raw: child.deprecatedVarName ?? child.varName)"))
+              TupleExprElementSyntax(
+                label: child.varOrCaseName,
+                colon: .colonToken(),
+                expression: IdentifierExprSyntax(identifier: child.deprecatedVarName ?? child.varOrCaseName)
+              )
             }
           }
           TupleExprElementSyntax(label: "trailingTrivia", expression: ExprSyntax("trailingTrivia"))

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -15,17 +15,6 @@ import SwiftSyntaxBuilder
 import SyntaxSupport
 import Utils
 
-extension Child {
-  public var docComment: SwiftSyntax.Trivia {
-    guard let description = documentation else {
-      return []
-    }
-    let lines = description.split(separator: "\n", omittingEmptySubsequences: false)
-    let pieces = lines.map { SwiftSyntax.TriviaPiece.docLineComment("/// \($0)") }
-    return Trivia(pieces: pieces)
-  }
-}
-
 /// This file generates the syntax nodes for SwiftSyntax. To keep the generated
 /// files at a manageable file size, it is to be invoked multiple times with the
 /// variable `emitKind` set to a base kind listed in
@@ -168,7 +157,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
 
           try! VariableDeclSyntax(
             """
-            \(raw: child.docComment)
+            \(raw: child.documentation)
             public var \(child.varOrCaseName.backtickedIfNeeded): \(type)
             """
           ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -29,7 +29,7 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         DeclSyntax(
           """
           \(raw: child.docComment)
-          var \(raw: child.varName): \(child.syntaxNodeKind.syntaxType)\(raw: child.isOptional ? "?" : "") { get set }
+          var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(raw: child.isOptional ? "?" : "") { get set }
           """
         )
       }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -28,7 +28,7 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       for child in trait.children {
         DeclSyntax(
           """
-          \(raw: child.docComment)
+          \(raw: child.documentation)
           var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(raw: child.isOptional ? "?" : "") { get set }
           """
         )

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/RenamedChildrenBuilderCompatibilityFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/RenamedChildrenBuilderCompatibilityFile.swift
@@ -22,7 +22,7 @@ let renamedChildrenBuilderCompatibilityFile = try! SourceFileSyntax(leadingTrivi
     if let convenienceInit = try layoutNode.createConvenienceBuilderInitializer(useDeprecatedChildName: true) {
       let deprecatedNames = layoutNode.children
         .filter { !$0.isUnexpectedNodes && $0.deprecatedName != nil }
-        .compactMap { $0.varName }
+        .compactMap { $0.varOrCaseName.description }
         .joined(separator: ", ")
 
       DeclSyntax(

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -4803,7 +4803,9 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#decl#>`, that can be inserted into the source code to represent the missing declaration./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#decl#>`, that can be inserted into the source code to represent the missing declaration.
+  /// 
+  /// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -4171,7 +4171,9 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression.
+  /// 
+  /// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -13475,7 +13475,9 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`
+  /// A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern.
+  /// 
+  /// This token should always have `presence = .missing`
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -363,7 +363,9 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#pattern#>`, that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#pattern#>`, that can be inserted into the source code to represent the missing pattern.
+  /// 
+  /// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -1589,7 +1589,9 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern.
+  /// 
+  /// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -1550,7 +1550,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - placeholder: A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
+  ///   - placeholder: A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -1586,7 +1586,9 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type.
+  /// 
+  /// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)


### PR DESCRIPTION
Two changes:
- Make `Child.varName` a `TokenSyntax`
- Change type of `Child.documentation` to `Trivia`
  - This also fixes a bug that caused multi-line documentation of children to be rendered incorrectly