### PR TITLE
[Package] Underscore "internal" products

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -10,10 +10,8 @@ builder:
       - SwiftSyntax
       - SwiftBasicFormat
       - SwiftCompilerPlugin
-      - SwiftCompilerPluginMessageHandling
       - SwiftDiagnostics
       - SwiftIDEUtils
-      - SwiftLibraryPluginProvider
       - SwiftOperators
       - SwiftParser
       - SwiftParserDiagnostics
@@ -21,5 +19,6 @@ builder:
       - SwiftSyntaxBuilder
       - SwiftSyntaxMacros
       - SwiftSyntaxMacroExpansion
+      - SwiftSyntaxMacrosGenericTestSupport
       - SwiftSyntaxMacrosTestSupport
       custom_documentation_parameters: [--experimental-skip-synthesized-symbols]

--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,8 @@ let package = Package(
   products: [
     .library(name: "SwiftBasicFormat", targets: ["SwiftBasicFormat"]),
     .library(name: "SwiftCompilerPlugin", targets: ["SwiftCompilerPlugin"]),
-    .library(name: "SwiftCompilerPluginMessageHandling", targets: ["SwiftCompilerPluginMessageHandling"]),
     .library(name: "SwiftDiagnostics", targets: ["SwiftDiagnostics"]),
     .library(name: "SwiftIDEUtils", targets: ["SwiftIDEUtils"]),
-    .library(name: "SwiftLibraryPluginProvider", targets: ["SwiftLibraryPluginProvider"]),
     .library(name: "SwiftOperators", targets: ["SwiftOperators"]),
     .library(name: "SwiftParser", targets: ["SwiftParser"]),
     .library(name: "SwiftParserDiagnostics", targets: ["SwiftParserDiagnostics"]),
@@ -28,10 +26,9 @@ let package = Package(
     .library(name: "SwiftSyntaxMacros", targets: ["SwiftSyntaxMacros"]),
     .library(name: "SwiftSyntaxMacroExpansion", targets: ["SwiftSyntaxMacroExpansion"]),
     .library(name: "SwiftSyntaxMacrosTestSupport", targets: ["SwiftSyntaxMacrosTestSupport"]),
-    .library(
-      name: "SwiftSyntaxMacrosGenericTestSupport",
-      targets: ["SwiftSyntaxMacrosGenericTestSupport"]
-    ),
+    .library(name: "SwiftSyntaxMacrosGenericTestSupport", targets: ["SwiftSyntaxMacrosGenericTestSupport"]),
+    .library(name: "_SwiftCompilerPluginMessageHandling", targets: ["SwiftCompilerPluginMessageHandling"]),
+    .library(name: "_SwiftLibraryPluginProvider", targets: ["SwiftLibraryPluginProvider"]),
   ],
   targets: [
     // MARK: - Internal helper targets

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifySourceCode.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifySourceCode.swift
@@ -129,6 +129,7 @@ struct VerifySpiYmlExecutor {
       .components(separatedBy: "\n")
       .filter({ !$0.matches(of: extractNameRegex).isEmpty })
       .map { $0.replacing(extractNameRegex) { $0.1 } }
+      .filter({ !$0.hasPrefix("_") })
       .sorted()
   }
   /// Returns all targets listed in `.spi.yml`.


### PR DESCRIPTION
`SwiftCompilerPluginMessageHandling` and `SwiftLibraryPluginProvider` are only meant to be used by internal components

Also, stop generating documents for these products by skipping the underscored product names in `swift-syntax-dev-utils verify-source-code`