### PR TITLE
[6.0] Fix an infinite recursion in `NameMatcher` if a position to resolve is in the leading whitespace before a token

### DIFF
--- a/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
+++ b/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
@@ -381,4 +381,11 @@ class NameMatcherTests: XCTestCase {
       ]
     )
   }
+
+  func testPositionAtSpaceInFrontOfIdentifier() {
+    assertNameMatcherResult(
+      " 1️⃣ fn",
+      expected: []
+    )
+  }
 }


### PR DESCRIPTION
- **Explanation**: If the name matcher was requested at a location inside whitespace in front of a token, it would try to parse the source file from there in order to match eg. a compound decl name inside the comment. However, if the location was inside leading whitespace, it would just find the token itself again and infinitely recurse. 
Limit the re-parsing to only the trivia text, which fixes the infinite recursion
- **Scope**: Name matcher
- **Risk**: Low
- **Testing**: Added test case
- **Issue**: rdar://129922267
- **Reviewer**:   @bnbarham on https://github.com/swiftlang/swift-syntax/pull/2708

