### PR TITLE
[6.0][Windows] Avoid linking with swiftWinSDK.dll

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -13,6 +13,7 @@ builder:
       - SwiftCompilerPluginMessageHandling
       - SwiftDiagnostics
       - SwiftIDEUtils
+      - SwiftLibraryPluginProvider
       - SwiftOperators
       - SwiftParser
       - SwiftParserDiagnostics

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     .library(name: "SwiftCompilerPluginMessageHandling", targets: ["SwiftCompilerPluginMessageHandling"]),
     .library(name: "SwiftDiagnostics", targets: ["SwiftDiagnostics"]),
     .library(name: "SwiftIDEUtils", targets: ["SwiftIDEUtils"]),
+    .library(name: "SwiftLibraryPluginProvider", targets: ["SwiftLibraryPluginProvider"]),
     .library(name: "SwiftOperators", targets: ["SwiftOperators"]),
     .library(name: "SwiftParser", targets: ["SwiftParser"]),
     .library(name: "SwiftParserDiagnostics", targets: ["SwiftParserDiagnostics"]),
@@ -143,7 +144,12 @@ let package = Package(
 
     .target(
       name: "SwiftLibraryPluginProvider",
-      dependencies: ["SwiftSyntaxMacros", "SwiftCompilerPluginMessageHandling"],
+      dependencies: ["SwiftSyntaxMacros", "SwiftCompilerPluginMessageHandling", "_SwiftLibraryPluginProviderCShims"],
+      exclude: ["CMakeLists.txt"]
+    ),
+
+    .target(
+      name: "_SwiftLibraryPluginProviderCShims",
       exclude: ["CMakeLists.txt"]
     ),
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -6,6 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+add_subdirectory(_SwiftLibraryPluginProviderCShims)
 add_subdirectory(_SwiftSyntaxCShims)
 add_subdirectory(SwiftBasicFormat)
 add_subdirectory(SwiftSyntax)

--- a/Sources/SwiftLibraryPluginProvider/CMakeLists.txt
+++ b/Sources/SwiftLibraryPluginProvider/CMakeLists.txt
@@ -9,7 +9,9 @@
 add_swift_syntax_library(SwiftLibraryPluginProvider
   LibraryPluginProvider.swift
 )
-
+target_link_libraries(SwiftLibraryPluginProvider PRIVATE
+  _SwiftLibraryPluginProviderCShims
+)
 target_link_swift_syntax_libraries(SwiftLibraryPluginProvider PUBLIC
   SwiftSyntaxMacros
   SwiftCompilerPluginMessageHandling

--- a/Sources/SwiftLibraryPluginProvider/LibraryPluginProvider.swift
+++ b/Sources/SwiftLibraryPluginProvider/LibraryPluginProvider.swift
@@ -13,6 +13,7 @@
 #if swift(>=6.0)
 public import SwiftSyntaxMacros
 @_spi(PluginMessage) public import SwiftCompilerPluginMessageHandling
+private import _SwiftLibraryPluginProviderCShims
 // NOTE: Do not use '_SwiftSyntaxCShims' for 'dlopen' and 'LoadLibraryW' (Windows)
 // because we don't want other modules depend on 'WinSDK'.
 #if canImport(Darwin)
@@ -21,20 +22,17 @@ private import Darwin
 private import Glibc
 #elseif canImport(Musl)
 private import Musl
-#elseif canImport(WinSDK)
-private import WinSDK
 #endif
 #else
 import SwiftSyntaxMacros
 @_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
+@_implementationOnly import _SwiftLibraryPluginProviderCShims
 #if canImport(Darwin)
 @_implementationOnly import Darwin
 #elseif canImport(Glibc)
 @_implementationOnly import Glibc
 #elseif canImport(Musl)
 @_implementationOnly import Musl
-#elseif canImport(WinSDK)
-@_implementationOnly import WinSDK
 #endif
 #endif
 
@@ -130,9 +128,9 @@ private func _loadLibrary(_ path: String) throws -> UnsafeMutableRawPointer {
   let end = utf16Path.initialize(fromContentsOf: path.utf16)
   utf16Path.initializeElement(at: end, to: 0)
 
-  guard let dlHandle = LoadLibraryW(utf16Path.baseAddress) else {
+  guard let dlHandle = swiftlibrarypluginprovider_LoadLibraryW(utf16Path.baseAddress) else {
     // FIXME: Format the error code to string.
-    throw LibraryPluginError(message: "loader error: \(GetLastError())")
+    throw LibraryPluginError(message: "loader error: \(swiftlibrarypluginprovider_GetLastError())")
   }
   return UnsafeMutableRawPointer(dlHandle)
 }

--- a/Sources/_SwiftLibraryPluginProviderCShims/CMakeLists.txt
+++ b/Sources/_SwiftLibraryPluginProviderCShims/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(_SwiftLibraryPluginProviderCShims STATIC
+  LoadLibrary.c
+)
+target_include_directories(_SwiftLibraryPluginProviderCShims PUBLIC "include")
+set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS _SwiftLibraryPluginProviderCShims)
+install(TARGETS _SwiftLibraryPluginProviderCShims EXPORT SwiftSyntaxTargets)

--- a/Sources/_SwiftLibraryPluginProviderCShims/LoadLibrary.c
+++ b/Sources/_SwiftLibraryPluginProviderCShims/LoadLibrary.c
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "LoadLibrary.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <libloaderapi.h>
+#include <errhandlingapi.h>
+
+void *swiftlibrarypluginprovider_LoadLibraryW(uint16_t *lpLibFileName) {
+  return LoadLibraryW(lpLibFileName);
+}
+
+unsigned long swiftlibrarypluginprovider_GetLastError() {
+  return GetLastError();
+}
+
+#endif /* _WIN32 */

--- a/Sources/_SwiftLibraryPluginProviderCShims/include/LoadLibrary.h
+++ b/Sources/_SwiftLibraryPluginProviderCShims/include/LoadLibrary.h
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_LIBRARY_PLUGIN_PROVIDER_LOAD_LIBRARY_H
+#define SWIFT_LIBRARY_PLUGIN_PROVIDER_LOAD_LIBRARY_H
+
+#ifdef _WIN32
+
+#include <stdint.h>
+
+void *swiftlibrarypluginprovider_LoadLibraryW(uint16_t *lpLibFileName);
+unsigned long swiftlibrarypluginprovider_GetLastError();
+
+#endif /* _WIN32 */
+
+#endif /* SWIFT_LIBRARY_PLUGIN_PROVIDER_LOAD_LIBRARY_H */

--- a/Sources/_SwiftLibraryPluginProviderCShims/include/module.modulemap
+++ b/Sources/_SwiftLibraryPluginProviderCShims/include/module.modulemap
@@ -1,0 +1,4 @@
+module _SwiftLibraryPluginProviderCShims {
+  header "LoadLibrary.h"
+  export *
+}


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/2685 into `release/6.0`

* **Explanation**: Avoid `import WinSDK` in swift sources or `#include <windows.h>` in headers. This is to avoid linking with Swift overlay library (`swiftWinSDK.dll`) so `swift-frontend` with plugins won't depends on it.
* **Scope**: swift-pluign-server
* **Risk**: Low. Although this adds a new component `_SwiftLibraryPluginProviderCShims` to the build system, it's just a static library so the final product should be equivalent, as long as the build succeeds
* **Testing**: Passes current test suite
* **Issues**: N/A
* **Reviewer**: Saleem Abdulrasool (@compnerd)