### PR TITLE
[MacroExamples] Update invalid URL example

### DIFF
--- a/Examples/Sources/MacroExamples/Playground/ExpressionMacrosPlayground.swift
+++ b/Examples/Sources/MacroExamples/Playground/ExpressionMacrosPlayground.swift
@@ -47,7 +47,7 @@ func runExpressionMacrosPlayground() {
 
   //  let domain = "domain.com"
   //print(#URL("https://\(domain)/api/path")) // error: #URL requires a static string literal
-  //print(#URL("https://not a url.com")) // error: Malformed url
+  //print(#URL("https://not a url.com:invalid-port/")) // error: Malformed url
 
   // MARK: - Warning
 

--- a/Examples/Tests/MacroExamples/Implementation/Expression/URLMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Expression/URLMacroTests.swift
@@ -21,13 +21,18 @@ final class URLMacroTests: XCTestCase {
   func testExpansionWithMalformedURLEmitsError() {
     assertMacroExpansion(
       """
-      let invalid = #URL("https://not a url.com")
+      let invalid = #URL("https://not a url.com:invalid-port/")
       """,
       expandedSource: """
-        let invalid = #URL("https://not a url.com")
+        let invalid = #URL("https://not a url.com:invalid-port/")
         """,
       diagnostics: [
-        DiagnosticSpec(message: #"malformed url: "https://not a url.com""#, line: 1, column: 15, severity: .error)
+        DiagnosticSpec(
+          message: #"malformed url: "https://not a url.com:invalid-port/""#,
+          line: 1,
+          column: 15,
+          severity: .error
+        )
       ],
       macros: macros,
       indentationWidth: .spaces(2)


### PR DESCRIPTION
Workaround for a Foundation bug that can return non-nil URL for `"https://not a url.com"`.