### PR TITLE
Fix issue that caused `AccessorDeclSyntax` initializer with header + body to be misparsed

### DIFF
--- a/Tests/SwiftSyntaxBuilderTest/AccessorDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/AccessorDeclTests.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import XCTest
+
+final class AccessorDeclTests: XCTestCase {
+  func testCreateAccessorWithHeaderAndBody() throws {
+    let accessor = try AccessorDeclSyntax("get") {
+      ExprSyntax("1")
+    }
+    XCTAssertEqual(accessor.body?.statements.count, 1)
+  }
+}


### PR DESCRIPTION
`get {}` was parsed by `Parser.parseDeclaration()` but it doesn't parse accessors.

`AccessorDeclSyntax` needs a special implementation of `init(header:bodyBuilder:)`.

rdar://131720084