### PR TITLE
[6.0] Properly deprecate default implementation of `MacroExpansionContext.lexicalContext`

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -88,11 +88,18 @@ extension MacroExpansionContext {
     return location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID)
   }
 
+  #if compiler(>=6.0)
+  @available(*, deprecated, message: "`MacroExpansionContext` conformance must implement `lexicalContext`")
+  public var lexicalContext: [Syntax] {
+    return []
+  }
+  #else
   public var lexicalContext: [Syntax] {
     fatalError(
       "`MacroExpansionContext` conformance must implement `lexicalContext`"
     )
   }
+  #endif
 }
 
 /// Diagnostic message used for thrown errors.


### PR DESCRIPTION
* **Explanation**: Now that we have rdar://123403268, we can change the default implementation of `MacroExpansionContext.lexicalContext` to return an empty array and be deprecated, making not implementing `lexicalContext` a compile-time warning instead of a runtime error.
* **Scope**: Very narrow, only types conforming to `MacroExpansionContext`, which clients of the library generally shouldn’t be doing
* **Risk**: Low, the scope is very narrow and shouldn’t affect anyone in practice. This  is just clean-up
* **Testing**: Manually tested that the deprecation message shows up if a user conforms a type to `MacroExpansionContext` without adding a `lexicalContext` member
* **Issue**: rdar://123410459
* **Reviewer**:  @rintaro on https://github.com/swiftlang/swift-syntax/pull/2695