### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Xcode 16 supports the [EditorConfig](https://editorconfig.org) standard, which allows a project to specify basic formatting rules so the editor can behave correctly. This means no additional configuration is required to get automatic 2-space indentation in Xcode rather than its default 4-space indentation. (You may need to quit and relaunch Xcode for it to pick up the editorconfig file after switching to a branch with it present)

Unfortunately, this does introduce duplication with `.swift-format` because both specify the indentation width. (It would be nice if swift-format picked up these settings automatically!)