### PR TITLE
Fix an infinite recursion in `NameMatcher` if a position to resolve is in the leading whitespace before a token

### DIFF
--- a/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
+++ b/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
@@ -381,4 +381,11 @@ class NameMatcherTests: XCTestCase {
       ]
     )
   }
+
+  func testPositionAtSpaceInFrontOfIdentifier() {
+    assertNameMatcherResult(
+      " 1️⃣ fn",
+      expected: []
+    )
+  }
 }


### PR DESCRIPTION
rdar://129922267