### PR TITLE
[CMake] Add option to EXCLUDE_FROM_ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,5 +82,9 @@ add_compile_definitions(
   $<$<COMPILE_LANGUAGE:Swift>:SWIFT_SYNTAX_BUILD_USING_CMAKE>
 )
 
+if(${SWIFTSYNTAX_EXCLUDE_FROM_ALL})
+  set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL YES)
+endif()
+
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)

--- a/Sources/SwiftCompilerPlugin/CMakeLists.txt
+++ b/Sources/SwiftCompilerPlugin/CMakeLists.txt
@@ -7,7 +7,6 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_syntax_library(SwiftCompilerPlugin
-  EXCLUDE_FROM_ALL
   CompilerPlugin.swift
 )
 


### PR DESCRIPTION
`SWIFTSYNTAX_EXCLUDE_FROM_ALL` is a CMake option to enable EXCLUDE_FROM_ALL on the entire directory.