### PR TITLE
Properly deprecate default implementation of `MacroExpansionContext.lexicalContext`

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -88,11 +88,18 @@ extension MacroExpansionContext {
     return location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID)
   }
 
+  #if compiler(>=6.0)
+  @available(*, deprecated, message: "`MacroExpansionContext` conformance must implement `lexicalContext`")
+  public var lexicalContext: [Syntax] {
+    return []
+  }
+  #else
   public var lexicalContext: [Syntax] {
     fatalError(
       "`MacroExpansionContext` conformance must implement `lexicalContext`"
     )
   }
+  #endif
 }
 
 /// Diagnostic message used for thrown errors.


### PR DESCRIPTION
Now that we have rdar://123403268, we can change the default implementation of `MacroExpansionContext.lexicalContext` to return an empty array and be deprecated, making not implementing `lexicalContext` a compile-time warning instead of a runtime error.

rdar://123410459