### PR TITLE
Return a `keyPathInParent` for syntax collections

### DIFF
--- a/Sources/SwiftSyntax/SyntaxNodeStructure.swift
+++ b/Sources/SwiftSyntax/SyntaxNodeStructure.swift
@@ -20,7 +20,7 @@ public enum SyntaxNodeStructure: Sendable {
   /// The node contains a fixed number of children which can be accessed by these key paths.
   case layout([AnyKeyPath & Sendable])
 
-  /// The node is a `SyntaxCollection` of the given type.
+  /// The node is a `SyntaxCollection` with elements of the given type.
   case collection(SyntaxProtocol.Type)
 
   /// The node can contain a single node with one of the listed types.

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -263,4 +263,17 @@ class SyntaxCollectionsTests: XCTestCase {
     // The filtered sequence should have the `ArrayExprSyntax` as a parent
     XCTAssert(filteredElements.parent?.is(ArrayExprSyntax.self) ?? false)
   }
+
+  public func testKeyPathInParent() throws {
+    let arrayElementList = ArrayElementListSyntax([
+      integerLiteralElement(0),
+      integerLiteralElement(1),
+      integerLiteralElement(2),
+    ])
+
+    let element = arrayElementList[1]
+    let keyPath = try XCTUnwrap(element.keyPathInParent)
+    XCTAssert(type(of: keyPath).rootType == ArrayElementListSyntax.self)
+    XCTAssert(type(of: keyPath).valueType == ArrayElementSyntax.self)
+  }
 }


### PR DESCRIPTION
Previously, `keyPathInParent` returned `nil` for nodes that occurred in `SyntaxCollection`s. Return a subscript-based key path instead.

rdar://111944659