### PR TITLE
[6.0][sending] Remove support for parsing transferring.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -469,7 +469,6 @@ public let DECL_NODES: [Node] = [
           .keyword(._resultDependsOnSelf),
           .keyword(.required),
           .keyword(.static),
-          .keyword(.transferring),
           .keyword(.unowned),
           .keyword(.weak),
           .keyword(.sending),

--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -17,7 +17,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case thenStatements
   case doExpressions
   case nonescapableTypes
-  case transferringArgsAndResults
   case borrowingSwitch
   case sendingArgsAndResults
 
@@ -32,8 +31,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "'do' expressions"
     case .nonescapableTypes:
       return "NonEscableTypes"
-    case .transferringArgsAndResults:
-      return "TransferringArgsAndResults"
     case .borrowingSwitch:
       return "borrowing pattern matching"
     case .sendingArgsAndResults:

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -281,7 +281,6 @@ public enum Keyword: CaseIterable {
   case then
   case `throw`
   case `throws`
-  case transferring
   case transpose
   case `true`
   case `try`
@@ -697,11 +696,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("throw", isLexerClassified: true)
     case .throws:
       return KeywordSpec("throws", isLexerClassified: true)
-    case .transferring:
-      return KeywordSpec(
-        "transferring",
-        experimentalFeature: .transferringArgsAndResults
-      )
     case .sending:
       return KeywordSpec(
         "sending",

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -591,7 +591,6 @@ public let TYPE_NODES: [Node] = [
           .keyword(._const),
           .keyword(.borrowing),
           .keyword(.consuming),
-          .keyword(.transferring),
           .keyword(._resultDependsOn),
           .keyword(.sending),
         ]),

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -23,7 +23,7 @@ extension DeclarationModifier {
       .borrowing, .class, .consuming, .convenience, .distributed, .dynamic,
       .final, .indirect, .infix, .isolated, .lazy, .mutating, .nonmutating,
       .optional, .override, .postfix, .prefix, .reasync, ._resultDependsOn, ._resultDependsOnSelf, .required,
-      .rethrows, .static, .weak, .transferring, .sending:
+      .rethrows, .static, .weak, .sending:
       return false
     case .fileprivate, .internal, .nonisolated, .package, .open, .private,
       .public, .unowned:

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -377,7 +377,6 @@ extension Parser.Lookahead {
         && !self.at(.keyword(.__owned))
         && !self.at(.keyword(.borrowing))
         && !self.at(.keyword(.consuming))
-        && !(experimentalFeatures.contains(.transferringArgsAndResults) && self.at(.keyword(.transferring)))
         && !(experimentalFeatures.contains(.sendingArgsAndResults) && self.at(.keyword(.sending)))
         && !(experimentalFeatures.contains(.nonescapableTypes) && self.at(.keyword(._resultDependsOn)))
       {

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -237,7 +237,7 @@ enum TokenPrecedence: Comparable {
       .__setter_access, .indirect, .isolated, .nonisolated, .distributed, ._local,
       .inout, ._mutating, ._borrow, ._borrowing, .borrowing, ._consuming, .consuming, .consume, ._resultDependsOnSelf,
       ._resultDependsOn,
-      .transferring, .dependsOn, .scoped, .sending,
+      .dependsOn, .scoped, .sending,
       // Accessors
       .get, .set, .didSet, .willSet, .unsafeAddress, .addressWithOwner, .addressWithNativeOwner, .unsafeMutableAddress,
       .mutableAddressWithOwner, .mutableAddressWithNativeOwner, ._read, ._modify,

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -379,7 +379,6 @@ enum DeclarationModifier: TokenSpecSet {
   case `rethrows`
   case sending
   case `static`
-  case transferring
   case unowned
   case weak
   case _resultDependsOn
@@ -420,7 +419,6 @@ enum DeclarationModifier: TokenSpecSet {
     case TokenSpec(.required): self = .required
     case TokenSpec(.rethrows): self = .rethrows
     case TokenSpec(.static): self = .static
-    case TokenSpec(.transferring): self = .transferring
     case TokenSpec(.sending): self = .sending
     case TokenSpec(.unowned): self = .unowned
     case TokenSpec(.weak): self = .weak
@@ -466,7 +464,6 @@ enum DeclarationModifier: TokenSpecSet {
     case .required: return .keyword(.required)
     case .rethrows: return TokenSpec(.rethrows, recoveryPrecedence: .declKeyword)
     case .static: return .keyword(.static)
-    case .transferring: return .keyword(.transferring)
     case .sending: return .keyword(.sending)
     case .unowned: return TokenSpec(.unowned, recoveryPrecedence: .declKeyword)
     case .weak: return TokenSpec(.weak, recoveryPrecedence: .declKeyword)

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -36,12 +36,9 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of NonEscableTypes.
   public static let nonescapableTypes = Self (rawValue: 1 << 3)
   
-  /// Whether to enable the parsing of TransferringArgsAndResults.
-  public static let transferringArgsAndResults = Self (rawValue: 1 << 4)
-  
   /// Whether to enable the parsing of borrowing pattern matching.
-  public static let borrowingSwitch = Self (rawValue: 1 << 5)
+  public static let borrowingSwitch = Self (rawValue: 1 << 4)
   
   /// Whether to enable the parsing of SendingArgsAndResults.
-  public static let sendingArgsAndResults = Self (rawValue: 1 << 6)
+  public static let sendingArgsAndResults = Self (rawValue: 1 << 5)
 }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -808,10 +808,6 @@ extension DeclModifierSyntax {
     case _resultDependsOnSelf
     case required
     case `static`
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
-    case transferring
     case unowned
     case weak
     #if compiler(>=5.8)
@@ -889,8 +885,6 @@ extension DeclModifierSyntax {
         self = .required
       case TokenSpec(.static):
         self = .static
-      case TokenSpec(.transferring) where experimentalFeatures.contains(.transferringArgsAndResults):
-        self = .transferring
       case TokenSpec(.unowned):
         self = .unowned
       case TokenSpec(.weak):
@@ -972,8 +966,6 @@ extension DeclModifierSyntax {
         self = .required
       case TokenSpec(.static):
         self = .static
-      case TokenSpec(.transferring):
-        self = .transferring
       case TokenSpec(.unowned):
         self = .unowned
       case TokenSpec(.weak):
@@ -1055,8 +1047,6 @@ extension DeclModifierSyntax {
         return .keyword(.required)
       case .static:
         return .keyword(.static)
-      case .transferring:
-        return .keyword(.transferring)
       case .unowned:
         return .keyword(.unowned)
       case .weak:
@@ -1140,8 +1130,6 @@ extension DeclModifierSyntax {
         return .keyword(.required)
       case .static:
         return .keyword(.static)
-      case .transferring:
-        return .keyword(.transferring)
       case .unowned:
         return .keyword(.unowned)
       case .weak:
@@ -3354,10 +3342,6 @@ extension SimpleTypeSpecifierSyntax {
     #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
     #endif
-    case transferring
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _resultDependsOn
     #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
@@ -3380,8 +3364,6 @@ extension SimpleTypeSpecifierSyntax {
         self = .borrowing
       case TokenSpec(.consuming):
         self = .consuming
-      case TokenSpec(.transferring) where experimentalFeatures.contains(.transferringArgsAndResults):
-        self = .transferring
       case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonescapableTypes):
         self = ._resultDependsOn
       case TokenSpec(.sending) where experimentalFeatures.contains(.sendingArgsAndResults):
@@ -3407,8 +3389,6 @@ extension SimpleTypeSpecifierSyntax {
         self = .borrowing
       case TokenSpec(.consuming):
         self = .consuming
-      case TokenSpec(.transferring):
-        self = .transferring
       case TokenSpec(._resultDependsOn):
         self = ._resultDependsOn
       case TokenSpec(.sending):
@@ -3434,8 +3414,6 @@ extension SimpleTypeSpecifierSyntax {
         return .keyword(.borrowing)
       case .consuming:
         return .keyword(.consuming)
-      case .transferring:
-        return .keyword(.transferring)
       case ._resultDependsOn:
         return .keyword(._resultDependsOn)
       case .sending:
@@ -3463,8 +3441,6 @@ extension SimpleTypeSpecifierSyntax {
         return .keyword(.borrowing)
       case .consuming:
         return .keyword(.consuming)
-      case .transferring:
-        return .keyword(.transferring)
       case ._resultDependsOn:
         return .keyword(._resultDependsOn)
       case .sending:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -232,10 +232,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case then
   case `throw`
   case `throws`
-  #if compiler(>=5.8)
-  @_spi(ExperimentalLanguageFeatures)
-  #endif
-  case transferring
   case transpose
   case `true`
   case `try`
@@ -679,8 +675,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .freestanding
       case "noDerivative":
         self = .noDerivative
-      case "transferring":
-        self = .transferring
       default:
         return nil
       }
@@ -1026,7 +1020,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "then", 
       "throw", 
       "throws", 
-      "transferring", 
       "transpose", 
       "true", 
       "try", 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -797,7 +797,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("_resultDependsOnSelf"), 
             .keyword("required"), 
             .keyword("static"), 
-            .keyword("transferring"), 
             .keyword("unowned"), 
             .keyword("weak"), 
             .keyword("sending")
@@ -2298,7 +2297,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("_const"), 
             .keyword("borrowing"), 
             .keyword("consuming"), 
-            .keyword("transferring"), 
             .keyword("_resultDependsOn"), 
             .keyword("sending")
           ]))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -169,7 +169,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 
 /// ### Children
 /// 
-///  - `name`: (`__consuming` | `__setter_access` | `_const` | `_local` | `actor` | `async` | `borrowing` | `class` | `consuming` | `convenience` | `distributed` | `dynamic` | `fileprivate` | `final` | `indirect` | `infix` | `internal` | `isolated` | `lazy` | `mutating` | `nonisolated` | `nonmutating` | `open` | `optional` | `override` | `package` | `postfix` | `prefix` | `private` | `public` | `reasync` | `_resultDependsOnSelf` | `required` | `static` | `transferring` | `unowned` | `weak` | `sending`)
+///  - `name`: (`__consuming` | `__setter_access` | `_const` | `_local` | `actor` | `async` | `borrowing` | `class` | `consuming` | `convenience` | `distributed` | `dynamic` | `fileprivate` | `final` | `indirect` | `infix` | `internal` | `isolated` | `lazy` | `mutating` | `nonisolated` | `nonmutating` | `open` | `optional` | `override` | `package` | `postfix` | `prefix` | `private` | `public` | `reasync` | `_resultDependsOnSelf` | `required` | `static` | `unowned` | `weak` | `sending`)
 ///  - `detail`: ``DeclModifierDetailSyntax``?
 ///
 /// ### Contained in
@@ -273,7 +273,6 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
   ///  - `_resultDependsOnSelf`
   ///  - `required`
   ///  - `static`
-  ///  - `transferring`
   ///  - `unowned`
   ///  - `weak`
   ///  - `sending`

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -1090,7 +1090,7 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable,
 ///
 /// ### Children
 /// 
-///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `_const` | `borrowing` | `consuming` | `transferring` | `_resultDependsOn` | `sending`)
+///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `_const` | `borrowing` | `consuming` | `_resultDependsOn` | `sending`)
 ///
 /// ### Contained in
 /// 
@@ -1154,7 +1154,6 @@ public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
   ///  - `_const`
   ///  - `borrowing`
   ///  - `consuming`
-  ///  - `transferring`
   ///  - `_resultDependsOn`
   ///  - `sending`
   public var specifier: TokenSyntax {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3294,21 +3294,6 @@ final class DeclarationTests: ParserTestCase {
     assertParse("public init() -> Int")
   }
 
-  func testTransferringTypeSpecifier() {
-    assertParse(
-      "func testVarDeclTupleElt() -> (transferring String, String) {}",
-      experimentalFeatures: .transferringArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (transferring String)) {}",
-      experimentalFeatures: .transferringArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (transferring String, String)) {}",
-      experimentalFeatures: .transferringArgsAndResults
-    )
-  }
-
   func testSendingTypeSpecifier() {
     assertParse(
       "func testVarDeclTupleElt() -> (sending String, String) {}",

--- a/Tests/SwiftParserTest/SendingTest.swift
+++ b/Tests/SwiftParserTest/SendingTest.swift
@@ -13,24 +13,24 @@
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 import XCTest
 
-final class TransferringTests: ParserTestCase {
-  func testTransferingArg1() {
+final class SendingTests: ParserTestCase {
+  func testSendingArg1() {
     assertParse(
       """
       class Klass {}
-      func transferMain(_ x: transferring Klass) -> ()
+      func transferMain(_ x: sending Klass) -> ()
       """,
-      experimentalFeatures: .transferringArgsAndResults
+      experimentalFeatures: .sendingArgsAndResults
     )
   }
 
-  func testTransferingArgMiddle() {
+  func testSendingArgMiddle() {
     assertParse(
       """
       class Klass {}
-      func transferMain(_ y: Klass, _ x: transferring Klass, _ z: Klass) -> ()
+      func transferMain(_ y: Klass, _ x: sending Klass, _ z: Klass) -> ()
       """,
-      experimentalFeatures: .transferringArgsAndResults
+      experimentalFeatures: .sendingArgsAndResults
     )
   }
 }


### PR DESCRIPTION
Explanation: This PR removes support from the compiler for parsing/handling transferring.

Radars:

- rdar://130253724

Original PRs:

- https://github.com/swiftlang/swift-syntax/pull/2692

Risk: Low. Just deletes code that has to do with transferring.
Testing: Ran compiler tests to validate nothing broke.
Reviewer: @ahoppen 