### PR TITLE
[6.0] Remove `@_spi(ExperimentalLanguageFeature)` from `BodyMacro`

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/BodyMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/BodyMacro.swift
@@ -16,7 +16,6 @@ import SwiftSyntax
 
 /// Describes a macro that can create the body for a function that does not
 /// have one.
-@_spi(ExperimentalLanguageFeature)
 public protocol BodyMacro: AttachedMacro {
   /// Expand a macro described by the given custom attribute and
   /// attached to the given declaration and evaluated within a


### PR DESCRIPTION
- **Explanation**: Function body macros have been accepted.
- **Scope**: `BodyMacro`
- **Risk**: Very low, makes SPI API
- **Testing**: n/a
- **Issue**: n/a
- **Reviewer**:   @DougGregor @bnbarham 