### PR TITLE
Include try and await expressions which are parents of a freestanding expression macro in lexicalContext

### DIFF
--- a/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
+++ b/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
@@ -74,11 +74,11 @@ extension SyntaxProtocol {
     // with a trivial placeholder, though.
     case var tryExpr as TryExprSyntax:
       tryExpr = tryExpr.detached
-      tryExpr.expression = "()"
+      tryExpr.expression = ExprSyntax(TypeExprSyntax(type: IdentifierTypeSyntax(name: .wildcardToken())))
       return Syntax(tryExpr)
     case var awaitExpr as AwaitExprSyntax:
       awaitExpr = awaitExpr.detached
-      awaitExpr.expression = "()"
+      awaitExpr.expression = ExprSyntax(TypeExprSyntax(type: IdentifierTypeSyntax(name: .wildcardToken())))
       return Syntax(awaitExpr)
 
     default:

--- a/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
+++ b/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
@@ -67,6 +67,20 @@ extension SyntaxProtocol {
     case let freestandingMacro as FreestandingMacroExpansionSyntax:
       return Syntax(freestandingMacro.detached) as Syntax
 
+    // Try and await are preserved: A freestanding expression macro preceded
+    // by try or await may need to know whether those keywords are present so it
+    // can propagate them to any expressions in its expansion which were passed
+    // as arguments to the macro. The expression of the try or await is replaced
+    // with a trivial placeholder, though.
+    case var tryExpr as TryExprSyntax:
+      tryExpr = tryExpr.detached
+      tryExpr.expression = "()"
+      return Syntax(tryExpr)
+    case var awaitExpr as AwaitExprSyntax:
+      awaitExpr = awaitExpr.detached
+      awaitExpr.expression = "()"
+      return Syntax(awaitExpr)
+
     default:
       return nil
     }

--- a/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
@@ -543,8 +543,8 @@ final class LexicalContextTests: XCTestCase {
             let arg: C
             var contextDescription: String {
               try await """
-              await ()
-              try ()
+              await _
+              try _
               contextDescription: String
               struct S {}
               { c in

--- a/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
@@ -531,7 +531,7 @@ final class LexicalContextTests: XCTestCase {
         struct S {
           let arg: C
           var contextDescription: String {
-            #lexicalContextDescription
+            try await #lexicalContextDescription
           }
         }
         return S(arg: c)
@@ -542,7 +542,9 @@ final class LexicalContextTests: XCTestCase {
           struct S {
             let arg: C
             var contextDescription: String {
-              """
+              try await """
+              await ()
+              try ()
               contextDescription: String
               struct S {}
               { c in
@@ -551,7 +553,7 @@ final class LexicalContextTests: XCTestCase {
                 struct S {
                   let arg: C
                   var contextDescription: String {
-                    #lexicalContextDescription
+                    try await #lexicalContextDescription
                   }
                 }
                 return S(arg: c)


### PR DESCRIPTION
This modifies the behavior of `MacroExpansionContext.lexicalContext` such that any preceding `try` or `await` expressions are included.

Motivation: The `#expect` macro in Swift Testing currently cannot propagate `try` or `await` placed _before_ the freestanding expression macro to expressions in its expanded code. See [Forum discussion](https://forums.swift.org/t/try-expect-throwing-or-expect-try-throwing/73076). This change would allow us to fix that.

Resolves rdar://109470248