### PR TITLE
build: parse arguments for `add_swift_host_library`

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -46,12 +46,18 @@ endfunction()
 
 # Add a new host library with the given name.
 function(add_swift_syntax_library name)
-  set(ASHL_SOURCES ${ARGN})
+  cmake_parse_arguments(ARGS "EXCLUDE_FROM_ALL" "" "" ${ARGN})
+
+  set(ASHL_SOURCES ${ARGS_UNPARSED_ARGUMENTS})
 
   set(target ${SWIFTSYNTAX_TARGET_NAMESPACE}${name})
 
   # Create the library target.
-  add_library(${target} ${ASHL_SOURCES})
+  if(ARGS_EXCLUDE_FROM_ALL)
+    add_library(${target} EXCLUDE_FROM_ALL ${ASHL_SOURCES})
+  else()
+    add_library(${target} ${ASHL_SOURCES})
+  endif()
 
   if(NOT DEFINED SWIFTSYNTAX_EMIT_MODULE OR SWIFTSYNTAX_EMIT_MODULE)
     # Determine where Swift modules will be built and installed.
@@ -150,7 +156,7 @@ function(add_swift_syntax_library name)
     endif()
   endif()
 
-  if(PROJECT_IS_TOP_LEVEL OR SWIFT_SYNTAX_INSTALL_TARGETS)
+  if(NOT ARGS_EXCLUDE_FROM_ALL AND (PROJECT_IS_TOP_LEVEL OR SWIFT_SYNTAX_INSTALL_TARGETS))
     # Install this target
     install(TARGETS ${target}
       EXPORT SwiftSyntaxTargets


### PR DESCRIPTION
We use `EXCLUDE_FROM_ALL` in one of the libraries but did not account for that in the installation. When building swift-syntax for the android host for building swift-foundation, this prevents installation of the package. Parse and explicitly pass along the flag.