### PR TITLE
Turn some static variables into static stored constants

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -199,17 +199,14 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
           }
         }
 
-        try! VariableDeclSyntax("public static var structure: SyntaxNodeStructure") {
-          let layout = ArrayExprSyntax {
-            for child in node.children {
-              ArrayElementSyntax(
-                expression: ExprSyntax(#"\Self.\#(child.varOrCaseName)"#)
-              )
-            }
+        let layout = ArrayExprSyntax {
+          for child in node.children {
+            ArrayElementSyntax(
+              expression: ExprSyntax(#"\Self.\#(child.varOrCaseName)"#)
+            )
           }
-
-          StmtSyntax("return .layout(\(layout))")
         }
+        "public static let structure: SyntaxNodeStructure = .layout(\(layout))"
       }
     }
   }

--- a/Sources/SwiftOperators/OperatorTable+Defaults.swift
+++ b/Sources/SwiftOperators/OperatorTable+Defaults.swift
@@ -64,7 +64,7 @@ extension OperatorTable {
   /// without requiring access to the standard library source code. However,
   /// because it does not incorporate user-defined operators, it will only
   /// ever be useful for a quick approximation.
-  public static var standardOperators: OperatorTable {
+  public static let standardOperators: OperatorTable = {
     let precedenceGroups: [PrecedenceGroup] = [
       PrecedenceGroup(
         name: "AssignmentPrecedence",
@@ -437,5 +437,5 @@ extension OperatorTable {
       precedenceGroups: precedenceGroups,
       operators: operators
     )
-  }
+  }()
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -238,17 +238,15 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndAccessors, 
-          \Self.accessors, 
-          \Self.unexpectedBetweenAccessorsAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndAccessors, 
+        \Self.accessors, 
+        \Self.unexpectedBetweenAccessorsAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - AccessorDeclSyntax
@@ -500,23 +498,21 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifier, 
-          \Self.modifier, 
-          \Self.unexpectedBetweenModifierAndAccessorSpecifier, 
-          \Self.accessorSpecifier, 
-          \Self.unexpectedBetweenAccessorSpecifierAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifier, 
+        \Self.modifier, 
+        \Self.unexpectedBetweenModifierAndAccessorSpecifier, 
+        \Self.accessorSpecifier, 
+        \Self.unexpectedBetweenAccessorSpecifierAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - AccessorEffectSpecifiersSyntax
@@ -633,15 +629,13 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsyncSpecifier, 
-          \Self.asyncSpecifier, 
-          \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedAfterThrowsClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsyncSpecifier, 
+        \Self.asyncSpecifier, 
+        \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedAfterThrowsClause
+      ])
 }
 
 // MARK: - AccessorParametersSyntax
@@ -784,17 +778,15 @@ public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ActorDeclSyntax
@@ -1121,27 +1113,25 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndActorKeyword, 
-          \Self.actorKeyword, 
-          \Self.unexpectedBetweenActorKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndActorKeyword, 
+        \Self.actorKeyword, 
+        \Self.unexpectedBetweenActorKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - ArrayElementSyntax
@@ -1255,15 +1245,13 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ArrayExprSyntax
@@ -1428,17 +1416,15 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - ArrayTypeSyntax
@@ -1574,17 +1560,15 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndElement, 
-          \Self.element, 
-          \Self.unexpectedBetweenElementAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndElement, 
+        \Self.element, 
+        \Self.unexpectedBetweenElementAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - ArrowExprSyntax
@@ -1702,15 +1686,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndArrow, 
-          \Self.arrow, 
-          \Self.unexpectedAfterArrow
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndArrow, 
+        \Self.arrow, 
+        \Self.unexpectedAfterArrow
+      ])
 }
 
 // MARK: - AsExprSyntax
@@ -1888,19 +1870,17 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndAsKeyword, 
-          \Self.asKeyword, 
-          \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
-          \Self.questionOrExclamationMark, 
-          \Self.unexpectedBetweenQuestionOrExclamationMarkAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndAsKeyword, 
+        \Self.asKeyword, 
+        \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
+        \Self.questionOrExclamationMark, 
+        \Self.unexpectedBetweenQuestionOrExclamationMarkAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - AssignmentExprSyntax
@@ -1975,9 +1955,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeEqual, \Self.equal, \Self.unexpectedAfterEqual])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeEqual, \Self.equal, \Self.unexpectedAfterEqual])
 }
 
 // MARK: - AssociatedTypeDeclSyntax
@@ -2309,25 +2287,23 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndAssociatedtypeKeyword, 
-          \Self.associatedtypeKeyword, 
-          \Self.unexpectedBetweenAssociatedtypeKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndAssociatedtypeKeyword, 
+        \Self.associatedtypeKeyword, 
+        \Self.unexpectedBetweenAssociatedtypeKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - AttributeSyntax
@@ -3236,21 +3212,19 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAtSign, 
-          \Self.atSign, 
-          \Self.unexpectedBetweenAtSignAndAttributeName, 
-          \Self.attributeName, 
-          \Self.unexpectedBetweenAttributeNameAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAtSign, 
+        \Self.atSign, 
+        \Self.unexpectedBetweenAtSignAndAttributeName, 
+        \Self.attributeName, 
+        \Self.unexpectedBetweenAttributeNameAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - AttributedTypeSyntax
@@ -3440,17 +3414,15 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSpecifiers, 
-          \Self.specifiers, 
-          \Self.unexpectedBetweenSpecifiersAndAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndBaseType, 
-          \Self.baseType, 
-          \Self.unexpectedAfterBaseType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSpecifiers, 
+        \Self.specifiers, 
+        \Self.unexpectedBetweenSpecifiersAndAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndBaseType, 
+        \Self.baseType, 
+        \Self.unexpectedAfterBaseType
+      ])
 }
 
 // MARK: - AvailabilityArgumentSyntax
@@ -3684,15 +3656,13 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArgument, 
-          \Self.argument, 
-          \Self.unexpectedBetweenArgumentAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArgument, 
+        \Self.argument, 
+        \Self.unexpectedBetweenArgumentAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - AvailabilityConditionSyntax
@@ -3889,19 +3859,17 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAvailabilityKeyword, 
-          \Self.availabilityKeyword, 
-          \Self.unexpectedBetweenAvailabilityKeywordAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndAvailabilityArguments, 
-          \Self.availabilityArguments, 
-          \Self.unexpectedBetweenAvailabilityArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAvailabilityKeyword, 
+        \Self.availabilityKeyword, 
+        \Self.unexpectedBetweenAvailabilityKeywordAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndAvailabilityArguments, 
+        \Self.availabilityArguments, 
+        \Self.unexpectedBetweenAvailabilityArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - AvailabilityLabeledArgumentSyntax
@@ -4138,17 +4106,15 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable,
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - AwaitExprSyntax
@@ -4256,15 +4222,13 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAwaitKeyword, 
-          \Self.awaitKeyword, 
-          \Self.unexpectedBetweenAwaitKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAwaitKeyword, 
+        \Self.awaitKeyword, 
+        \Self.unexpectedBetweenAwaitKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - BackDeployedAttributeArgumentsSyntax
@@ -4441,17 +4405,15 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBeforeLabel, 
-          \Self.beforeLabel, 
-          \Self.unexpectedBetweenBeforeLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPlatforms, 
-          \Self.platforms, 
-          \Self.unexpectedAfterPlatforms
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBeforeLabel, 
+        \Self.beforeLabel, 
+        \Self.unexpectedBetweenBeforeLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPlatforms, 
+        \Self.platforms, 
+        \Self.unexpectedAfterPlatforms
+      ])
 }
 
 // MARK: - BinaryOperatorExprSyntax
@@ -4532,9 +4494,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeOperator, \Self.operator, \Self.unexpectedAfterOperator])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeOperator, \Self.operator, \Self.unexpectedAfterOperator])
 }
 
 // MARK: - BooleanLiteralExprSyntax
@@ -4611,9 +4571,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
 }
 
 // MARK: - BorrowExprSyntax
@@ -4721,15 +4679,13 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBorrowKeyword, 
-          \Self.borrowKeyword, 
-          \Self.unexpectedBetweenBorrowKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBorrowKeyword, 
+        \Self.borrowKeyword, 
+        \Self.unexpectedBetweenBorrowKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - BreakStmtSyntax
@@ -4840,13 +4796,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBreakKeyword, 
-          \Self.breakKeyword, 
-          \Self.unexpectedBetweenBreakKeywordAndLabel, 
-          \Self.label, 
-          \Self.unexpectedAfterLabel
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBreakKeyword, 
+        \Self.breakKeyword, 
+        \Self.unexpectedBetweenBreakKeywordAndLabel, 
+        \Self.label, 
+        \Self.unexpectedAfterLabel
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
@@ -201,21 +201,19 @@ public struct _CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCanImportKeyword, 
-          \Self.canImportKeyword, 
-          \Self.unexpectedBetweenCanImportKeywordAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndImportPath, 
-          \Self.importPath, 
-          \Self.unexpectedBetweenImportPathAndVersionInfo, 
-          \Self.versionInfo, 
-          \Self.unexpectedBetweenVersionInfoAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCanImportKeyword, 
+        \Self.canImportKeyword, 
+        \Self.unexpectedBetweenCanImportKeywordAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndImportPath, 
+        \Self.importPath, 
+        \Self.unexpectedBetweenImportPathAndVersionInfo, 
+        \Self.versionInfo, 
+        \Self.unexpectedBetweenVersionInfoAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - _CanImportVersionInfoSyntax
@@ -385,19 +383,17 @@ public struct _CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndVersion, 
-          \Self.version, 
-          \Self.unexpectedAfterVersion
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndVersion, 
+        \Self.version, 
+        \Self.unexpectedAfterVersion
+      ])
 }
 
 // MARK: - CatchClauseSyntax
@@ -561,17 +557,15 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCatchKeyword, 
-          \Self.catchKeyword, 
-          \Self.unexpectedBetweenCatchKeywordAndCatchItems, 
-          \Self.catchItems, 
-          \Self.unexpectedBetweenCatchItemsAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCatchKeyword, 
+        \Self.catchKeyword, 
+        \Self.unexpectedBetweenCatchKeywordAndCatchItems, 
+        \Self.catchItems, 
+        \Self.unexpectedBetweenCatchItemsAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - CatchItemSyntax
@@ -708,17 +702,15 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndWhereClause, 
-          \Self.whereClause, 
-          \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndWhereClause, 
+        \Self.whereClause, 
+        \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClassDeclSyntax
@@ -1075,27 +1067,25 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndClassKeyword, 
-          \Self.classKeyword, 
-          \Self.unexpectedBetweenClassKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndClassKeyword, 
+        \Self.classKeyword, 
+        \Self.unexpectedBetweenClassKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - ClassRestrictionTypeSyntax
@@ -1170,9 +1160,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeClassKeyword, \Self.classKeyword, \Self.unexpectedAfterClassKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeClassKeyword, \Self.classKeyword, \Self.unexpectedAfterClassKeyword])
 }
 
 // MARK: - ClosureCaptureClauseSyntax
@@ -1339,17 +1327,15 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndItems, 
-          \Self.items, 
-          \Self.unexpectedBetweenItemsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndItems, 
+        \Self.items, 
+        \Self.unexpectedBetweenItemsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - ClosureCaptureSpecifierSyntax
@@ -1524,19 +1510,17 @@ public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSpecifier, 
-          \Self.specifier, 
-          \Self.unexpectedBetweenSpecifierAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndDetail, 
-          \Self.detail, 
-          \Self.unexpectedBetweenDetailAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSpecifier, 
+        \Self.specifier, 
+        \Self.unexpectedBetweenSpecifierAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndDetail, 
+        \Self.detail, 
+        \Self.unexpectedBetweenDetailAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ClosureCaptureSyntax
@@ -1729,21 +1713,19 @@ public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSpecifier, 
-          \Self.specifier, 
-          \Self.unexpectedBetweenSpecifierAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSpecifier, 
+        \Self.specifier, 
+        \Self.unexpectedBetweenSpecifierAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClosureExprSyntax
@@ -1939,19 +1921,17 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedBetweenStatementsAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedBetweenStatementsAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - ClosureParameterClauseSyntax
@@ -2126,17 +2106,15 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ClosureParameterSyntax
@@ -2485,27 +2463,25 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndEllipsis, 
-          \Self.ellipsis, 
-          \Self.unexpectedBetweenEllipsisAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndEllipsis, 
+        \Self.ellipsis, 
+        \Self.unexpectedBetweenEllipsisAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClosureShorthandParameterSyntax
@@ -2622,15 +2598,13 @@ public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClosureSignatureSyntax
@@ -2951,23 +2925,21 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndCapture, 
-          \Self.capture, 
-          \Self.unexpectedBetweenCaptureAndParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedBetweenReturnClauseAndInKeyword, 
-          \Self.inKeyword, 
-          \Self.unexpectedAfterInKeyword
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndCapture, 
+        \Self.capture, 
+        \Self.unexpectedBetweenCaptureAndParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedBetweenReturnClauseAndInKeyword, 
+        \Self.inKeyword, 
+        \Self.unexpectedAfterInKeyword
+      ])
 }
 
 // MARK: - CodeBlockItemSyntax
@@ -3201,15 +3173,13 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeItem, 
-          \Self.item, 
-          \Self.unexpectedBetweenItemAndSemicolon, 
-          \Self.semicolon, 
-          \Self.unexpectedAfterSemicolon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeItem, 
+        \Self.item, 
+        \Self.unexpectedBetweenItemAndSemicolon, 
+        \Self.semicolon, 
+        \Self.unexpectedAfterSemicolon
+      ])
 }
 
 // MARK: - CodeBlockSyntax
@@ -3394,17 +3364,15 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedBetweenStatementsAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedBetweenStatementsAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - CompositionTypeElementSyntax
@@ -3513,15 +3481,13 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndAmpersand, 
-          \Self.ampersand, 
-          \Self.unexpectedAfterAmpersand
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndAmpersand, 
+        \Self.ampersand, 
+        \Self.unexpectedAfterAmpersand
+      ])
 }
 
 // MARK: - CompositionTypeSyntax
@@ -3620,9 +3586,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
 }
 
 // MARK: - ConditionElementSyntax
@@ -3887,15 +3851,13 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCondition, 
-          \Self.condition, 
-          \Self.unexpectedBetweenConditionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCondition, 
+        \Self.condition, 
+        \Self.unexpectedBetweenConditionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ConformanceRequirementSyntax
@@ -4032,17 +3994,15 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftType, 
-          \Self.leftType, 
-          \Self.unexpectedBetweenLeftTypeAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndRightType, 
-          \Self.rightType, 
-          \Self.unexpectedAfterRightType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftType, 
+        \Self.leftType, 
+        \Self.unexpectedBetweenLeftTypeAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndRightType, 
+        \Self.rightType, 
+        \Self.unexpectedAfterRightType
+      ])
 }
 
 // MARK: - ConsumeExprSyntax
@@ -4152,15 +4112,13 @@ public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeConsumeKeyword, 
-          \Self.consumeKeyword, 
-          \Self.unexpectedBetweenConsumeKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeConsumeKeyword, 
+        \Self.consumeKeyword, 
+        \Self.unexpectedBetweenConsumeKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - ContinueStmtSyntax
@@ -4271,15 +4229,13 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeContinueKeyword, 
-          \Self.continueKeyword, 
-          \Self.unexpectedBetweenContinueKeywordAndLabel, 
-          \Self.label, 
-          \Self.unexpectedAfterLabel
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeContinueKeyword, 
+        \Self.continueKeyword, 
+        \Self.unexpectedBetweenContinueKeywordAndLabel, 
+        \Self.label, 
+        \Self.unexpectedAfterLabel
+      ])
 }
 
 // MARK: - ConventionAttributeArgumentsSyntax
@@ -4480,21 +4436,19 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeConventionLabel, 
-          \Self.conventionLabel, 
-          \Self.unexpectedBetweenConventionLabelAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndCTypeLabel, 
-          \Self.cTypeLabel, 
-          \Self.unexpectedBetweenCTypeLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndCTypeString, 
-          \Self.cTypeString, 
-          \Self.unexpectedAfterCTypeString
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeConventionLabel, 
+        \Self.conventionLabel, 
+        \Self.unexpectedBetweenConventionLabelAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndCTypeLabel, 
+        \Self.cTypeLabel, 
+        \Self.unexpectedBetweenCTypeLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndCTypeString, 
+        \Self.cTypeString, 
+        \Self.unexpectedAfterCTypeString
+      ])
 }
 
 // MARK: - ConventionWitnessMethodAttributeArgumentsSyntax
@@ -4648,17 +4602,15 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWitnessMethodLabel, 
-          \Self.witnessMethodLabel, 
-          \Self.unexpectedBetweenWitnessMethodLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndProtocolName, 
-          \Self.protocolName, 
-          \Self.unexpectedAfterProtocolName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWitnessMethodLabel, 
+        \Self.witnessMethodLabel, 
+        \Self.unexpectedBetweenWitnessMethodLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndProtocolName, 
+        \Self.protocolName, 
+        \Self.unexpectedAfterProtocolName
+      ])
 }
 
 // MARK: - CopyExprSyntax
@@ -4766,13 +4718,11 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCopyKeyword, 
-          \Self.copyKeyword, 
-          \Self.unexpectedBetweenCopyKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCopyKeyword, 
+        \Self.copyKeyword, 
+        \Self.unexpectedBetweenCopyKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -152,17 +152,15 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndDetail, 
-          \Self.detail, 
-          \Self.unexpectedBetweenDetailAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndDetail, 
+        \Self.detail, 
+        \Self.unexpectedBetweenDetailAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - DeclModifierSyntax
@@ -311,15 +309,13 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndDetail, 
-          \Self.detail, 
-          \Self.unexpectedAfterDetail
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndDetail, 
+        \Self.detail, 
+        \Self.unexpectedAfterDetail
+      ])
 }
 
 // MARK: - DeclNameArgumentSyntax
@@ -431,15 +427,13 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - DeclNameArgumentsSyntax
@@ -606,17 +600,15 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - DeclReferenceExprSyntax
@@ -741,15 +733,13 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBaseName, 
-          \Self.baseName, 
-          \Self.unexpectedBetweenBaseNameAndArgumentNames, 
-          \Self.argumentNames, 
-          \Self.unexpectedAfterArgumentNames
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBaseName, 
+        \Self.baseName, 
+        \Self.unexpectedBetweenBaseNameAndArgumentNames, 
+        \Self.argumentNames, 
+        \Self.unexpectedAfterArgumentNames
+      ])
 }
 
 // MARK: - DeferStmtSyntax
@@ -857,15 +847,13 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDeferKeyword, 
-          \Self.deferKeyword, 
-          \Self.unexpectedBetweenDeferKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDeferKeyword, 
+        \Self.deferKeyword, 
+        \Self.unexpectedBetweenDeferKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - DeinitializerDeclSyntax
@@ -1120,21 +1108,19 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndDeinitKeyword, 
-          \Self.deinitKeyword, 
-          \Self.unexpectedBetweenDeinitKeywordAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndDeinitKeyword, 
+        \Self.deinitKeyword, 
+        \Self.unexpectedBetweenDeinitKeywordAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - DeinitializerEffectSpecifiersSyntax
@@ -1216,9 +1202,7 @@ public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashabl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeAsyncSpecifier, \Self.asyncSpecifier, \Self.unexpectedAfterAsyncSpecifier])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeAsyncSpecifier, \Self.asyncSpecifier, \Self.unexpectedAfterAsyncSpecifier])
 }
 
 // MARK: - DerivativeAttributeArgumentsSyntax
@@ -1485,25 +1469,23 @@ public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOfLabel, 
-          \Self.ofLabel, 
-          \Self.unexpectedBetweenOfLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndOriginalDeclName, 
-          \Self.originalDeclName, 
-          \Self.unexpectedBetweenOriginalDeclNameAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndAccessorSpecifier, 
-          \Self.accessorSpecifier, 
-          \Self.unexpectedBetweenAccessorSpecifierAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedAfterArguments
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOfLabel, 
+        \Self.ofLabel, 
+        \Self.unexpectedBetweenOfLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndOriginalDeclName, 
+        \Self.originalDeclName, 
+        \Self.unexpectedBetweenOriginalDeclNameAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndAccessorSpecifier, 
+        \Self.accessorSpecifier, 
+        \Self.unexpectedBetweenAccessorSpecifierAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedAfterArguments
+      ])
 }
 
 // MARK: - DesignatedTypeSyntax
@@ -1615,15 +1597,13 @@ public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeadingComma, 
-          \Self.leadingComma, 
-          \Self.unexpectedBetweenLeadingCommaAndName, 
-          \Self.name, 
-          \Self.unexpectedAfterName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeadingComma, 
+        \Self.leadingComma, 
+        \Self.unexpectedBetweenLeadingCommaAndName, 
+        \Self.name, 
+        \Self.unexpectedAfterName
+      ])
 }
 
 // MARK: - DictionaryElementSyntax
@@ -1790,19 +1770,17 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeKey, 
-          \Self.key, 
-          \Self.unexpectedBetweenKeyAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeKey, 
+        \Self.key, 
+        \Self.unexpectedBetweenKeyAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - DictionaryExprSyntax
@@ -2022,17 +2000,15 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndContent, 
-          \Self.content, 
-          \Self.unexpectedBetweenContentAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndContent, 
+        \Self.content, 
+        \Self.unexpectedBetweenContentAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - DictionaryTypeSyntax
@@ -2221,21 +2197,19 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndKey, 
-          \Self.key, 
-          \Self.unexpectedBetweenKeyAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndKey, 
+        \Self.key, 
+        \Self.unexpectedBetweenKeyAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - DifferentiabilityArgumentSyntax
@@ -2356,15 +2330,13 @@ public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArgument, 
-          \Self.argument, 
-          \Self.unexpectedBetweenArgumentAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArgument, 
+        \Self.argument, 
+        \Self.unexpectedBetweenArgumentAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - DifferentiabilityArgumentsSyntax
@@ -2535,17 +2507,15 @@ public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable, 
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - DifferentiabilityWithRespectToArgumentSyntax
@@ -2776,17 +2746,15 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWrtLabel, 
-          \Self.wrtLabel, 
-          \Self.unexpectedBetweenWrtLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedAfterArguments
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWrtLabel, 
+        \Self.wrtLabel, 
+        \Self.unexpectedBetweenWrtLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedAfterArguments
+      ])
 }
 
 // MARK: - DifferentiableAttributeArgumentsSyntax
@@ -2997,21 +2965,19 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeKindSpecifier, 
-          \Self.kindSpecifier, 
-          \Self.unexpectedBetweenKindSpecifierAndKindSpecifierComma, 
-          \Self.kindSpecifierComma, 
-          \Self.unexpectedBetweenKindSpecifierCommaAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndArgumentsComma, 
-          \Self.argumentsComma, 
-          \Self.unexpectedBetweenArgumentsCommaAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeKindSpecifier, 
+        \Self.kindSpecifier, 
+        \Self.unexpectedBetweenKindSpecifierAndKindSpecifierComma, 
+        \Self.kindSpecifierComma, 
+        \Self.unexpectedBetweenKindSpecifierCommaAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndArgumentsComma, 
+        \Self.argumentsComma, 
+        \Self.unexpectedBetweenArgumentsCommaAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - DiscardAssignmentExprSyntax
@@ -3099,9 +3065,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
 }
 
 // MARK: - DiscardStmtSyntax
@@ -3209,15 +3173,13 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDiscardKeyword, 
-          \Self.discardKeyword, 
-          \Self.unexpectedBetweenDiscardKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDiscardKeyword, 
+        \Self.discardKeyword, 
+        \Self.unexpectedBetweenDiscardKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - DoExprSyntax
@@ -3404,17 +3366,15 @@ public struct DoExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDoKeyword, 
-          \Self.doKeyword, 
-          \Self.unexpectedBetweenDoKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndCatchClauses, 
-          \Self.catchClauses, 
-          \Self.unexpectedAfterCatchClauses
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDoKeyword, 
+        \Self.doKeyword, 
+        \Self.unexpectedBetweenDoKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndCatchClauses, 
+        \Self.catchClauses, 
+        \Self.unexpectedAfterCatchClauses
+      ])
 }
 
 // MARK: - DoStmtSyntax
@@ -3601,19 +3561,17 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDoKeyword, 
-          \Self.doKeyword, 
-          \Self.unexpectedBetweenDoKeywordAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedBetweenThrowsClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndCatchClauses, 
-          \Self.catchClauses, 
-          \Self.unexpectedAfterCatchClauses
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDoKeyword, 
+        \Self.doKeyword, 
+        \Self.unexpectedBetweenDoKeywordAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedBetweenThrowsClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndCatchClauses, 
+        \Self.catchClauses, 
+        \Self.unexpectedAfterCatchClauses
+      ])
 }
 
 // MARK: - DocumentationAttributeArgumentSyntax
@@ -3868,19 +3826,17 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - DynamicReplacementAttributeArgumentsSyntax
@@ -4022,15 +3978,13 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeForLabel, 
-          \Self.forLabel, 
-          \Self.unexpectedBetweenForLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedAfterDeclName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeForLabel, 
+        \Self.forLabel, 
+        \Self.unexpectedBetweenForLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedAfterDeclName
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -207,17 +207,15 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPlaceholder, 
-          \Self.placeholder, 
-          \Self.unexpectedAfterPlaceholder
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPlaceholder, 
+        \Self.placeholder, 
+        \Self.unexpectedAfterPlaceholder
+      ])
 }
 
 // MARK: - EditorPlaceholderExprSyntax
@@ -294,9 +292,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - EnumCaseDeclSyntax
@@ -546,19 +542,17 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndElements, 
-          \Self.elements, 
-          \Self.unexpectedAfterElements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndElements, 
+        \Self.elements, 
+        \Self.unexpectedAfterElements
+      ])
 }
 
 // MARK: - EnumCaseElementSyntax
@@ -735,19 +729,17 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndRawValue, 
-          \Self.rawValue, 
-          \Self.unexpectedBetweenRawValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndRawValue, 
+        \Self.rawValue, 
+        \Self.unexpectedBetweenRawValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - EnumCaseParameterClauseSyntax
@@ -922,17 +914,15 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - EnumCaseParameterSyntax
@@ -1219,25 +1209,23 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndDefaultValue, 
-          \Self.defaultValue, 
-          \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndDefaultValue, 
+        \Self.defaultValue, 
+        \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - EnumDeclSyntax
@@ -1572,27 +1560,25 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndEnumKeyword, 
-          \Self.enumKeyword, 
-          \Self.unexpectedBetweenEnumKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndEnumKeyword, 
+        \Self.enumKeyword, 
+        \Self.unexpectedBetweenEnumKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - ExposeAttributeArgumentsSyntax
@@ -1731,17 +1717,15 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLanguage, 
-          \Self.language, 
-          \Self.unexpectedBetweenLanguageAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndCxxName, 
-          \Self.cxxName, 
-          \Self.unexpectedAfterCxxName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLanguage, 
+        \Self.language, 
+        \Self.unexpectedBetweenLanguageAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndCxxName, 
+        \Self.cxxName, 
+        \Self.unexpectedAfterCxxName
+      ])
 }
 
 // MARK: - ExpressionPatternSyntax
@@ -1827,9 +1811,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
 }
 
 // MARK: - ExpressionSegmentSyntax
@@ -2056,21 +2038,19 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBackslash, 
-          \Self.backslash, 
-          \Self.unexpectedBetweenBackslashAndPounds, 
-          \Self.pounds, 
-          \Self.unexpectedBetweenPoundsAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndExpressions, 
-          \Self.expressions, 
-          \Self.unexpectedBetweenExpressionsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBackslash, 
+        \Self.backslash, 
+        \Self.unexpectedBetweenBackslashAndPounds, 
+        \Self.pounds, 
+        \Self.unexpectedBetweenPoundsAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndExpressions, 
+        \Self.expressions, 
+        \Self.unexpectedBetweenExpressionsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ExpressionStmtSyntax
@@ -2142,9 +2122,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStm
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
 }
 
 // MARK: - ExtensionDeclSyntax
@@ -2466,25 +2444,23 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndExtensionKeyword, 
-          \Self.extensionKeyword, 
-          \Self.unexpectedBetweenExtensionKeywordAndExtendedType, 
-          \Self.extendedType, 
-          \Self.unexpectedBetweenExtendedTypeAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndExtensionKeyword, 
+        \Self.extensionKeyword, 
+        \Self.unexpectedBetweenExtensionKeywordAndExtendedType, 
+        \Self.extendedType, 
+        \Self.unexpectedBetweenExtendedTypeAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - FallThroughStmtSyntax
@@ -2559,9 +2535,7 @@ public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafSt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeFallthroughKeyword, \Self.fallthroughKeyword, \Self.unexpectedAfterFallthroughKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeFallthroughKeyword, \Self.fallthroughKeyword, \Self.unexpectedAfterFallthroughKeyword])
 }
 
 // MARK: - FloatLiteralExprSyntax
@@ -2636,9 +2610,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
 }
 
 // MARK: - ForStmtSyntax
@@ -2958,31 +2930,29 @@ public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeForKeyword, 
-          \Self.forKeyword, 
-          \Self.unexpectedBetweenForKeywordAndTryKeyword, 
-          \Self.tryKeyword, 
-          \Self.unexpectedBetweenTryKeywordAndAwaitKeyword, 
-          \Self.awaitKeyword, 
-          \Self.unexpectedBetweenAwaitKeywordAndCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInKeyword, 
-          \Self.inKeyword, 
-          \Self.unexpectedBetweenInKeywordAndSequence, 
-          \Self.sequence, 
-          \Self.unexpectedBetweenSequenceAndWhereClause, 
-          \Self.whereClause, 
-          \Self.unexpectedBetweenWhereClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeForKeyword, 
+        \Self.forKeyword, 
+        \Self.unexpectedBetweenForKeywordAndTryKeyword, 
+        \Self.tryKeyword, 
+        \Self.unexpectedBetweenTryKeywordAndAwaitKeyword, 
+        \Self.awaitKeyword, 
+        \Self.unexpectedBetweenAwaitKeywordAndCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInKeyword, 
+        \Self.inKeyword, 
+        \Self.unexpectedBetweenInKeywordAndSequence, 
+        \Self.sequence, 
+        \Self.unexpectedBetweenSequenceAndWhereClause, 
+        \Self.whereClause, 
+        \Self.unexpectedBetweenWhereClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - ForceUnwrapExprSyntax
@@ -3090,15 +3060,13 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndExclamationMark, 
-          \Self.exclamationMark, 
-          \Self.unexpectedAfterExclamationMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndExclamationMark, 
+        \Self.exclamationMark, 
+        \Self.unexpectedAfterExclamationMark
+      ])
 }
 
 // MARK: - FunctionCallExprSyntax
@@ -3363,23 +3331,21 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCalledExpression, 
-          \Self.calledExpression, 
-          \Self.unexpectedBetweenCalledExpressionAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCalledExpression, 
+        \Self.calledExpression, 
+        \Self.unexpectedBetweenCalledExpressionAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - FunctionDeclSyntax
@@ -3736,27 +3702,25 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFuncKeyword, 
-          \Self.funcKeyword, 
-          \Self.unexpectedBetweenFuncKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFuncKeyword, 
+        \Self.funcKeyword, 
+        \Self.unexpectedBetweenFuncKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - FunctionEffectSpecifiersSyntax
@@ -3875,15 +3839,13 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsyncSpecifier, 
-          \Self.asyncSpecifier, 
-          \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedAfterThrowsClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsyncSpecifier, 
+        \Self.asyncSpecifier, 
+        \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedAfterThrowsClause
+      ])
 }
 
 // MARK: - FunctionParameterClauseSyntax
@@ -4051,17 +4013,15 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - FunctionParameterSyntax
@@ -4443,29 +4403,27 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndEllipsis, 
-          \Self.ellipsis, 
-          \Self.unexpectedBetweenEllipsisAndDefaultValue, 
-          \Self.defaultValue, 
-          \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndEllipsis, 
+        \Self.ellipsis, 
+        \Self.unexpectedBetweenEllipsisAndDefaultValue, 
+        \Self.defaultValue, 
+        \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - FunctionSignatureSyntax
@@ -4609,17 +4567,15 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedAfterReturnClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedAfterReturnClause
+      ])
 }
 
 // MARK: - FunctionTypeSyntax
@@ -4832,19 +4788,17 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedAfterReturnClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedAfterReturnClause
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -181,17 +181,15 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftAngle, 
-          \Self.leftAngle, 
-          \Self.unexpectedBetweenLeftAngleAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightAngle, 
-          \Self.rightAngle, 
-          \Self.unexpectedAfterRightAngle
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftAngle, 
+        \Self.leftAngle, 
+        \Self.unexpectedBetweenLeftAngleAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightAngle, 
+        \Self.rightAngle, 
+        \Self.unexpectedAfterRightAngle
+      ])
 }
 
 // MARK: - GenericArgumentSyntax
@@ -303,15 +301,13 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArgument, 
-          \Self.argument, 
-          \Self.unexpectedBetweenArgumentAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArgument, 
+        \Self.argument, 
+        \Self.unexpectedBetweenArgumentAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - GenericParameterClauseSyntax
@@ -524,19 +520,17 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftAngle, 
-          \Self.leftAngle, 
-          \Self.unexpectedBetweenLeftAngleAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndRightAngle, 
-          \Self.rightAngle, 
-          \Self.unexpectedAfterRightAngle
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftAngle, 
+        \Self.leftAngle, 
+        \Self.unexpectedBetweenLeftAngleAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndRightAngle, 
+        \Self.rightAngle, 
+        \Self.unexpectedAfterRightAngle
+      ])
 }
 
 // MARK: - GenericParameterSyntax
@@ -784,23 +778,21 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndEachKeyword, 
-          \Self.eachKeyword, 
-          \Self.unexpectedBetweenEachKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndInheritedType, 
-          \Self.inheritedType, 
-          \Self.unexpectedBetweenInheritedTypeAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndEachKeyword, 
+        \Self.eachKeyword, 
+        \Self.unexpectedBetweenEachKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndInheritedType, 
+        \Self.inheritedType, 
+        \Self.unexpectedBetweenInheritedTypeAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - GenericRequirementSyntax
@@ -1027,15 +1019,13 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRequirement, 
-          \Self.requirement, 
-          \Self.unexpectedBetweenRequirementAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRequirement, 
+        \Self.requirement, 
+        \Self.unexpectedBetweenRequirementAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - GenericSpecializationExprSyntax
@@ -1140,15 +1130,13 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - GenericWhereClauseSyntax
@@ -1308,15 +1296,13 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWhereKeyword, 
-          \Self.whereKeyword, 
-          \Self.unexpectedBetweenWhereKeywordAndRequirements, 
-          \Self.requirements, 
-          \Self.unexpectedAfterRequirements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWhereKeyword, 
+        \Self.whereKeyword, 
+        \Self.unexpectedBetweenWhereKeywordAndRequirements, 
+        \Self.requirements, 
+        \Self.unexpectedAfterRequirements
+      ])
 }
 
 // MARK: - GuardStmtSyntax
@@ -1504,19 +1490,17 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeGuardKeyword, 
-          \Self.guardKeyword, 
-          \Self.unexpectedBetweenGuardKeywordAndConditions, 
-          \Self.conditions, 
-          \Self.unexpectedBetweenConditionsAndElseKeyword, 
-          \Self.elseKeyword, 
-          \Self.unexpectedBetweenElseKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeGuardKeyword, 
+        \Self.guardKeyword, 
+        \Self.unexpectedBetweenGuardKeywordAndConditions, 
+        \Self.conditions, 
+        \Self.unexpectedBetweenConditionsAndElseKeyword, 
+        \Self.elseKeyword, 
+        \Self.unexpectedBetweenElseKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - IdentifierPatternSyntax
@@ -1607,9 +1591,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeIdentifier, \Self.identifier, \Self.unexpectedAfterIdentifier])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeIdentifier, \Self.identifier, \Self.unexpectedAfterIdentifier])
 }
 
 // MARK: - IdentifierTypeSyntax
@@ -1721,15 +1703,13 @@ public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - IfConfigClauseSyntax
@@ -2056,17 +2036,15 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePoundKeyword, 
-          \Self.poundKeyword, 
-          \Self.unexpectedBetweenPoundKeywordAndCondition, 
-          \Self.condition, 
-          \Self.unexpectedBetweenConditionAndElements, 
-          \Self.elements, 
-          \Self.unexpectedAfterElements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePoundKeyword, 
+        \Self.poundKeyword, 
+        \Self.unexpectedBetweenPoundKeywordAndCondition, 
+        \Self.condition, 
+        \Self.unexpectedBetweenConditionAndElements, 
+        \Self.elements, 
+        \Self.unexpectedAfterElements
+      ])
 }
 
 // MARK: - IfConfigDeclSyntax
@@ -2207,15 +2185,13 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeClauses, 
-          \Self.clauses, 
-          \Self.unexpectedBetweenClausesAndPoundEndif, 
-          \Self.poundEndif, 
-          \Self.unexpectedAfterPoundEndif
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeClauses, 
+        \Self.clauses, 
+        \Self.unexpectedBetweenClausesAndPoundEndif, 
+        \Self.poundEndif, 
+        \Self.unexpectedAfterPoundEndif
+      ])
 }
 
 // MARK: - IfExprSyntax
@@ -2514,21 +2490,19 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeIfKeyword, 
-          \Self.ifKeyword, 
-          \Self.unexpectedBetweenIfKeywordAndConditions, 
-          \Self.conditions, 
-          \Self.unexpectedBetweenConditionsAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndElseKeyword, 
-          \Self.elseKeyword, 
-          \Self.unexpectedBetweenElseKeywordAndElseBody, 
-          \Self.elseBody, 
-          \Self.unexpectedAfterElseBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeIfKeyword, 
+        \Self.ifKeyword, 
+        \Self.unexpectedBetweenIfKeywordAndConditions, 
+        \Self.conditions, 
+        \Self.unexpectedBetweenConditionsAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndElseKeyword, 
+        \Self.elseKeyword, 
+        \Self.unexpectedBetweenElseKeywordAndElseBody, 
+        \Self.elseBody, 
+        \Self.unexpectedAfterElseBody
+      ])
 }
 
 // MARK: - ImplementsAttributeArgumentsSyntax
@@ -2674,17 +2648,15 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedAfterDeclName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedAfterDeclName
+      ])
 }
 
 // MARK: - ImplicitlyUnwrappedOptionalTypeSyntax
@@ -2792,15 +2764,13 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWrappedType, 
-          \Self.wrappedType, 
-          \Self.unexpectedBetweenWrappedTypeAndExclamationMark, 
-          \Self.exclamationMark, 
-          \Self.unexpectedAfterExclamationMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWrappedType, 
+        \Self.wrappedType, 
+        \Self.unexpectedBetweenWrappedTypeAndExclamationMark, 
+        \Self.exclamationMark, 
+        \Self.unexpectedAfterExclamationMark
+      ])
 }
 
 // MARK: - ImportDeclSyntax
@@ -3098,21 +3068,19 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndImportKeyword, 
-          \Self.importKeyword, 
-          \Self.unexpectedBetweenImportKeywordAndImportKindSpecifier, 
-          \Self.importKindSpecifier, 
-          \Self.unexpectedBetweenImportKindSpecifierAndPath, 
-          \Self.path, 
-          \Self.unexpectedAfterPath
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndImportKeyword, 
+        \Self.importKeyword, 
+        \Self.unexpectedBetweenImportKeywordAndImportKindSpecifier, 
+        \Self.importKindSpecifier, 
+        \Self.unexpectedBetweenImportKindSpecifierAndPath, 
+        \Self.path, 
+        \Self.unexpectedAfterPath
+      ])
 }
 
 // MARK: - ImportPathComponentSyntax
@@ -3231,15 +3199,13 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingPeriod, 
-          \Self.trailingPeriod, 
-          \Self.unexpectedAfterTrailingPeriod
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingPeriod, 
+        \Self.trailingPeriod, 
+        \Self.unexpectedAfterTrailingPeriod
+      ])
 }
 
 // MARK: - InOutExprSyntax
@@ -3349,15 +3315,13 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAmpersand, 
-          \Self.ampersand, 
-          \Self.unexpectedBetweenAmpersandAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAmpersand, 
+        \Self.ampersand, 
+        \Self.unexpectedBetweenAmpersandAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - InfixOperatorExprSyntax
@@ -3493,17 +3457,15 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftOperand, 
-          \Self.leftOperand, 
-          \Self.unexpectedBetweenLeftOperandAndOperator, 
-          \Self.operator, 
-          \Self.unexpectedBetweenOperatorAndRightOperand, 
-          \Self.rightOperand, 
-          \Self.unexpectedAfterRightOperand
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftOperand, 
+        \Self.leftOperand, 
+        \Self.unexpectedBetweenLeftOperandAndOperator, 
+        \Self.operator, 
+        \Self.unexpectedBetweenOperatorAndRightOperand, 
+        \Self.rightOperand, 
+        \Self.unexpectedAfterRightOperand
+      ])
 }
 
 // MARK: - InheritanceClauseSyntax
@@ -3648,15 +3610,13 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndInheritedTypes, 
-          \Self.inheritedTypes, 
-          \Self.unexpectedAfterInheritedTypes
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndInheritedTypes, 
+        \Self.inheritedTypes, 
+        \Self.unexpectedAfterInheritedTypes
+      ])
 }
 
 // MARK: - InheritedTypeSyntax
@@ -3768,15 +3728,13 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - InitializerClauseSyntax
@@ -3894,15 +3852,13 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - InitializerDeclSyntax
@@ -4248,27 +4204,25 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDe
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndInitKeyword, 
-          \Self.initKeyword, 
-          \Self.unexpectedBetweenInitKeywordAndOptionalMark, 
-          \Self.optionalMark, 
-          \Self.unexpectedBetweenOptionalMarkAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndInitKeyword, 
+        \Self.initKeyword, 
+        \Self.unexpectedBetweenInitKeywordAndOptionalMark, 
+        \Self.optionalMark, 
+        \Self.unexpectedBetweenOptionalMarkAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - IntegerLiteralExprSyntax
@@ -4343,9 +4297,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
 }
 
 // MARK: - IsExprSyntax
@@ -4496,17 +4448,15 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndIsKeyword, 
-          \Self.isKeyword, 
-          \Self.unexpectedBetweenIsKeywordAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndIsKeyword, 
+        \Self.isKeyword, 
+        \Self.unexpectedBetweenIsKeywordAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - IsTypePatternSyntax
@@ -4614,13 +4564,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafP
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeIsKeyword, 
-          \Self.isKeyword, 
-          \Self.unexpectedBetweenIsKeywordAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeIsKeyword, 
+        \Self.isKeyword, 
+        \Self.unexpectedBetweenIsKeywordAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -238,15 +238,13 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndComponent, 
-          \Self.component, 
-          \Self.unexpectedAfterComponent
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndComponent, 
+        \Self.component, 
+        \Self.unexpectedAfterComponent
+      ])
 }
 
 // MARK: - KeyPathExprSyntax
@@ -414,17 +412,15 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBackslash, 
-          \Self.backslash, 
-          \Self.unexpectedBetweenBackslashAndRoot, 
-          \Self.root, 
-          \Self.unexpectedBetweenRootAndComponents, 
-          \Self.components, 
-          \Self.unexpectedAfterComponents
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBackslash, 
+        \Self.backslash, 
+        \Self.unexpectedBetweenBackslashAndRoot, 
+        \Self.root, 
+        \Self.unexpectedBetweenRootAndComponents, 
+        \Self.components, 
+        \Self.unexpectedAfterComponents
+      ])
 }
 
 // MARK: - KeyPathOptionalComponentSyntax
@@ -507,9 +503,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeQuestionOrExclamationMark, \Self.questionOrExclamationMark, \Self.unexpectedAfterQuestionOrExclamationMark])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeQuestionOrExclamationMark, \Self.questionOrExclamationMark, \Self.unexpectedAfterQuestionOrExclamationMark])
 }
 
 // MARK: - KeyPathPropertyComponentSyntax
@@ -620,15 +614,13 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDeclName, 
-          \Self.declName, 
-          \Self.unexpectedBetweenDeclNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDeclName, 
+        \Self.declName, 
+        \Self.unexpectedBetweenDeclNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - KeyPathSubscriptComponentSyntax
@@ -797,17 +789,15 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - LabeledExprSyntax
@@ -983,19 +973,17 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - LabeledSpecializeArgumentSyntax
@@ -1182,19 +1170,17 @@ public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - LabeledStmtSyntax
@@ -1330,17 +1316,15 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndStatement, 
-          \Self.statement, 
-          \Self.unexpectedAfterStatement
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndStatement, 
+        \Self.statement, 
+        \Self.unexpectedAfterStatement
+      ])
 }
 
 // MARK: - LayoutRequirementSyntax
@@ -1629,27 +1613,25 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndLayoutSpecifier, 
-          \Self.layoutSpecifier, 
-          \Self.unexpectedBetweenLayoutSpecifierAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndSize, 
-          \Self.size, 
-          \Self.unexpectedBetweenSizeAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndAlignment, 
-          \Self.alignment, 
-          \Self.unexpectedBetweenAlignmentAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndLayoutSpecifier, 
+        \Self.layoutSpecifier, 
+        \Self.unexpectedBetweenLayoutSpecifierAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndSize, 
+        \Self.size, 
+        \Self.unexpectedBetweenSizeAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndAlignment, 
+        \Self.alignment, 
+        \Self.unexpectedBetweenAlignmentAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - LifetimeSpecifierArgumentSyntax
@@ -1779,15 +1761,13 @@ public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeParameter, 
-          \Self.parameter, 
-          \Self.unexpectedBetweenParameterAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeParameter, 
+        \Self.parameter, 
+        \Self.unexpectedBetweenParameterAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - LifetimeTypeSpecifierSyntax
@@ -2023,21 +2003,19 @@ public struct LifetimeTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDependsOnKeyword, 
-          \Self.dependsOnKeyword, 
-          \Self.unexpectedBetweenDependsOnKeywordAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndScopedKeyword, 
-          \Self.scopedKeyword, 
-          \Self.unexpectedBetweenScopedKeywordAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDependsOnKeyword, 
+        \Self.dependsOnKeyword, 
+        \Self.unexpectedBetweenDependsOnKeywordAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndScopedKeyword, 
+        \Self.scopedKeyword, 
+        \Self.unexpectedBetweenScopedKeywordAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - MacroDeclSyntax
@@ -2356,27 +2334,25 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndMacroKeyword, 
-          \Self.macroKeyword, 
-          \Self.unexpectedBetweenMacroKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndDefinition, 
-          \Self.definition, 
-          \Self.unexpectedBetweenDefinitionAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndMacroKeyword, 
+        \Self.macroKeyword, 
+        \Self.unexpectedBetweenMacroKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndDefinition, 
+        \Self.definition, 
+        \Self.unexpectedBetweenDefinitionAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - MacroExpansionDeclSyntax
@@ -2806,31 +2782,29 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPound, 
-          \Self.pound, 
-          \Self.unexpectedBetweenPoundAndMacroName, 
-          \Self.macroName, 
-          \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPound, 
+        \Self.pound, 
+        \Self.unexpectedBetweenPoundAndMacroName, 
+        \Self.macroName, 
+        \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - MacroExpansionExprSyntax
@@ -3156,27 +3130,25 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePound, 
-          \Self.pound, 
-          \Self.unexpectedBetweenPoundAndMacroName, 
-          \Self.macroName, 
-          \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePound, 
+        \Self.pound, 
+        \Self.unexpectedBetweenPoundAndMacroName, 
+        \Self.macroName, 
+        \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - MatchingPatternConditionSyntax
@@ -3338,19 +3310,17 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedAfterInitializer
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedAfterInitializer
+      ])
 }
 
 // MARK: - MemberAccessExprSyntax
@@ -3489,17 +3459,15 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBase, 
-          \Self.base, 
-          \Self.unexpectedBetweenBaseAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedAfterDeclName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBase, 
+        \Self.base, 
+        \Self.unexpectedBetweenBaseAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedAfterDeclName
+      ])
 }
 
 // MARK: - MemberBlockItemSyntax
@@ -3618,15 +3586,13 @@ public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDecl, 
-          \Self.decl, 
-          \Self.unexpectedBetweenDeclAndSemicolon, 
-          \Self.semicolon, 
-          \Self.unexpectedAfterSemicolon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDecl, 
+        \Self.decl, 
+        \Self.unexpectedBetweenDeclAndSemicolon, 
+        \Self.semicolon, 
+        \Self.unexpectedAfterSemicolon
+      ])
 }
 
 // MARK: - MemberBlockSyntax
@@ -3798,17 +3764,15 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndMembers, 
-          \Self.members, 
-          \Self.unexpectedBetweenMembersAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndMembers, 
+        \Self.members, 
+        \Self.unexpectedBetweenMembersAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - MemberTypeSyntax
@@ -3971,19 +3935,17 @@ public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBaseType, 
-          \Self.baseType, 
-          \Self.unexpectedBetweenBaseTypeAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBaseType, 
+        \Self.baseType, 
+        \Self.unexpectedBetweenBaseTypeAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - MetatypeTypeSyntax
@@ -4121,17 +4083,15 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBaseType, 
-          \Self.baseType, 
-          \Self.unexpectedBetweenBaseTypeAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndMetatypeSpecifier, 
-          \Self.metatypeSpecifier, 
-          \Self.unexpectedAfterMetatypeSpecifier
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBaseType, 
+        \Self.baseType, 
+        \Self.unexpectedBetweenBaseTypeAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndMetatypeSpecifier, 
+        \Self.metatypeSpecifier, 
+        \Self.unexpectedAfterMetatypeSpecifier
+      ])
 }
 
 // MARK: - MissingDeclSyntax
@@ -4329,17 +4289,15 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPlaceholder, 
-          \Self.placeholder, 
-          \Self.unexpectedAfterPlaceholder
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPlaceholder, 
+        \Self.placeholder, 
+        \Self.unexpectedAfterPlaceholder
+      ])
 }
 
 // MARK: - MissingExprSyntax
@@ -4421,9 +4379,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingPatternSyntax
@@ -4505,9 +4461,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingStmtSyntax
@@ -4589,9 +4543,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingSyntax
@@ -4673,9 +4625,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingTypeSyntax
@@ -4757,9 +4707,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MultipleTrailingClosureElementSyntax
@@ -4901,17 +4849,15 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndClosure, 
-          \Self.closure, 
-          \Self.unexpectedAfterClosure
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndClosure, 
+        \Self.closure, 
+        \Self.unexpectedAfterClosure
+      ])
 }
 
 // MARK: - NamedOpaqueReturnTypeSyntax
@@ -5018,15 +4964,13 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - NilLiteralExprSyntax
@@ -5101,7 +5045,5 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeNilKeyword, \Self.nilKeyword, \Self.unexpectedAfterNilKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeNilKeyword, \Self.nilKeyword, \Self.unexpectedAfterNilKeyword])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
@@ -128,15 +128,13 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - OpaqueReturnTypeOfAttributeArgumentsSyntax
@@ -283,17 +281,15 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeMangledName, 
-          \Self.mangledName, 
-          \Self.unexpectedBetweenMangledNameAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndOrdinal, 
-          \Self.ordinal, 
-          \Self.unexpectedAfterOrdinal
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeMangledName, 
+        \Self.mangledName, 
+        \Self.unexpectedBetweenMangledNameAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndOrdinal, 
+        \Self.ordinal, 
+        \Self.unexpectedAfterOrdinal
+      ])
 }
 
 // MARK: - OperatorDeclSyntax
@@ -470,19 +466,17 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeFixitySpecifier, 
-          \Self.fixitySpecifier, 
-          \Self.unexpectedBetweenFixitySpecifierAndOperatorKeyword, 
-          \Self.operatorKeyword, 
-          \Self.unexpectedBetweenOperatorKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndOperatorPrecedenceAndTypes, 
-          \Self.operatorPrecedenceAndTypes, 
-          \Self.unexpectedAfterOperatorPrecedenceAndTypes
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeFixitySpecifier, 
+        \Self.fixitySpecifier, 
+        \Self.unexpectedBetweenFixitySpecifierAndOperatorKeyword, 
+        \Self.operatorKeyword, 
+        \Self.unexpectedBetweenOperatorKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndOperatorPrecedenceAndTypes, 
+        \Self.operatorPrecedenceAndTypes, 
+        \Self.unexpectedAfterOperatorPrecedenceAndTypes
+      ])
 }
 
 // MARK: - OperatorPrecedenceAndTypesSyntax
@@ -656,17 +650,15 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable, 
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPrecedenceGroup, 
-          \Self.precedenceGroup, 
-          \Self.unexpectedBetweenPrecedenceGroupAndDesignatedTypes, 
-          \Self.designatedTypes, 
-          \Self.unexpectedAfterDesignatedTypes
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPrecedenceGroup, 
+        \Self.precedenceGroup, 
+        \Self.unexpectedBetweenPrecedenceGroupAndDesignatedTypes, 
+        \Self.designatedTypes, 
+        \Self.unexpectedAfterDesignatedTypes
+      ])
 }
 
 // MARK: - OptionalBindingConditionSyntax
@@ -834,19 +826,17 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBindingSpecifier, 
-          \Self.bindingSpecifier, 
-          \Self.unexpectedBetweenBindingSpecifierAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedAfterInitializer
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBindingSpecifier, 
+        \Self.bindingSpecifier, 
+        \Self.unexpectedBetweenBindingSpecifierAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedAfterInitializer
+      ])
 }
 
 // MARK: - OptionalChainingExprSyntax
@@ -954,15 +944,13 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedAfterQuestionMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedAfterQuestionMark
+      ])
 }
 
 // MARK: - OptionalTypeSyntax
@@ -1070,15 +1058,13 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWrappedType, 
-          \Self.wrappedType, 
-          \Self.unexpectedBetweenWrappedTypeAndQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedAfterQuestionMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWrappedType, 
+        \Self.wrappedType, 
+        \Self.unexpectedBetweenWrappedTypeAndQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedAfterQuestionMark
+      ])
 }
 
 // MARK: - OriginallyDefinedInAttributeArgumentsSyntax
@@ -1300,21 +1286,19 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeModuleLabel, 
-          \Self.moduleLabel, 
-          \Self.unexpectedBetweenModuleLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndModuleName, 
-          \Self.moduleName, 
-          \Self.unexpectedBetweenModuleNameAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndPlatforms, 
-          \Self.platforms, 
-          \Self.unexpectedAfterPlatforms
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeModuleLabel, 
+        \Self.moduleLabel, 
+        \Self.unexpectedBetweenModuleLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndModuleName, 
+        \Self.moduleName, 
+        \Self.unexpectedBetweenModuleNameAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndPlatforms, 
+        \Self.platforms, 
+        \Self.unexpectedAfterPlatforms
+      ])
 }
 
 // MARK: - PackElementExprSyntax
@@ -1424,15 +1408,13 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEachKeyword, 
-          \Self.eachKeyword, 
-          \Self.unexpectedBetweenEachKeywordAndPack, 
-          \Self.pack, 
-          \Self.unexpectedAfterPack
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEachKeyword, 
+        \Self.eachKeyword, 
+        \Self.unexpectedBetweenEachKeywordAndPack, 
+        \Self.pack, 
+        \Self.unexpectedAfterPack
+      ])
 }
 
 // MARK: - PackElementTypeSyntax
@@ -1540,15 +1522,13 @@ public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEachKeyword, 
-          \Self.eachKeyword, 
-          \Self.unexpectedBetweenEachKeywordAndPack, 
-          \Self.pack, 
-          \Self.unexpectedAfterPack
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEachKeyword, 
+        \Self.eachKeyword, 
+        \Self.unexpectedBetweenEachKeywordAndPack, 
+        \Self.pack, 
+        \Self.unexpectedAfterPack
+      ])
 }
 
 // MARK: - PackExpansionExprSyntax
@@ -1658,15 +1638,13 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRepeatKeyword, 
-          \Self.repeatKeyword, 
-          \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
-          \Self.repetitionPattern, 
-          \Self.unexpectedAfterRepetitionPattern
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRepeatKeyword, 
+        \Self.repeatKeyword, 
+        \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
+        \Self.repetitionPattern, 
+        \Self.unexpectedAfterRepetitionPattern
+      ])
 }
 
 // MARK: - PackExpansionTypeSyntax
@@ -1774,15 +1752,13 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRepeatKeyword, 
-          \Self.repeatKeyword, 
-          \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
-          \Self.repetitionPattern, 
-          \Self.unexpectedAfterRepetitionPattern
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRepeatKeyword, 
+        \Self.repeatKeyword, 
+        \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
+        \Self.repetitionPattern, 
+        \Self.unexpectedAfterRepetitionPattern
+      ])
 }
 
 // MARK: - PatternBindingSyntax
@@ -1991,21 +1967,19 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedBetweenInitializerAndAccessorBlock, 
-          \Self.accessorBlock, 
-          \Self.unexpectedBetweenAccessorBlockAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedBetweenInitializerAndAccessorBlock, 
+        \Self.accessorBlock, 
+        \Self.unexpectedBetweenAccessorBlockAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - PatternExprSyntax
@@ -2077,9 +2051,7 @@ public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePattern, \Self.pattern, \Self.unexpectedAfterPattern])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePattern, \Self.pattern, \Self.unexpectedAfterPattern])
 }
 
 // MARK: - PlatformVersionItemSyntax
@@ -2198,15 +2170,13 @@ public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePlatformVersion, 
-          \Self.platformVersion, 
-          \Self.unexpectedBetweenPlatformVersionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePlatformVersion, 
+        \Self.platformVersion, 
+        \Self.unexpectedBetweenPlatformVersionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - PlatformVersionSyntax
@@ -2330,15 +2300,13 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePlatform, 
-          \Self.platform, 
-          \Self.unexpectedBetweenPlatformAndVersion, 
-          \Self.version, 
-          \Self.unexpectedAfterVersion
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePlatform, 
+        \Self.platform, 
+        \Self.unexpectedBetweenPlatformAndVersion, 
+        \Self.version, 
+        \Self.unexpectedAfterVersion
+      ])
 }
 
 // MARK: - PostfixIfConfigExprSyntax
@@ -2443,15 +2411,13 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBase, 
-          \Self.base, 
-          \Self.unexpectedBetweenBaseAndConfig, 
-          \Self.config, 
-          \Self.unexpectedAfterConfig
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBase, 
+        \Self.base, 
+        \Self.unexpectedBetweenBaseAndConfig, 
+        \Self.config, 
+        \Self.unexpectedAfterConfig
+      ])
 }
 
 // MARK: - PostfixOperatorExprSyntax
@@ -2559,15 +2525,13 @@ public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndOperator, 
-          \Self.operator, 
-          \Self.unexpectedAfterOperator
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndOperator, 
+        \Self.operator, 
+        \Self.unexpectedAfterOperator
+      ])
 }
 
 // MARK: - PoundSourceLocationArgumentsSyntax
@@ -2819,25 +2783,23 @@ public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeFileLabel, 
-          \Self.fileLabel, 
-          \Self.unexpectedBetweenFileLabelAndFileColon, 
-          \Self.fileColon, 
-          \Self.unexpectedBetweenFileColonAndFileName, 
-          \Self.fileName, 
-          \Self.unexpectedBetweenFileNameAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndLineLabel, 
-          \Self.lineLabel, 
-          \Self.unexpectedBetweenLineLabelAndLineColon, 
-          \Self.lineColon, 
-          \Self.unexpectedBetweenLineColonAndLineNumber, 
-          \Self.lineNumber, 
-          \Self.unexpectedAfterLineNumber
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeFileLabel, 
+        \Self.fileLabel, 
+        \Self.unexpectedBetweenFileLabelAndFileColon, 
+        \Self.fileColon, 
+        \Self.unexpectedBetweenFileColonAndFileName, 
+        \Self.fileName, 
+        \Self.unexpectedBetweenFileNameAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndLineLabel, 
+        \Self.lineLabel, 
+        \Self.unexpectedBetweenLineLabelAndLineColon, 
+        \Self.lineColon, 
+        \Self.unexpectedBetweenLineColonAndLineNumber, 
+        \Self.lineNumber, 
+        \Self.unexpectedAfterLineNumber
+      ])
 }
 
 // MARK: - PoundSourceLocationSyntax
@@ -3001,19 +2963,17 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePoundSourceLocation, 
-          \Self.poundSourceLocation, 
-          \Self.unexpectedBetweenPoundSourceLocationAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePoundSourceLocation, 
+        \Self.poundSourceLocation, 
+        \Self.unexpectedBetweenPoundSourceLocationAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - PrecedenceGroupAssignmentSyntax
@@ -3163,17 +3123,15 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAssignmentLabel, 
-          \Self.assignmentLabel, 
-          \Self.unexpectedBetweenAssignmentLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAssignmentLabel, 
+        \Self.assignmentLabel, 
+        \Self.unexpectedBetweenAssignmentLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - PrecedenceGroupAssociativitySyntax
@@ -3324,17 +3282,15 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAssociativityLabel, 
-          \Self.associativityLabel, 
-          \Self.unexpectedBetweenAssociativityLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAssociativityLabel, 
+        \Self.associativityLabel, 
+        \Self.unexpectedBetweenAssociativityLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - PrecedenceGroupDeclSyntax
@@ -3668,25 +3624,23 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPrecedencegroupKeyword, 
-          \Self.precedencegroupKeyword, 
-          \Self.unexpectedBetweenPrecedencegroupKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndGroupAttributes, 
-          \Self.groupAttributes, 
-          \Self.unexpectedBetweenGroupAttributesAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPrecedencegroupKeyword, 
+        \Self.precedencegroupKeyword, 
+        \Self.unexpectedBetweenPrecedencegroupKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndGroupAttributes, 
+        \Self.groupAttributes, 
+        \Self.unexpectedBetweenGroupAttributesAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - PrecedenceGroupNameSyntax
@@ -3801,15 +3755,13 @@ public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - PrecedenceGroupRelationSyntax
@@ -3985,17 +3937,15 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeHigherThanOrLowerThanLabel, 
-          \Self.higherThanOrLowerThanLabel, 
-          \Self.unexpectedBetweenHigherThanOrLowerThanLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPrecedenceGroups, 
-          \Self.precedenceGroups, 
-          \Self.unexpectedAfterPrecedenceGroups
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeHigherThanOrLowerThanLabel, 
+        \Self.higherThanOrLowerThanLabel, 
+        \Self.unexpectedBetweenHigherThanOrLowerThanLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPrecedenceGroups, 
+        \Self.precedenceGroups, 
+        \Self.unexpectedAfterPrecedenceGroups
+      ])
 }
 
 // MARK: - PrefixOperatorExprSyntax
@@ -4115,15 +4065,13 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOperator, 
-          \Self.operator, 
-          \Self.unexpectedBetweenOperatorAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOperator, 
+        \Self.operator, 
+        \Self.unexpectedBetweenOperatorAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - PrimaryAssociatedTypeClauseSyntax
@@ -4290,17 +4238,15 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable,
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftAngle, 
-          \Self.leftAngle, 
-          \Self.unexpectedBetweenLeftAngleAndPrimaryAssociatedTypes, 
-          \Self.primaryAssociatedTypes, 
-          \Self.unexpectedBetweenPrimaryAssociatedTypesAndRightAngle, 
-          \Self.rightAngle, 
-          \Self.unexpectedAfterRightAngle
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftAngle, 
+        \Self.leftAngle, 
+        \Self.unexpectedBetweenLeftAngleAndPrimaryAssociatedTypes, 
+        \Self.primaryAssociatedTypes, 
+        \Self.unexpectedBetweenPrimaryAssociatedTypesAndRightAngle, 
+        \Self.rightAngle, 
+        \Self.unexpectedAfterRightAngle
+      ])
 }
 
 // MARK: - PrimaryAssociatedTypeSyntax
@@ -4415,15 +4361,13 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ProtocolDeclSyntax
@@ -4766,25 +4710,23 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndProtocolKeyword, 
-          \Self.protocolKeyword, 
-          \Self.unexpectedBetweenProtocolKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndPrimaryAssociatedTypeClause, 
-          \Self.primaryAssociatedTypeClause, 
-          \Self.unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndProtocolKeyword, 
+        \Self.protocolKeyword, 
+        \Self.unexpectedBetweenProtocolKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndPrimaryAssociatedTypeClause, 
+        \Self.primaryAssociatedTypeClause, 
+        \Self.unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -204,21 +204,19 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOpeningPounds, 
-          \Self.openingPounds, 
-          \Self.unexpectedBetweenOpeningPoundsAndOpeningSlash, 
-          \Self.openingSlash, 
-          \Self.unexpectedBetweenOpeningSlashAndRegex, 
-          \Self.regex, 
-          \Self.unexpectedBetweenRegexAndClosingSlash, 
-          \Self.closingSlash, 
-          \Self.unexpectedBetweenClosingSlashAndClosingPounds, 
-          \Self.closingPounds, 
-          \Self.unexpectedAfterClosingPounds
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOpeningPounds, 
+        \Self.openingPounds, 
+        \Self.unexpectedBetweenOpeningPoundsAndOpeningSlash, 
+        \Self.openingSlash, 
+        \Self.unexpectedBetweenOpeningSlashAndRegex, 
+        \Self.regex, 
+        \Self.unexpectedBetweenRegexAndClosingSlash, 
+        \Self.closingSlash, 
+        \Self.unexpectedBetweenClosingSlashAndClosingPounds, 
+        \Self.closingPounds, 
+        \Self.unexpectedAfterClosingPounds
+      ])
 }
 
 // MARK: - RepeatStmtSyntax
@@ -379,19 +377,17 @@ public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRepeatKeyword, 
-          \Self.repeatKeyword, 
-          \Self.unexpectedBetweenRepeatKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndWhileKeyword, 
-          \Self.whileKeyword, 
-          \Self.unexpectedBetweenWhileKeywordAndCondition, 
-          \Self.condition, 
-          \Self.unexpectedAfterCondition
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRepeatKeyword, 
+        \Self.repeatKeyword, 
+        \Self.unexpectedBetweenRepeatKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndWhileKeyword, 
+        \Self.whileKeyword, 
+        \Self.unexpectedBetweenWhileKeywordAndCondition, 
+        \Self.condition, 
+        \Self.unexpectedAfterCondition
+      ])
 }
 
 // MARK: - ReturnClauseSyntax
@@ -511,15 +507,13 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArrow, 
-          \Self.arrow, 
-          \Self.unexpectedBetweenArrowAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArrow, 
+        \Self.arrow, 
+        \Self.unexpectedBetweenArrowAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - ReturnStmtSyntax
@@ -627,15 +621,13 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeReturnKeyword, 
-          \Self.returnKeyword, 
-          \Self.unexpectedBetweenReturnKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeReturnKeyword, 
+        \Self.returnKeyword, 
+        \Self.unexpectedBetweenReturnKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - SameTypeRequirementSyntax
@@ -775,17 +767,15 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftType, 
-          \Self.leftType, 
-          \Self.unexpectedBetweenLeftTypeAndEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndRightType, 
-          \Self.rightType, 
-          \Self.unexpectedAfterRightType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftType, 
+        \Self.leftType, 
+        \Self.unexpectedBetweenLeftTypeAndEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndRightType, 
+        \Self.rightType, 
+        \Self.unexpectedAfterRightType
+      ])
 }
 
 // MARK: - SequenceExprSyntax
@@ -892,9 +882,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
 }
 
 // MARK: - SimpleStringLiteralExprSyntax
@@ -1076,17 +1064,15 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable,
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOpeningQuote, 
-          \Self.openingQuote, 
-          \Self.unexpectedBetweenOpeningQuoteAndSegments, 
-          \Self.segments, 
-          \Self.unexpectedBetweenSegmentsAndClosingQuote, 
-          \Self.closingQuote, 
-          \Self.unexpectedAfterClosingQuote
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOpeningQuote, 
+        \Self.openingQuote, 
+        \Self.unexpectedBetweenOpeningQuoteAndSegments, 
+        \Self.segments, 
+        \Self.unexpectedBetweenSegmentsAndClosingQuote, 
+        \Self.closingQuote, 
+        \Self.unexpectedAfterClosingQuote
+      ])
 }
 
 // MARK: - SimpleTypeSpecifierSyntax
@@ -1178,9 +1164,7 @@ public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeSpecifier, \Self.specifier, \Self.unexpectedAfterSpecifier])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeSpecifier, \Self.specifier, \Self.unexpectedAfterSpecifier])
 }
 
 // MARK: - SomeOrAnyTypeSyntax
@@ -1290,15 +1274,13 @@ public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafType
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSomeOrAnySpecifier, 
-          \Self.someOrAnySpecifier, 
-          \Self.unexpectedBetweenSomeOrAnySpecifierAndConstraint, 
-          \Self.constraint, 
-          \Self.unexpectedAfterConstraint
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSomeOrAnySpecifier, 
+        \Self.someOrAnySpecifier, 
+        \Self.unexpectedBetweenSomeOrAnySpecifierAndConstraint, 
+        \Self.constraint, 
+        \Self.unexpectedAfterConstraint
+      ])
 }
 
 // MARK: - SourceFileSyntax
@@ -1464,17 +1446,15 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeShebang, 
-          \Self.shebang, 
-          \Self.unexpectedBetweenShebangAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedBetweenStatementsAndEndOfFileToken, 
-          \Self.endOfFileToken, 
-          \Self.unexpectedAfterEndOfFileToken
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeShebang, 
+        \Self.shebang, 
+        \Self.unexpectedBetweenShebangAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedBetweenStatementsAndEndOfFileToken, 
+        \Self.endOfFileToken, 
+        \Self.unexpectedAfterEndOfFileToken
+      ])
 }
 
 // MARK: - SpecializeAvailabilityArgumentSyntax
@@ -1677,19 +1657,17 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAvailabilityLabel, 
-          \Self.availabilityLabel, 
-          \Self.unexpectedBetweenAvailabilityLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndAvailabilityArguments, 
-          \Self.availabilityArguments, 
-          \Self.unexpectedBetweenAvailabilityArgumentsAndSemicolon, 
-          \Self.semicolon, 
-          \Self.unexpectedAfterSemicolon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAvailabilityLabel, 
+        \Self.availabilityLabel, 
+        \Self.unexpectedBetweenAvailabilityLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndAvailabilityArguments, 
+        \Self.availabilityArguments, 
+        \Self.unexpectedBetweenAvailabilityArgumentsAndSemicolon, 
+        \Self.semicolon, 
+        \Self.unexpectedAfterSemicolon
+      ])
 }
 
 // MARK: - SpecializeTargetFunctionArgumentSyntax
@@ -1870,19 +1848,17 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeTargetLabel, 
-          \Self.targetLabel, 
-          \Self.unexpectedBetweenTargetLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedBetweenDeclNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeTargetLabel, 
+        \Self.targetLabel, 
+        \Self.unexpectedBetweenTargetLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedBetweenDeclNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - StringLiteralExprSyntax
@@ -2126,21 +2102,19 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOpeningPounds, 
-          \Self.openingPounds, 
-          \Self.unexpectedBetweenOpeningPoundsAndOpeningQuote, 
-          \Self.openingQuote, 
-          \Self.unexpectedBetweenOpeningQuoteAndSegments, 
-          \Self.segments, 
-          \Self.unexpectedBetweenSegmentsAndClosingQuote, 
-          \Self.closingQuote, 
-          \Self.unexpectedBetweenClosingQuoteAndClosingPounds, 
-          \Self.closingPounds, 
-          \Self.unexpectedAfterClosingPounds
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOpeningPounds, 
+        \Self.openingPounds, 
+        \Self.unexpectedBetweenOpeningPoundsAndOpeningQuote, 
+        \Self.openingQuote, 
+        \Self.unexpectedBetweenOpeningQuoteAndSegments, 
+        \Self.segments, 
+        \Self.unexpectedBetweenSegmentsAndClosingQuote, 
+        \Self.closingQuote, 
+        \Self.unexpectedBetweenClosingQuoteAndClosingPounds, 
+        \Self.closingPounds, 
+        \Self.unexpectedAfterClosingPounds
+      ])
 }
 
 // MARK: - StringSegmentSyntax
@@ -2224,9 +2198,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeContent, \Self.content, \Self.unexpectedAfterContent])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeContent, \Self.content, \Self.unexpectedAfterContent])
 }
 
 // MARK: - StructDeclSyntax
@@ -2617,27 +2589,25 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndStructKeyword, 
-          \Self.structKeyword, 
-          \Self.unexpectedBetweenStructKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndStructKeyword, 
+        \Self.structKeyword, 
+        \Self.unexpectedBetweenStructKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - SubscriptCallExprSyntax
@@ -2902,23 +2872,21 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCalledExpression, 
-          \Self.calledExpression, 
-          \Self.unexpectedBetweenCalledExpressionAndLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedBetweenRightSquareAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCalledExpression, 
+        \Self.calledExpression, 
+        \Self.unexpectedBetweenCalledExpressionAndLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedBetweenRightSquareAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - SubscriptDeclSyntax
@@ -3234,27 +3202,25 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndSubscriptKeyword, 
-          \Self.subscriptKeyword, 
-          \Self.unexpectedBetweenSubscriptKeywordAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedBetweenReturnClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndAccessorBlock, 
-          \Self.accessorBlock, 
-          \Self.unexpectedAfterAccessorBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndSubscriptKeyword, 
+        \Self.subscriptKeyword, 
+        \Self.unexpectedBetweenSubscriptKeywordAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedBetweenReturnClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndAccessorBlock, 
+        \Self.accessorBlock, 
+        \Self.unexpectedAfterAccessorBlock
+      ])
 }
 
 // MARK: - SuperExprSyntax
@@ -3329,9 +3295,7 @@ public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeSuperKeyword, \Self.superKeyword, \Self.unexpectedAfterSuperKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeSuperKeyword, \Self.superKeyword, \Self.unexpectedAfterSuperKeyword])
 }
 
 // MARK: - SuppressedTypeSyntax
@@ -3439,15 +3403,13 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWithoutTilde, 
-          \Self.withoutTilde, 
-          \Self.unexpectedBetweenWithoutTildeAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWithoutTilde, 
+        \Self.withoutTilde, 
+        \Self.unexpectedBetweenWithoutTildeAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - SwitchCaseItemSyntax
@@ -3584,17 +3546,15 @@ public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndWhereClause, 
-          \Self.whereClause, 
-          \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndWhereClause, 
+        \Self.whereClause, 
+        \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - SwitchCaseLabelSyntax
@@ -3761,17 +3721,15 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndCaseItems, 
-          \Self.caseItems, 
-          \Self.unexpectedBetweenCaseItemsAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndCaseItems, 
+        \Self.caseItems, 
+        \Self.unexpectedBetweenCaseItemsAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - SwitchCaseSyntax
@@ -4016,17 +3974,15 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttribute, 
-          \Self.attribute, 
-          \Self.unexpectedBetweenAttributeAndLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedAfterStatements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttribute, 
+        \Self.attribute, 
+        \Self.unexpectedBetweenAttributeAndLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedAfterStatements
+      ])
 }
 
 // MARK: - SwitchDefaultLabelSyntax
@@ -4141,15 +4097,13 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDefaultKeyword, 
-          \Self.defaultKeyword, 
-          \Self.unexpectedBetweenDefaultKeywordAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDefaultKeyword, 
+        \Self.defaultKeyword, 
+        \Self.unexpectedBetweenDefaultKeywordAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - SwitchExprSyntax
@@ -4391,19 +4345,17 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSwitchKeyword, 
-          \Self.switchKeyword, 
-          \Self.unexpectedBetweenSwitchKeywordAndSubject, 
-          \Self.subject, 
-          \Self.unexpectedBetweenSubjectAndLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndCases, 
-          \Self.cases, 
-          \Self.unexpectedBetweenCasesAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSwitchKeyword, 
+        \Self.switchKeyword, 
+        \Self.unexpectedBetweenSwitchKeywordAndSubject, 
+        \Self.subject, 
+        \Self.unexpectedBetweenSubjectAndLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndCases, 
+        \Self.cases, 
+        \Self.unexpectedBetweenCasesAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -206,21 +206,19 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCondition, 
-          \Self.condition, 
-          \Self.unexpectedBetweenConditionAndQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
-          \Self.thenExpression, 
-          \Self.unexpectedBetweenThenExpressionAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndElseExpression, 
-          \Self.elseExpression, 
-          \Self.unexpectedAfterElseExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCondition, 
+        \Self.condition, 
+        \Self.unexpectedBetweenConditionAndQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
+        \Self.thenExpression, 
+        \Self.unexpectedBetweenThenExpressionAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndElseExpression, 
+        \Self.elseExpression, 
+        \Self.unexpectedAfterElseExpression
+      ])
 }
 
 // MARK: - ThenStmtSyntax
@@ -341,15 +339,13 @@ public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeThenKeyword, 
-          \Self.thenKeyword, 
-          \Self.unexpectedBetweenThenKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeThenKeyword, 
+        \Self.thenKeyword, 
+        \Self.unexpectedBetweenThenKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - ThrowStmtSyntax
@@ -457,15 +453,13 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeThrowKeyword, 
-          \Self.throwKeyword, 
-          \Self.unexpectedBetweenThrowKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeThrowKeyword, 
+        \Self.throwKeyword, 
+        \Self.unexpectedBetweenThrowKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - ThrowsClauseSyntax
@@ -649,19 +643,17 @@ public struct ThrowsClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeThrowsSpecifier, 
-          \Self.throwsSpecifier, 
-          \Self.unexpectedBetweenThrowsSpecifierAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeThrowsSpecifier, 
+        \Self.throwsSpecifier, 
+        \Self.unexpectedBetweenThrowsSpecifierAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TryExprSyntax
@@ -815,17 +807,15 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeTryKeyword, 
-          \Self.tryKeyword, 
-          \Self.unexpectedBetweenTryKeywordAndQuestionOrExclamationMark, 
-          \Self.questionOrExclamationMark, 
-          \Self.unexpectedBetweenQuestionOrExclamationMarkAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeTryKeyword, 
+        \Self.tryKeyword, 
+        \Self.unexpectedBetweenTryKeywordAndQuestionOrExclamationMark, 
+        \Self.questionOrExclamationMark, 
+        \Self.unexpectedBetweenQuestionOrExclamationMarkAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - TupleExprSyntax
@@ -988,17 +978,15 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TuplePatternElementSyntax
@@ -1179,19 +1167,17 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - TuplePatternSyntax
@@ -1371,17 +1357,15 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPa
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TupleTypeElementSyntax
@@ -1637,25 +1621,23 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeInoutKeyword, 
-          \Self.inoutKeyword, 
-          \Self.unexpectedBetweenInoutKeywordAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndEllipsis, 
-          \Self.ellipsis, 
-          \Self.unexpectedBetweenEllipsisAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeInoutKeyword, 
+        \Self.inoutKeyword, 
+        \Self.unexpectedBetweenInoutKeywordAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndEllipsis, 
+        \Self.ellipsis, 
+        \Self.unexpectedBetweenEllipsisAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - TupleTypeSyntax
@@ -1818,17 +1800,15 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TypeAliasDeclSyntax
@@ -2122,25 +2102,23 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndTypealiasKeyword, 
-          \Self.typealiasKeyword, 
-          \Self.unexpectedBetweenTypealiasKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndTypealiasKeyword, 
+        \Self.typealiasKeyword, 
+        \Self.unexpectedBetweenTypealiasKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - TypeAnnotationSyntax
@@ -2258,15 +2236,13 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - TypeEffectSpecifiersSyntax
@@ -2382,15 +2358,13 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsyncSpecifier, 
-          \Self.asyncSpecifier, 
-          \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedAfterThrowsClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsyncSpecifier, 
+        \Self.asyncSpecifier, 
+        \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedAfterThrowsClause
+      ])
 }
 
 // MARK: - TypeExprSyntax
@@ -2462,9 +2436,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeType, \Self.type, \Self.unexpectedAfterType])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeType, \Self.type, \Self.unexpectedAfterType])
 }
 
 // MARK: - TypeInitializerClauseSyntax
@@ -2577,15 +2549,13 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - UnavailableFromAsyncAttributeArgumentsSyntax
@@ -2727,17 +2697,15 @@ public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, Synt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeMessageLabel, 
-          \Self.messageLabel, 
-          \Self.unexpectedBetweenMessageLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndMessage, 
-          \Self.message, 
-          \Self.unexpectedAfterMessage
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeMessageLabel, 
+        \Self.messageLabel, 
+        \Self.unexpectedBetweenMessageLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndMessage, 
+        \Self.message, 
+        \Self.unexpectedAfterMessage
+      ])
 }
 
 // MARK: - UnderscorePrivateAttributeArgumentsSyntax
@@ -2879,17 +2847,15 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSourceFileLabel, 
-          \Self.sourceFileLabel, 
-          \Self.unexpectedBetweenSourceFileLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndFilename, 
-          \Self.filename, 
-          \Self.unexpectedAfterFilename
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSourceFileLabel, 
+        \Self.sourceFileLabel, 
+        \Self.unexpectedBetweenSourceFileLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndFilename, 
+        \Self.filename, 
+        \Self.unexpectedAfterFilename
+      ])
 }
 
 // MARK: - UnresolvedAsExprSyntax
@@ -3007,15 +2973,13 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsKeyword, 
-          \Self.asKeyword, 
-          \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
-          \Self.questionOrExclamationMark, 
-          \Self.unexpectedAfterQuestionOrExclamationMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsKeyword, 
+        \Self.asKeyword, 
+        \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
+        \Self.questionOrExclamationMark, 
+        \Self.unexpectedAfterQuestionOrExclamationMark
+      ])
 }
 
 // MARK: - UnresolvedIsExprSyntax
@@ -3095,9 +3059,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeIsKeyword, \Self.isKeyword, \Self.unexpectedAfterIsKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeIsKeyword, \Self.isKeyword, \Self.unexpectedAfterIsKeyword])
 }
 
 // MARK: - UnresolvedTernaryExprSyntax
@@ -3239,17 +3201,15 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
-          \Self.thenExpression, 
-          \Self.unexpectedBetweenThenExpressionAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
+        \Self.thenExpression, 
+        \Self.unexpectedBetweenThenExpressionAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - ValueBindingPatternSyntax
@@ -3364,15 +3324,13 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, 
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBindingSpecifier, 
-          \Self.bindingSpecifier, 
-          \Self.unexpectedBetweenBindingSpecifierAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedAfterPattern
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBindingSpecifier, 
+        \Self.bindingSpecifier, 
+        \Self.unexpectedBetweenBindingSpecifierAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedAfterPattern
+      ])
 }
 
 // MARK: - VariableDeclSyntax
@@ -3639,19 +3597,17 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndBindingSpecifier, 
-          \Self.bindingSpecifier, 
-          \Self.unexpectedBetweenBindingSpecifierAndBindings, 
-          \Self.bindings, 
-          \Self.unexpectedAfterBindings
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndBindingSpecifier, 
+        \Self.bindingSpecifier, 
+        \Self.unexpectedBetweenBindingSpecifierAndBindings, 
+        \Self.bindings, 
+        \Self.unexpectedAfterBindings
+      ])
 }
 
 // MARK: - VersionComponentSyntax
@@ -3774,15 +3730,13 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndNumber, 
-          \Self.number, 
-          \Self.unexpectedAfterNumber
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndNumber, 
+        \Self.number, 
+        \Self.unexpectedAfterNumber
+      ])
 }
 
 // MARK: - VersionTupleSyntax
@@ -3930,15 +3884,13 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeMajor, 
-          \Self.major, 
-          \Self.unexpectedBetweenMajorAndComponents, 
-          \Self.components, 
-          \Self.unexpectedAfterComponents
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeMajor, 
+        \Self.major, 
+        \Self.unexpectedBetweenMajorAndComponents, 
+        \Self.components, 
+        \Self.unexpectedAfterComponents
+      ])
 }
 
 // MARK: - WhereClauseSyntax
@@ -4052,15 +4004,13 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWhereKeyword, 
-          \Self.whereKeyword, 
-          \Self.unexpectedBetweenWhereKeywordAndCondition, 
-          \Self.condition, 
-          \Self.unexpectedAfterCondition
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWhereKeyword, 
+        \Self.whereKeyword, 
+        \Self.unexpectedBetweenWhereKeywordAndCondition, 
+        \Self.condition, 
+        \Self.unexpectedAfterCondition
+      ])
 }
 
 // MARK: - WhileStmtSyntax
@@ -4220,17 +4170,15 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWhileKeyword, 
-          \Self.whileKeyword, 
-          \Self.unexpectedBetweenWhileKeywordAndConditions, 
-          \Self.conditions, 
-          \Self.unexpectedBetweenConditionsAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWhileKeyword, 
+        \Self.whileKeyword, 
+        \Self.unexpectedBetweenWhileKeywordAndConditions, 
+        \Self.conditions, 
+        \Self.unexpectedBetweenConditionsAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - WildcardPatternSyntax
@@ -4318,9 +4266,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
 }
 
 // MARK: - YieldStmtSyntax
@@ -4510,15 +4456,13 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeYieldKeyword, 
-          \Self.yieldKeyword, 
-          \Self.unexpectedBetweenYieldKeywordAndYieldedExpressions, 
-          \Self.yieldedExpressions, 
-          \Self.unexpectedAfterYieldedExpressions
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeYieldKeyword, 
+        \Self.yieldKeyword, 
+        \Self.unexpectedBetweenYieldKeywordAndYieldedExpressions, 
+        \Self.yieldedExpressions, 
+        \Self.unexpectedAfterYieldedExpressions
+      ])
 }
 
 // MARK: - YieldedExpressionSyntax
@@ -4630,15 +4574,13 @@ public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndComma, 
-          \Self.comma, 
-          \Self.unexpectedAfterComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndComma, 
+        \Self.comma, 
+        \Self.unexpectedAfterComma
+      ])
 }
 
 // MARK: - YieldedExpressionsClauseSyntax
@@ -4805,15 +4747,13 @@ public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }


### PR DESCRIPTION
Computing `OperatorTable.standardOperators` is not trivial, make it `static let` instead of computed static variable.
So as `SyntaxProtocol.structure` implementations.