### PR TITLE
[6.0] Mark `FormatMode` as `Sendable`

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/Macro+Format.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/Macro+Format.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Describes the mode to use to format the result of an expansion.
-public enum FormatMode {
+public enum FormatMode: Sendable {
   /// Perform a basic format of the expansion. This is primarily for inserting
   /// whitespace as required (eg. between two keywords), but also adds simple
   /// newline and indentation.


### PR DESCRIPTION
* **Explanation**: Mark `FormatMode` as `Sendable`
* **Risk**: Low, just adds a `Sendable` conformance to a type that’s obviously sendable
* **Testing**: n/a
* **Issue**: n/a
* **Reviewer**:  @bnbarham 