### PR TITLE
Declare rules_swift max_compatibility_version = 2, set rules_swift to 1.18.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,4 +6,4 @@ module(
 
 bazel_dep(name = "apple_support", version = "1.13.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_apple", version = "3.3.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.16.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_rules_swift")


### PR DESCRIPTION
This enables repos using `rules_swift` 2.0+ to work with swift-syntax.

swift-syntax does not use any features unique to 1.x, nor have any implicit dependencies on 1.x rules. Tested via overriding `rules_apple` to sha `c8a6f615e37c8781e28c65dafed03ecb378281b3`, which sets rules_swift to 2.1.0.