### PR TITLE
[sending] Get rid of transferring

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -468,7 +468,6 @@ public let DECL_NODES: [Node] = [
           .keyword(.reasync),
           .keyword(.required),
           .keyword(.static),
-          .keyword(.transferring),
           .keyword(.unowned),
           .keyword(.weak),
           .keyword(.sending),

--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -17,7 +17,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case thenStatements
   case doExpressions
   case nonescapableTypes
-  case transferringArgsAndResults
   case trailingComma
   case sendingArgsAndResults
 
@@ -32,8 +31,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "'do' expressions"
     case .nonescapableTypes:
       return "NonEscableTypes"
-    case .transferringArgsAndResults:
-      return "TransferringArgsAndResults"
     case .trailingComma:
       return "trailing comma"
     case .sendingArgsAndResults:

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -279,7 +279,6 @@ public enum Keyword: CaseIterable {
   case then
   case `throw`
   case `throws`
-  case transferring
   case transpose
   case `true`
   case `try`
@@ -691,11 +690,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("throw", isLexerClassified: true)
     case .throws:
       return KeywordSpec("throws", isLexerClassified: true)
-    case .transferring:
-      return KeywordSpec(
-        "transferring",
-        experimentalFeature: .transferringArgsAndResults
-      )
     case .sending:
       return KeywordSpec(
         "sending",

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -591,7 +591,6 @@ public let TYPE_NODES: [Node] = [
           .keyword(._const),
           .keyword(.borrowing),
           .keyword(.consuming),
-          .keyword(.transferring),
           .keyword(.sending),
         ]),
         documentation: "The specifier token that's attached to the type."

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -23,7 +23,7 @@ extension DeclarationModifier {
       .borrowing, .class, .consuming, .convenience, .distributed, .dynamic,
       .final, .indirect, .infix, .isolated, .lazy, .mutating, .nonmutating,
       .optional, .override, .postfix, .prefix, .reasync, .required,
-      .rethrows, .static, .weak, .transferring, .sending:
+      .rethrows, .static, .weak, .sending:
       return false
     case .fileprivate, .internal, .nonisolated, .package, .open, .private,
       .public, .unowned:

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -377,7 +377,6 @@ extension Parser.Lookahead {
         && !self.at(.keyword(.__owned))
         && !self.at(.keyword(.borrowing))
         && !self.at(.keyword(.consuming))
-        && !(experimentalFeatures.contains(.transferringArgsAndResults) && self.at(.keyword(.transferring)))
         && !(experimentalFeatures.contains(.sendingArgsAndResults) && self.at(.keyword(.sending)))
       {
         return true

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -236,7 +236,7 @@ enum TokenPrecedence: Comparable {
       .convenience, .override, .package, .open,
       .__setter_access, .indirect, .isolated, .nonisolated, .distributed, ._local,
       .inout, ._mutating, ._borrow, ._borrowing, .borrowing, ._consuming, .consuming, .consume,
-      .transferring, .dependsOn, .scoped, .sending,
+      .dependsOn, .scoped, .sending,
       // Accessors
       .get, .set, .didSet, .willSet, .unsafeAddress, .addressWithOwner, .addressWithNativeOwner, .unsafeMutableAddress,
       .mutableAddressWithOwner, .mutableAddressWithNativeOwner, ._read, ._modify,

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -379,7 +379,6 @@ enum DeclarationModifier: TokenSpecSet {
   case `rethrows`
   case sending
   case `static`
-  case transferring
   case unowned
   case weak
 
@@ -418,7 +417,6 @@ enum DeclarationModifier: TokenSpecSet {
     case TokenSpec(.required): self = .required
     case TokenSpec(.rethrows): self = .rethrows
     case TokenSpec(.static): self = .static
-    case TokenSpec(.transferring): self = .transferring
     case TokenSpec(.sending): self = .sending
     case TokenSpec(.unowned): self = .unowned
     case TokenSpec(.weak): self = .weak
@@ -461,7 +459,6 @@ enum DeclarationModifier: TokenSpecSet {
     case .required: return .keyword(.required)
     case .rethrows: return TokenSpec(.rethrows, recoveryPrecedence: .declKeyword)
     case .static: return .keyword(.static)
-    case .transferring: return .keyword(.transferring)
     case .sending: return .keyword(.sending)
     case .unowned: return TokenSpec(.unowned, recoveryPrecedence: .declKeyword)
     case .weak: return TokenSpec(.weak, recoveryPrecedence: .declKeyword)

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -36,12 +36,9 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of NonEscableTypes.
   public static let nonescapableTypes = Self (rawValue: 1 << 3)
   
-  /// Whether to enable the parsing of TransferringArgsAndResults.
-  public static let transferringArgsAndResults = Self (rawValue: 1 << 4)
-  
   /// Whether to enable the parsing of trailing comma.
-  public static let trailingComma = Self (rawValue: 1 << 5)
+  public static let trailingComma = Self (rawValue: 1 << 4)
   
   /// Whether to enable the parsing of SendingArgsAndResults.
-  public static let sendingArgsAndResults = Self (rawValue: 1 << 6)
+  public static let sendingArgsAndResults = Self (rawValue: 1 << 5)
 }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -804,10 +804,6 @@ extension DeclModifierSyntax {
     case reasync
     case required
     case `static`
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
-    case transferring
     case unowned
     case weak
     #if compiler(>=5.8)
@@ -883,8 +879,6 @@ extension DeclModifierSyntax {
         self = .required
       case TokenSpec(.static):
         self = .static
-      case TokenSpec(.transferring) where experimentalFeatures.contains(.transferringArgsAndResults):
-        self = .transferring
       case TokenSpec(.unowned):
         self = .unowned
       case TokenSpec(.weak):
@@ -964,8 +958,6 @@ extension DeclModifierSyntax {
         self = .required
       case TokenSpec(.static):
         self = .static
-      case TokenSpec(.transferring):
-        self = .transferring
       case TokenSpec(.unowned):
         self = .unowned
       case TokenSpec(.weak):
@@ -1045,8 +1037,6 @@ extension DeclModifierSyntax {
         return .keyword(.required)
       case .static:
         return .keyword(.static)
-      case .transferring:
-        return .keyword(.transferring)
       case .unowned:
         return .keyword(.unowned)
       case .weak:
@@ -1128,8 +1118,6 @@ extension DeclModifierSyntax {
         return .keyword(.required)
       case .static:
         return .keyword(.static)
-      case .transferring:
-        return .keyword(.transferring)
       case .unowned:
         return .keyword(.unowned)
       case .weak:
@@ -3342,10 +3330,6 @@ extension SimpleTypeSpecifierSyntax {
     #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
     #endif
-    case transferring
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case sending
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -3364,8 +3348,6 @@ extension SimpleTypeSpecifierSyntax {
         self = .borrowing
       case TokenSpec(.consuming):
         self = .consuming
-      case TokenSpec(.transferring) where experimentalFeatures.contains(.transferringArgsAndResults):
-        self = .transferring
       case TokenSpec(.sending) where experimentalFeatures.contains(.sendingArgsAndResults):
         self = .sending
       default:
@@ -3389,8 +3371,6 @@ extension SimpleTypeSpecifierSyntax {
         self = .borrowing
       case TokenSpec(.consuming):
         self = .consuming
-      case TokenSpec(.transferring):
-        self = .transferring
       case TokenSpec(.sending):
         self = .sending
       default:
@@ -3414,8 +3394,6 @@ extension SimpleTypeSpecifierSyntax {
         return .keyword(.borrowing)
       case .consuming:
         return .keyword(.consuming)
-      case .transferring:
-        return .keyword(.transferring)
       case .sending:
         return .keyword(.sending)
       }
@@ -3441,8 +3419,6 @@ extension SimpleTypeSpecifierSyntax {
         return .keyword(.borrowing)
       case .consuming:
         return .keyword(.consuming)
-      case .transferring:
-        return .keyword(.transferring)
       case .sending:
         return .keyword(.sending)
       }

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -224,10 +224,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case then
   case `throw`
   case `throws`
-  #if compiler(>=5.8)
-  @_spi(ExperimentalLanguageFeatures)
-  #endif
-  case transferring
   case transpose
   case `true`
   case `try`
@@ -671,8 +667,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .freestanding
       case "noDerivative":
         self = .noDerivative
-      case "transferring":
-        self = .transferring
       default:
         return nil
       }
@@ -1012,7 +1006,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "then", 
       "throw", 
       "throws", 
-      "transferring", 
       "transpose", 
       "true", 
       "try", 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -796,7 +796,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("reasync"), 
             .keyword("required"), 
             .keyword("static"), 
-            .keyword("transferring"), 
             .keyword("unowned"), 
             .keyword("weak"), 
             .keyword("sending")
@@ -2297,7 +2296,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("_const"), 
             .keyword("borrowing"), 
             .keyword("consuming"), 
-            .keyword("transferring"), 
             .keyword("sending")
           ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -169,7 +169,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 
 /// ### Children
 /// 
-///  - `name`: (`__consuming` | `__setter_access` | `_const` | `_local` | `actor` | `async` | `borrowing` | `class` | `consuming` | `convenience` | `distributed` | `dynamic` | `fileprivate` | `final` | `indirect` | `infix` | `internal` | `isolated` | `lazy` | `mutating` | `nonisolated` | `nonmutating` | `open` | `optional` | `override` | `package` | `postfix` | `prefix` | `private` | `public` | `reasync` | `required` | `static` | `transferring` | `unowned` | `weak` | `sending`)
+///  - `name`: (`__consuming` | `__setter_access` | `_const` | `_local` | `actor` | `async` | `borrowing` | `class` | `consuming` | `convenience` | `distributed` | `dynamic` | `fileprivate` | `final` | `indirect` | `infix` | `internal` | `isolated` | `lazy` | `mutating` | `nonisolated` | `nonmutating` | `open` | `optional` | `override` | `package` | `postfix` | `prefix` | `private` | `public` | `reasync` | `required` | `static` | `unowned` | `weak` | `sending`)
 ///  - `detail`: ``DeclModifierDetailSyntax``?
 ///
 /// ### Contained in
@@ -272,7 +272,6 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
   ///  - `reasync`
   ///  - `required`
   ///  - `static`
-  ///  - `transferring`
   ///  - `unowned`
   ///  - `weak`
   ///  - `sending`

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -1090,7 +1090,7 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable,
 ///
 /// ### Children
 /// 
-///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `_const` | `borrowing` | `consuming` | `transferring` | `sending`)
+///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `_const` | `borrowing` | `consuming` | `sending`)
 ///
 /// ### Contained in
 /// 
@@ -1154,7 +1154,6 @@ public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
   ///  - `_const`
   ///  - `borrowing`
   ///  - `consuming`
-  ///  - `transferring`
   ///  - `sending`
   public var specifier: TokenSyntax {
     get {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3248,21 +3248,6 @@ final class DeclarationTests: ParserTestCase {
     assertParse("public init() -> Int")
   }
 
-  func testTransferringTypeSpecifier() {
-    assertParse(
-      "func testVarDeclTupleElt() -> (transferring String, String) {}",
-      experimentalFeatures: .transferringArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (transferring String)) {}",
-      experimentalFeatures: .transferringArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (transferring String, String)) {}",
-      experimentalFeatures: .transferringArgsAndResults
-    )
-  }
-
   func testSendingTypeSpecifier() {
     assertParse(
       "func testVarDeclTupleElt() -> (sending String, String) {}",

--- a/Tests/SwiftParserTest/SendingTest.swift
+++ b/Tests/SwiftParserTest/SendingTest.swift
@@ -13,24 +13,24 @@
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 import XCTest
 
-final class TransferringTests: ParserTestCase {
-  func testTransferingArg1() {
+final class SendingTests: ParserTestCase {
+  func testSendingArg1() {
     assertParse(
       """
       class Klass {}
-      func transferMain(_ x: transferring Klass) -> ()
+      func transferMain(_ x: sending Klass) -> ()
       """,
-      experimentalFeatures: .transferringArgsAndResults
+      experimentalFeatures: .sendingArgsAndResults
     )
   }
 
-  func testTransferingArgMiddle() {
+  func testSendingArgMiddle() {
     assertParse(
       """
       class Klass {}
-      func transferMain(_ y: Klass, _ x: transferring Klass, _ z: Klass) -> ()
+      func transferMain(_ y: Klass, _ x: sending Klass, _ z: Klass) -> ()
       """,
-      experimentalFeatures: .transferringArgsAndResults
+      experimentalFeatures: .sendingArgsAndResults
     )
   }
 }


### PR DESCRIPTION
We left in support for transferring for a little bit. Now let's remove it.

This is the swift-syntax side of this:

https://github.com/swiftlang/swift/pull/74610