### PR TITLE
Expand trailing comma implementation

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -378,7 +378,7 @@ extension Parser {
       return parseAttribute(argumentMode: .customAttribute) { parser in
         let arguments = parser.parseArgumentListElements(
           pattern: .none,
-          allowTrailingComma: parser.experimentalFeatures.contains(.trailingComma)
+          allowTrailingComma: true
         )
         return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -376,7 +376,10 @@ extension Parser {
       }
     case nil:
       return parseAttribute(argumentMode: .customAttribute) { parser in
-        let arguments = parser.parseArgumentListElements(pattern: .none, allowTrailingComma: false)
+        let arguments = parser.parseArgumentListElements(
+          pattern: .none,
+          allowTrailingComma: parser.experimentalFeatures.contains(.trailingComma)
+        )
         return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }
     }

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -47,10 +47,15 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && self.hasProgressed(&availabilityArgumentProgress)
+      } while keepGoing != nil && !self.atAvailabilitySpecListTerminator()
+        && self.hasProgressed(&availabilityArgumentProgress)
     }
 
     return RawAvailabilityArgumentListSyntax(elements: elements, arena: self.arena)
+  }
+
+  mutating func atAvailabilitySpecListTerminator() -> Bool {
+    return self.experimentalFeatures.contains(.trailingComma) && self.at(.rightParen)
   }
 
   enum AvailabilityArgumentKind: TokenSpecSet {

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -47,15 +47,11 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && !self.atAvailabilitySpecListTerminator()
+      } while keepGoing != nil
         && self.hasProgressed(&availabilityArgumentProgress)
     }
 
     return RawAvailabilityArgumentListSyntax(elements: elements, arena: self.arena)
-  }
-
-  mutating func atAvailabilitySpecListTerminator() -> Bool {
-    return self.experimentalFeatures.contains(.trailingComma) && self.at(.rightParen)
   }
 
   enum AvailabilityArgumentKind: TokenSpecSet {

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -520,7 +520,7 @@ extension Parser {
   }
 
   mutating func atGenericParametersListTerminator() -> Bool {
-    return self.experimentalFeatures.contains(.trailingComma) && self.at(prefix: ">")
+    return self.at(prefix: ">")
   }
 
   mutating func parseGenericWhereClause() -> RawGenericWhereClauseSyntax {
@@ -2039,7 +2039,7 @@ extension Parser {
     if leftParen != nil {
       args = parseArgumentListElements(
         pattern: .none,
-        allowTrailingComma: self.experimentalFeatures.contains(.trailingComma)
+        allowTrailingComma: true
       )
       (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     } else {

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -749,7 +749,7 @@ extension Parser {
         let args = self.parseArgumentListElements(
           pattern: pattern,
           flavor: flavor.callArgumentFlavor,
-          allowTrailingComma: experimentalFeatures.contains(.trailingComma)
+          allowTrailingComma: true
         )
         let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
 
@@ -788,7 +788,7 @@ extension Parser {
         } else {
           args = self.parseArgumentListElements(
             pattern: pattern,
-            allowTrailingComma: self.experimentalFeatures.contains(.trailingComma)
+            allowTrailingComma: true
           )
         }
         let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquare)
@@ -1024,7 +1024,7 @@ extension Parser {
         } else {
           args = self.parseArgumentListElements(
             pattern: pattern,
-            allowTrailingComma: self.experimentalFeatures.contains(.trailingComma)
+            allowTrailingComma: true
           )
         }
         let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquare)
@@ -1322,7 +1322,7 @@ extension Parser {
     if leftParen != nil {
       args = parseArgumentListElements(
         pattern: pattern,
-        allowTrailingComma: self.experimentalFeatures.contains(.trailingComma)
+        allowTrailingComma: true
       )
       (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     } else {
@@ -1439,7 +1439,7 @@ extension Parser {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let elements = self.parseArgumentListElements(
       pattern: pattern,
-      allowTrailingComma: experimentalFeatures.contains(.trailingComma)
+      allowTrailingComma: true
     )
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawTupleExprSyntax(

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -315,7 +315,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && self.hasProgressed(&loopProgress)
+      } while keepGoing != nil && !self.atInheritanceListTerminator() && self.hasProgressed(&loopProgress)
     }
 
     let unexpectedAfterInheritedTypeCollection: RawUnexpectedNodesSyntax?
@@ -337,6 +337,10 @@ extension Parser {
       unexpectedAfterInheritedTypeCollection,
       arena: self.arena
     )
+  }
+
+  mutating func atInheritanceListTerminator() -> Bool {
+    return self.experimentalFeatures.contains(.trailingComma) && (self.at(.leftBrace) || self.at(.keyword(.where)))
   }
 
   mutating func parsePrimaryAssociatedTypes() -> RawPrimaryAssociatedTypeClauseSyntax {

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -551,7 +551,10 @@ extension Parser {
         )
         let leftParen = self.expectWithoutRecoveryOrLeadingTrivia(.leftParen)
         let expressions = RawLabeledExprListSyntax(
-          elements: self.parseArgumentListElements(pattern: .none, allowTrailingComma: false),
+          elements: self.parseArgumentListElements(
+            pattern: .none,
+            allowTrailingComma: self.experimentalFeatures.contains(.trailingComma)
+          ),
           arena: self.arena
         )
 

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -553,7 +553,7 @@ extension Parser {
         let expressions = RawLabeledExprListSyntax(
           elements: self.parseArgumentListElements(
             pattern: .none,
-            allowTrailingComma: self.experimentalFeatures.contains(.trailingComma)
+            allowTrailingComma: true
           ),
           arena: self.arena
         )

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -1025,7 +1025,10 @@ extension Parser {
       }
     case nil:  // Custom attribute
       return parseAttribute(argumentMode: .customAttribute) { parser in
-        let arguments = parser.parseArgumentListElements(pattern: .none, allowTrailingComma: false)
+        let arguments = parser.parseArgumentListElements(
+          pattern: .none,
+          allowTrailingComma: parser.experimentalFeatures.contains(.trailingComma)
+        )
         return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -1027,7 +1027,7 @@ extension Parser {
       return parseAttribute(argumentMode: .customAttribute) { parser in
         let arguments = parser.parseArgumentListElements(
           pattern: .none,
-          allowTrailingComma: parser.experimentalFeatures.contains(.trailingComma)
+          allowTrailingComma: true
         )
         return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }

--- a/Tests/SwiftParserTest/TrailingCommaTests.swift
+++ b/Tests/SwiftParserTest/TrailingCommaTests.swift
@@ -231,4 +231,113 @@ final class TrailingCommaTests: ParserTestCase {
   func testWhileConditions() {
     assertParse("while true, { print(0) }")
   }
+
+  func testSubscriptArguments() {
+    assertParse("d[1, 2,]")
+  }
+
+  func testStringLiteralInterpolation() {
+    assertParse(#""\(1, 2,)""#)
+  }
+
+  func testKeyPathExpressionArguments() {
+    assertParse(
+      """
+      \\Foo.bar[0,]
+      """
+    )
+  }
+
+  func testCustomAttributes() {
+    assertParse("@Foo(a, b, c,) struct S { }")
+    
+    assertParse("f(_: @foo(1, 2,) Int)")
+  }
+
+  func testTypeAttribute() {
+    assertParse("f(_: @foo(1, 2,) Int)")
+  }
+
+  func testMacroExpansionExpressionArguments() {
+    assertParse(
+      """
+      #foo(1, 2,)
+      """
+    )
+  }
+
+  func testMacroExpansionDeclarationArguments() {
+    assertParse(
+      """
+      struct S {
+      #foo(1, 2,)
+      }
+      """
+    )
+  }
+
+  func testGenericParameters() {
+    assertParse(
+      """
+      struct S<T1, T2,> { }
+      """
+    )
+  }
+
+  func testSwitchCaseLabel() {
+    assertParse(
+      """
+      switch number {
+      case 1, 2,:
+          break
+      default:
+          break
+      }
+      """
+    )
+  }
+
+  func testClosureCaptureList() {
+    assertParse(
+      """
+      { [obj1, obj2,] in }
+      """
+    )
+  }
+
+  func testInheritance() {
+    assertParse(
+      """
+      struct T: P1, P2, { }
+      """
+    )
+
+    assertParse(
+      """
+      struct T: P1, P2, where P1: Equatable, P2: Equatable { }
+      """
+    )
+  }
+
+  func testGenericWhereClause() {
+    assertParse(
+      """
+      struct T: P1, P2, where P1: Equatable, P2: Equatable, { }
+      """
+    )
+  }
+
+  func testAvailabilityArgumentSpecList() {
+    assertParse(
+      """
+      if #available(iOS 15, watchOS 9, *,) { }
+      """
+    )
+
+    assertParse(
+      """
+      if #unavailable(iOS 15, watchOS 9,) { }
+      """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/TrailingCommaTests.swift
+++ b/Tests/SwiftParserTest/TrailingCommaTests.swift
@@ -15,7 +15,6 @@ import SwiftSyntax
 import XCTest
 
 final class TrailingCommaTests: ParserTestCase {
-  override var experimentalFeatures: Parser.ExperimentalFeatures { [.trailingComma] }
 
   func testTuple() {
     assertParse("(1, 2, 3,)")
@@ -60,178 +59,6 @@ final class TrailingCommaTests: ParserTestCase {
     )
   }
 
-  func testIfConditions() {
-    assertParse("if true, { }")
-
-    assertParse("if true, { }; { }()")
-
-    assertParse(
-      """
-      if true, { print("if-body") } else { print("else-body") }
-      """
-    )
-
-    assertParse(
-      """
-      if true, { print("if-body") } else if true, { print("else-if-body") } { print("else-body") }
-      """
-    )
-
-    assertParse("if true, { if true { { } } }")
-
-    assertParse("{ if true, { print(0) } }")
-
-    assertParse("( if true, { print(0) } )")
-
-    assertParse(
-      """
-      if true, { true }() { print(0) }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax(condition: .expression("true"), trailingComma: .commaToken()),
-          ConditionElementSyntax(condition: .expression("{ true }()"), trailingComma: nil),
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      """
-      if true, { true }, { print(0) }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
-          ConditionElementSyntax.init(condition: .expression("{ true }"), trailingComma: .commaToken()),
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      """
-      if true, { true } { print(0) }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
-          ConditionElementSyntax.init(condition: .expression("{ true }"), trailingComma: nil),
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      """
-      if true, { print(0) }
-      { }()
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken())
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      """
-      if true, { true }
-      { print(0) }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken())
-        ],
-        body: "{ true }"
-      )
-    )
-
-    assertParse(
-      """
-      if true, { true }
-      ,{ print(0) }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
-          ConditionElementSyntax.init(condition: .expression("{ true }"), trailingComma: .commaToken()),
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      """
-      if true,
-      { true }+++ { print(0) }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
-          ConditionElementSyntax.init(condition: .expression("{ true }+++"), trailingComma: nil),
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      """
-      if true, { (x: () -> Void) in true } != nil { print(0) }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
-          ConditionElementSyntax.init(condition: .expression("{ (x: () -> Void) in true } != nil"), trailingComma: nil),
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      """
-      if true, { (x: () -> Void) in true }
-      != nil
-      {
-        print(0)
-      }
-      """,
-      substructure: IfExprSyntax(
-        conditions: [
-          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
-          ConditionElementSyntax.init(condition: .expression("{ (x: () -> Void) in true } != nil"), trailingComma: nil),
-        ],
-        body: "{ print(0) }"
-      )
-    )
-
-    assertParse(
-      "if 1️⃣, { }",
-      diagnostics: [DiagnosticSpec(message: "missing condition in 'if' statement")]
-    )
-  }
-
-  func testGuardConditions() {
-    assertParse("guard true, else { break }")
-
-    assertParse(
-      "guard true, 1️⃣, else { return }",
-      diagnostics: [DiagnosticSpec(message: "expected expression in 'guard' statement", fixIts: ["insert expression"])],
-      fixedSource: "guard true, <#expression#>, else { return }"
-    )
-
-    assertParse(
-      "guard true, 1️⃣{ return }",
-      diagnostics: [DiagnosticSpec(message: "expected 'else' in 'guard' statement", fixIts: ["insert 'else'"])],
-      fixedSource: "guard true, else { return }"
-    )
-  }
-
-  func testWhileConditions() {
-    assertParse("while true, { print(0) }")
-  }
-
   func testSubscriptArguments() {
     assertParse("d[1, 2,]")
   }
@@ -250,11 +77,7 @@ final class TrailingCommaTests: ParserTestCase {
 
   func testCustomAttributes() {
     assertParse("@Foo(a, b, c,) struct S { }")
-    
-    assertParse("f(_: @foo(1, 2,) Int)")
-  }
 
-  func testTypeAttribute() {
     assertParse("f(_: @foo(1, 2,) Int)")
   }
 
@@ -284,6 +107,200 @@ final class TrailingCommaTests: ParserTestCase {
     )
   }
 
+  func testClosureCaptureList() {
+    assertParse(
+      """
+      { [obj1, obj2,] in }
+      """
+    )
+  }
+
+  func testIfConditions() {
+    assertParse("if true, { }", experimentalFeatures: .trailingComma)
+
+    assertParse("if true, { }; { }()", experimentalFeatures: .trailingComma)
+
+    assertParse(
+      """
+      if true, { print("if-body") } else { print("else-body") }
+      """,
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { print("if-body") } else if true, { print("else-if-body") } { print("else-body") }
+      """,
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse("if true, { if true { { } } }", experimentalFeatures: .trailingComma)
+
+    assertParse("{ if true, { print(0) } }", experimentalFeatures: .trailingComma)
+
+    assertParse("( if true, { print(0) } )", experimentalFeatures: .trailingComma)
+
+    assertParse(
+      """
+      if true, { true }() { print(0) }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax(condition: .expression("true"), trailingComma: .commaToken()),
+          ConditionElementSyntax(condition: .expression("{ true }()"), trailingComma: nil),
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { true }, { print(0) }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
+          ConditionElementSyntax.init(condition: .expression("{ true }"), trailingComma: .commaToken()),
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { true } { print(0) }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
+          ConditionElementSyntax.init(condition: .expression("{ true }"), trailingComma: nil),
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { print(0) }
+      { }()
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken())
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { true }
+      { print(0) }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken())
+        ],
+        body: "{ true }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { true }
+      ,{ print(0) }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
+          ConditionElementSyntax.init(condition: .expression("{ true }"), trailingComma: .commaToken()),
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true,
+      { true }+++ { print(0) }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
+          ConditionElementSyntax.init(condition: .expression("{ true }+++"), trailingComma: nil),
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { (x: () -> Void) in true } != nil { print(0) }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
+          ConditionElementSyntax.init(condition: .expression("{ (x: () -> Void) in true } != nil"), trailingComma: nil),
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      """
+      if true, { (x: () -> Void) in true }
+      != nil
+      {
+        print(0)
+      }
+      """,
+      substructure: IfExprSyntax(
+        conditions: [
+          ConditionElementSyntax.init(condition: .expression("true"), trailingComma: .commaToken()),
+          ConditionElementSyntax.init(condition: .expression("{ (x: () -> Void) in true } != nil"), trailingComma: nil),
+        ],
+        body: "{ print(0) }"
+      ),
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      "if 1️⃣, { }",
+      diagnostics: [DiagnosticSpec(message: "missing condition in 'if' statement")],
+      experimentalFeatures: .trailingComma
+    )
+  }
+
+  func testGuardConditions() {
+    assertParse("guard true, else { break }", experimentalFeatures: .trailingComma)
+
+    assertParse(
+      "guard true, 1️⃣, else { return }",
+      diagnostics: [DiagnosticSpec(message: "expected expression in 'guard' statement", fixIts: ["insert expression"])],
+      fixedSource: "guard true, <#expression#>, else { return }",
+      experimentalFeatures: .trailingComma
+    )
+
+    assertParse(
+      "guard true, 1️⃣{ return }",
+      diagnostics: [DiagnosticSpec(message: "expected 'else' in 'guard' statement", fixIts: ["insert 'else'"])],
+      fixedSource: "guard true, else { return }",
+      experimentalFeatures: .trailingComma
+    )
+  }
+
+  func testWhileConditions() {
+    assertParse("while true, { print(0) }", experimentalFeatures: .trailingComma)
+  }
+
   func testSwitchCaseLabel() {
     assertParse(
       """
@@ -293,15 +310,8 @@ final class TrailingCommaTests: ParserTestCase {
       default:
           break
       }
-      """
-    )
-  }
-
-  func testClosureCaptureList() {
-    assertParse(
-      """
-      { [obj1, obj2,] in }
-      """
+      """,
+      experimentalFeatures: .trailingComma
     )
   }
 
@@ -309,13 +319,15 @@ final class TrailingCommaTests: ParserTestCase {
     assertParse(
       """
       struct T: P1, P2, { }
-      """
+      """,
+      experimentalFeatures: .trailingComma
     )
 
     assertParse(
       """
       struct T: P1, P2, where P1: Equatable, P2: Equatable { }
-      """
+      """,
+      experimentalFeatures: .trailingComma
     )
   }
 
@@ -323,21 +335,8 @@ final class TrailingCommaTests: ParserTestCase {
     assertParse(
       """
       struct T: P1, P2, where P1: Equatable, P2: Equatable, { }
-      """
-    )
-  }
-
-  func testAvailabilityArgumentSpecList() {
-    assertParse(
-      """
-      if #available(iOS 15, watchOS 9, *,) { }
-      """
-    )
-
-    assertParse(
-      """
-      if #unavailable(iOS 15, watchOS 9,) { }
-      """
+      """,
+      experimentalFeatures: .trailingComma
     )
   }
 }

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -322,18 +322,10 @@ final class IfconfigExprTests: ParserTestCase {
   func testIfconfigExpr23() {
     assertParse(
       """
-      #if canImport(A,1️⃣)
+      #if canImport(A,)
         let a = 1
       #endif
-      """,
-      diagnostics: [
-        DiagnosticSpec(message: "expected value in function call", fixIts: ["insert value"])
-      ],
-      fixedSource: """
-        #if canImport(A, <#expression#>)
-          let a = 1
-        #endif
-        """
+      """
     )
   }
 


### PR DESCRIPTION
This continues the work that I began in https://github.com/apple/swift-syntax/pull/2515#event-12563352688. After feedback from the language steering group I have expanded the original proposal to allow trailing comma in more places. See the updated proposal text in https://github.com/swiftlang/swift-evolution/pull/2344.