### PR TITLE
[CMake] Enable package CMO if possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,23 +42,24 @@ option(SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26
        $<IF:$<AND:$<NOT:$<CONFIG:Debug>>,$<PLATFORM_ID:Darwin>>,YES,NO>)
 
 include(AddSwiftHostLibrary)
+include(SwiftCompilerCapability)
 
-# Ensure that we do not link the _StringProcessing module. But we can
-# only pass this flag for new-enough compilers that support it.
-file(WRITE "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift" "")
-execute_process(
-  COMMAND
-    "${CMAKE_Swift_COMPILER}"
-    -Xfrontend -disable-implicit-string-processing-module-import
-    -Xfrontend -parse-stdlib
-    -typecheck "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
-  OUTPUT_QUIET ERROR_QUIET
-  RESULT_VARIABLE
-    SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
-if (NOT SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
-  add_compile_options(
-    $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend>
-    $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
+# Don't link with 'string-processing' and 'backtracing'.
+swift_supports_implicit_module("string-processing" SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
+swift_supports_implicit_module("backtracing" SWIFT_SUPPORTS_DISABLE_IMPLICIT_BACKTRACING_MODULE_IMPORT)
+if(SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
+  add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
+endif()
+if(SWIFT_SUPPORTS_DISABLE_IMPLICIT_BACKTRACING_MODULE_IMPORT)
+  add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-backtracing-module-import>")
+endif()
+
+# SWIFTSYNTAX_EMIT_MODULE is TRUE by default
+if(NOT DEFINED SWIFTSYNTAX_EMIT_MODULE)
+  set(SWIFTSYNTAX_EMIT_MODULE TRUE)
+endif()
+if(SWIFTSYNTAX_EMIT_MODULE)
+  swift_get_package_cmo_support(SWIFT_PACKAGE_CMO_SUPPORT)
 endif()
 
 # Determine the module triple.

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -53,7 +53,7 @@ function(add_swift_syntax_library name)
   # Create the library target.
   add_library(${target} ${ASHL_SOURCES})
 
-  if(NOT DEFINED SWIFTSYNTAX_EMIT_MODULE OR SWIFTSYNTAX_EMIT_MODULE)
+  if(SWIFTSYNTAX_EMIT_MODULE)
     # Determine where Swift modules will be built and installed.
     set(module_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
     set(module_base "${module_dir}/${name}.swiftmodule")
@@ -79,6 +79,25 @@ function(add_swift_syntax_library name)
         -emit-module-interface-path;${module_interface_file};
         -emit-private-module-interface-path;${module_private_interface_file}
     >)
+
+    # Enable package CMO if possible.
+    if(SWIFT_PACKAGE_CMO_SUPPORT STREQUAL "IMPLEMENTED")
+      target_compile_options("${target}" PRIVATE
+        $<$<COMPILE_LANGUAGE:Swift>:
+          "SHELL:-package-name ${SWIFT_MODULE_ABI_NAME_PREFIX}${PROJECT_NAME}"
+          "SHELL:-Xfrontend -package-cmo"
+          "SHELL:-Xfrontend -allow-non-resilient-access"
+      >)
+    elseif(SWIFT_PACKAGE_CMO_SUPPORT STREQUAL "EXPERIMENTAL")
+      target_compile_options("${target}" PRIVATE
+        $<$<COMPILE_LANGUAGE:Swift>:
+          "SHELL:-package-name ${SWIFT_MODULE_ABI_NAME_PREFIX}${PROJECT_NAME}"
+          "SHELL:-Xfrontend -experimental-package-cmo"
+          "SHELL:-Xfrontend -experimental-allow-non-resilient-access"
+          "SHELL:-Xfrontend -experimental-package-bypass-resilience"
+      >)
+    endif()
+
   else()
     set(module_dir ${CMAKE_CURRENT_BINARY_DIR})
     set(module_base "${module_dir}/${name}.swiftmodule")

--- a/cmake/modules/SwiftCompilerCapability.cmake
+++ b/cmake/modules/SwiftCompilerCapability.cmake
@@ -1,0 +1,52 @@
+
+# Test if the Swift compiler returns success for supplied compiler arguments....
+function(swift_supports_compiler_arguments out_var)
+  file(WRITE "${CMAKE_BINARY_DIR}/tmp/dummy.swift" "")
+  execute_process(
+    COMMAND "${CMAKE_Swift_COMPILER}" -parse ${ARGN} -
+    INPUT_FILE "${CMAKE_BINARY_DIR}/tmp/dummy.swift"
+    OUTPUT_QUIET ERROR_QUIET
+    RESULT_VARIABLE result
+  )
+  if(NOT result)
+    set("${out_var}" "TRUE" PARENT_SCOPE)
+  else()
+    set("${out_var}" "FALSE" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Test if the Swift compiler supports -disable-implicit-<module>-module-import.
+macro(swift_supports_implicit_module module_name out_var)
+  swift_supports_compiler_arguments(${out_var}
+    -Xfrontend -disable-implicit-${module_name}-module-import
+  )
+endmacro()
+
+# Get "package cross-module-optimization" compiler arguments suitable for the compiler.
+function(swift_get_package_cmo_support out_var)
+  # > 6.0 : Fixed feature.
+  swift_supports_compiler_arguments(result
+    -package-name my-package
+    -Xfrontend -package-cmo
+    -Xfrontend -allow-non-resilient-access
+  )
+  if(result)
+    set(${out_var} IMPLEMENTED PARENT_SCOPE)
+    return()
+  endif()
+
+  # == 6.0 : Experimental.
+  swift_supports_compiler_arguments(result
+    -package-name my-package
+    -Xfrontend -experimental-package-cmo
+    -Xfrontend -experimental-allow-non-resilient-access
+    -Xfrontend -experimental-package-bypass-resilience
+  )
+  if(result)
+    set(${out_var} EXPERIMENTAL PARENT_SCOPE)
+    return()
+  endif()
+
+  # < 6.0 : Not supported.
+  set(${out_var} NO PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Package cross-module-optimization allows non-resilient access between modules as long as they share the same package name.