### PR TITLE
Improve `SyntaxWriter.visitAny(_:)` docs

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -106,7 +106,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       ///         methods will not be called for this node and the
       ///         visited node will be replaced by the returned node in the
       ///         rewritten tree.
-      ///         You can call the ``SyntaxWriter.rewrite(_:detach:)``
+      ///         You can call the `SyntaxWriter.rewrite(_:detach:)`
       ///         method recursively when returning a non-nil result
       ///         if you want to visit the node's children anyway.
       open func visitAny(_ node: Syntax) -> Syntax? {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -101,10 +101,14 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Override point to choose custom visitation dispatch instead of the
       /// specialized `visit(_:)` methods. Use this instead of those methods if
       /// you intend to dynamically dispatch rewriting behavior.
-      /// - note: If this method returns a non-nil result, the specialized
-      ///         `visit(_:)` methods will not be called for this node and the
+      /// - note: If this method returns a non-nil result, the consequent
+      ///         `visitAny(_:)` methods and the specialized `visit(_:)`
+      ///         methods will not be called for this node and the
       ///         visited node will be replaced by the returned node in the
       ///         rewritten tree.
+      ///         You can call the ``SyntaxWriter.rewrite(_:detach:)``
+      ///         method recursively when returning a non-nil result
+      ///         if you want to visit the node's children anyway.
       open func visitAny(_ node: Syntax) -> Syntax? {
         return nil
       }

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -101,7 +101,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Override point to choose custom visitation dispatch instead of the
       /// specialized `visit(_:)` methods. Use this instead of those methods if
       /// you intend to dynamically dispatch rewriting behavior.
-      /// - note: If this method returns a non-nil result, the consequent
+      /// - note: If this method returns a non-nil result, the subsequent
       ///         `visitAny(_:)` methods and the specialized `visit(_:)`
       ///         methods will not be called for this node and the
       ///         visited node will be replaced by the returned node in the

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -106,7 +106,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       ///         methods will not be called for this node and the
       ///         visited node will be replaced by the returned node in the
       ///         rewritten tree.
-      ///         You can call the `SyntaxWriter.rewrite(_:detach:)`
+      ///         You can call the ``SyntaxRewriter/rewrite(_:detach:)``
       ///         method recursively when returning a non-nil result
       ///         if you want to visit the node's children anyway.
       open func visitAny(_ node: Syntax) -> Syntax? {

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -74,7 +74,7 @@ open class SyntaxRewriter {
   ///         methods will not be called for this node and the
   ///         visited node will be replaced by the returned node in the
   ///         rewritten tree.
-  ///         You can call the ``SyntaxWriter.rewrite(_:detach:)``
+  ///         You can call the `SyntaxWriter.rewrite(_:detach:)`
   ///         method recursively when returning a non-nil result
   ///         if you want to visit the node's children anyway.
   open func visitAny(_ node: Syntax) -> Syntax? {

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -69,10 +69,14 @@ open class SyntaxRewriter {
   /// Override point to choose custom visitation dispatch instead of the
   /// specialized `visit(_:)` methods. Use this instead of those methods if
   /// you intend to dynamically dispatch rewriting behavior.
-  /// - note: If this method returns a non-nil result, the specialized
-  ///         `visit(_:)` methods will not be called for this node and the
+  /// - note: If this method returns a non-nil result, the consequent
+  ///         `visitAny(_:)` methods and the specialized `visit(_:)`
+  ///         methods will not be called for this node and the
   ///         visited node will be replaced by the returned node in the
   ///         rewritten tree.
+  ///         You can call the ``SyntaxWriter.rewrite(_:detach:)``
+  ///         method recursively when returning a non-nil result
+  ///         if you want to visit the node's children anyway.
   open func visitAny(_ node: Syntax) -> Syntax? {
     return nil
   }

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -74,7 +74,7 @@ open class SyntaxRewriter {
   ///         methods will not be called for this node and the
   ///         visited node will be replaced by the returned node in the
   ///         rewritten tree.
-  ///         You can call the `SyntaxWriter.rewrite(_:detach:)`
+  ///         You can call the ``SyntaxRewriter/rewrite(_:detach:)``
   ///         method recursively when returning a non-nil result
   ///         if you want to visit the node's children anyway.
   open func visitAny(_ node: Syntax) -> Syntax? {

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -69,7 +69,7 @@ open class SyntaxRewriter {
   /// Override point to choose custom visitation dispatch instead of the
   /// specialized `visit(_:)` methods. Use this instead of those methods if
   /// you intend to dynamically dispatch rewriting behavior.
-  /// - note: If this method returns a non-nil result, the consequent
+  /// - note: If this method returns a non-nil result, the subsequent
   ///         `visitAny(_:)` methods and the specialized `visit(_:)`
   ///         methods will not be called for this node and the
   ///         visited node will be replaced by the returned node in the


### PR DESCRIPTION
`SyntaxWriter.visitAny(_:)` does not clearly mention that it always and completely skips running on the children nodes if you return a non-nil result.