### PR TITLE
[6.0] Performance improvements for SyntaxRewriter

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -183,7 +183,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Create a \(raw: node.kind.doccLink) node from a specialized syntax node.
-        public init(_ syntax: some \(node.kind.protocolType)) {
+        public init(_ syntax: __shared some \(node.kind.protocolType)) {
           // We know this cast is going to succeed. Go through init(_: SyntaxData)
           // to do a sanity check and verify the kind matches in debug builds and get
           // maximum performance in release builds.
@@ -195,7 +195,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Create a \(raw: node.kind.doccLink) node from a specialized optional syntax node.
-        public init?(_ syntax: (some \(node.kind.protocolType))?) {
+        public init?(_ syntax: __shared (some \(node.kind.protocolType))?) {
           guard let syntax = syntax else { return nil }
           self.init(syntax)
         }
@@ -204,7 +204,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       DeclSyntax(
         """
-        public init(fromProtocol syntax: \(node.kind.protocolType)) {
+        public init(fromProtocol syntax: __shared \(node.kind.protocolType)) {
           // We know this cast is going to succeed. Go through init(_: SyntaxData)
           // to do a sanity check and verify the kind matches in debug builds and get
           // maximum performance in release builds.
@@ -216,14 +216,14 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Create a \(raw: node.kind.doccLink) node from a specialized optional syntax node.
-        public init?(fromProtocol syntax: \(node.kind.protocolType)?) {
+        public init?(fromProtocol syntax: __shared \(node.kind.protocolType)?) {
           guard let syntax = syntax else { return nil }
           self.init(fromProtocol: syntax)
         }
         """
       )
 
-      try InitializerDeclSyntax("public init?(_ node: some SyntaxProtocol)") {
+      try InitializerDeclSyntax("public init?(_ node: __shared some SyntaxProtocol)") {
         try SwitchExprSyntax("switch node.raw.kind") {
           SwitchCaseListSyntax {
             SwitchCaseSyntax(

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -199,17 +199,14 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
           }
         }
 
-        try! VariableDeclSyntax("public static var structure: SyntaxNodeStructure") {
-          let layout = ArrayExprSyntax {
-            for child in node.children {
-              ArrayElementSyntax(
-                expression: ExprSyntax(#"\Self.\#(child.varOrCaseName)"#)
-              )
-            }
+        let layout = ArrayExprSyntax {
+          for child in node.children {
+            ArrayElementSyntax(
+              expression: ExprSyntax(#"\Self.\#(child.varOrCaseName)"#)
+            )
           }
-
-          StmtSyntax("return .layout(\(layout))")
         }
+        "public static let structure: SyntaxNodeStructure = .layout(\(layout))"
       }
     }
   }

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -47,7 +47,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
 
         DeclSyntax(
           """
-          public init?(_ node: some SyntaxProtocol) {
+          public init?(_ node: __shared some SyntaxProtocol) {
             guard node.raw.kind == .\(node.varOrCaseName) else { return nil }
             self._syntaxNode = node._syntaxNode
           }
@@ -256,7 +256,7 @@ private func generateSyntaxChildChoices(for child: Child) throws -> EnumDeclSynt
       }
     }
 
-    try! InitializerDeclSyntax("public init?(_ node: some SyntaxProtocol)") {
+    try! InitializerDeclSyntax("public init?(_ node: __shared some SyntaxProtocol)") {
       for choice in choices {
         StmtSyntax(
           """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -34,19 +34,8 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      /// `Syntax.Info` salvaged from the node being deinitialized in 'visitChildren'.
-      ///
-      /// Instead of deallocating them and allocating memory for new syntax nodes, store the allocated memory in an array.
-      /// We can then re-use them to create new syntax nodes.
-      ///
-      /// The array's size should be a typical nesting depth of a Swift file. That way we can store all allocated syntax
-      /// nodes when unwinding the visitation stack.
-      ///
-      /// The actual `info` stored in the `Syntax.Info` objects is garbage. It needs to be set when any of the `Syntax.Info`
-      /// objects get re-used.
-      ///
-      /// Note: making the element non-nil causes 'swift::runtime::SwiftTLSContext::get()' traffic somehow.
-      private var recyclableNodeInfos: ContiguousArray<Syntax.Info?>
+      /// 'Syntax' object factory recycling 'Syntax.Info' instances.
+      private let nodeFactory: SyntaxNodeFactory = SyntaxNodeFactory()
       """
     )
 
@@ -54,8 +43,6 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       public init(viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         self.viewMode = viewMode
-        self.recyclableNodeInfos = []
-        self.recyclableNodeInfos.reserveCapacity(64)
       }
       """
     )
@@ -330,15 +317,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           }
 
           // Build the Syntax node to rewrite
-          var childNode: Syntax
-          if !recyclableNodeInfos.isEmpty {
-            let recycledInfo: Syntax.Info = recyclableNodeInfos.removeLast()!
-            recycledInfo.info = .nonRoot(.init(parent: Syntax(node), absoluteInfo: info))
-            childNode = Syntax(child, info: recycledInfo)
-          } else {
-            let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
-            childNode = Syntax(absoluteRaw, parent: syntaxNode)
-          }
+          var childNode = nodeFactory.create(parent: syntaxNode, raw: child, absoluteInfo: info)
 
           dispatchVisit(&childNode)
           if childNode.raw.id != child.id {
@@ -369,14 +348,8 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
 
-          if recyclableNodeInfos.capacity > recyclableNodeInfos.count,
-             isKnownUniquelyReferenced(&childNode.info) {
-            var info: Syntax.Info! = nil
-            // 'swap' to avoid ref-counting traffic.
-            swap(&childNode.info, &info)
-            info.info = nil
-            recyclableNodeInfos.append(info)
-          }
+          // Recycle 'childNode.info'
+          nodeFactory.dispose(&childNode)
         }
 
         if let newLayout {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -297,15 +297,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         // with 'Syntax'
         var rewrittens: ContiguousArray<RetainedSyntaxArena> = []
 
-        // Incrementing i manually is faster than using .enumerated()
-        var childIndex = 0
-        for (raw, info) in RawSyntaxChildren(node) {
-          defer { childIndex += 1 }
-
-          guard let child = raw, viewMode.shouldTraverse(node: child) else {
-            // Node does not exist or should not be visited.
-            continue
-          }
+        for case let (child?, info) in RawSyntaxChildren(node) where viewMode.shouldTraverse(node: child) {
 
           // Build the Syntax node to rewrite
           var childNode = nodeFactory.create(parent: node, raw: child, absoluteInfo: info)
@@ -322,7 +314,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
 
             // Update the rewritten child.
-            newLayout[childIndex] = childNode.raw
+            newLayout[Int(info.indexInParent)] = childNode.raw
             // Retain the syntax arena of the new node until it's wrapped with Syntax node.
             rewrittens.append(childNode.raw.arenaReference.retained)
           }

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -293,7 +293,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
         // newLayout is nil until the first child node is rewritten and rewritten
         // nodes are being collected.
-        var newLayout: ContiguousArray<RawSyntax?>?
+        var newLayout: UnsafeMutableBufferPointer<RawSyntax?> = .init(start: nil, count: 0)
 
         // Keep 'SyntaxArena' of rewritten nodes alive until they are wrapped
         // with 'Syntax'
@@ -307,12 +307,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           defer { childIndex += 1 }
 
           guard let child = raw, viewMode.shouldTraverse(node: child) else {
-            // Node does not exist or should not be visited. If we are collecting
-            // rewritten nodes, we need to collect this one as well, otherwise we
-            // can ignore it.
-            if newLayout != nil {
-              newLayout!.append(raw)
-            }
+            // Node does not exist or should not be visited.
             continue
           }
 
@@ -322,44 +317,31 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           dispatchVisit(&childNode)
           if childNode.raw.id != child.id {
             // The node was rewritten, let's handle it
-            if newLayout == nil {
+
+            if newLayout.baseAddress == nil {
               // We have not yet collected any previous rewritten nodes. Initialize
-              // the new layout with the previous nodes of the parent. This is
-              // possible, since we know they were not rewritten.
-
-              // The below implementation is based on Collection.map but directly
-              // reserves enough capacity for the entire layout.
-              newLayout = ContiguousArray<RawSyntax?>()
-              newLayout!.reserveCapacity(node.raw.layoutView!.children.count)
-              for j in 0..<childIndex {
-                newLayout!.append(node.raw.layoutView!.children[j])
-              }
+              // the new layout with the previous nodes of the parent.
+              newLayout = .allocate(capacity: node.raw.layoutView!.children.count)
+              _ = newLayout.initialize(fromContentsOf: node.raw.layoutView!.children)
             }
 
-            // Now that we know we have a new layout in which we collect rewritten
-            // nodes, add it.
+            // Update the rewritten child.
+            newLayout[childIndex] = childNode.raw
+            // Retain the syntax arena of the new node until it's wrapped with Syntax node.
             rewrittens.append(childNode.raw.arenaReference.retained)
-            newLayout!.append(childNode.raw)
-          } else {
-            // The node was not changed by the rewriter. Only store it if a previous
-            // node has been rewritten and we are collecting a rewritten layout.
-            if newLayout != nil {
-              newLayout!.append(raw)
-            }
           }
 
           // Recycle 'childNode.info'
           nodeFactory.dispose(&childNode)
         }
 
-        if let newLayout {
+        if newLayout.baseAddress != nil {
           // A child node was rewritten. Build the updated node.
 
-          // Sanity check, ensure the new children are the same length.
-          precondition(newLayout.count == node.raw.layoutView!.children.count)
-
           let arena = SyntaxArena()
-          let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)
+          let newRaw = node.raw.layoutView!.replacingLayout(with: newLayout, arena: arena)
+          newLayout.deinitialize()
+          newLayout.deallocate()
           // 'withExtendedLifetime' to keep 'SyntaxArena's of them alive until here.
           return withExtendedLifetime(rewrittens) {
             Syntax(raw: newRaw, rawNodeArena: arena).cast(SyntaxType.self)

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -139,7 +139,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           ///   - Returns: the rewritten node
           \(node.apiAttributes())\
           open func visit(_ node: \(node.kind.syntaxType)) -> \(node.kind.syntaxType) {
-            return visitChildren(node._syntaxNode)?.cast(\(node.kind.syntaxType).self) ?? node
+            return visitChildren(node._syntaxNode).cast(\(node.kind.syntaxType).self)
           }
           """
         )
@@ -151,7 +151,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           ///   - Returns: the rewritten node
           \(node.apiAttributes())\
           open func visit(_ node: \(node.kind.syntaxType)) -> \(node.baseType.syntaxBaseName) {
-            return \(node.baseType.syntaxBaseName)(visitChildren(node._syntaxNode)?.cast(\(node.kind.syntaxType).self) ?? node)
+            return \(node.baseType.syntaxBaseName)(visitChildren(node._syntaxNode).cast(\(node.kind.syntaxType).self))
           }
           """
         )
@@ -281,7 +281,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      private func visitChildren(_ node: Syntax) -> Syntax? {
+      private func visitChildren(_ node: Syntax) -> Syntax {
         // Walk over all children of this node and rewrite them. Don't store any
         // rewritten nodes until the first non-`nil` value is encountered. When this
         // happens, retrieve all previous syntax nodes from the parent node to
@@ -336,7 +336,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           }
         } else {
           // No child node was rewritten. So no need to change this node as well.
-          return nil
+          return node
         }
       }
       """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -34,8 +34,28 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
+      /// `Syntax.Info` salvaged from the node being deinitialized in 'visitChildren'.
+      ///
+      /// Instead of deallocating them and allocating memory for new syntax nodes, store the allocated memory in an array.
+      /// We can then re-use them to create new syntax nodes.
+      ///
+      /// The array's size should be a typical nesting depth of a Swift file. That way we can store all allocated syntax
+      /// nodes when unwinding the visitation stack.
+      ///
+      /// The actual `info` stored in the `Syntax.Info` objects is garbage. It needs to be set when any of the `Syntax.Info`
+      /// objects get re-used.
+      ///
+      /// Note: making the element non-nil causes 'swift::runtime::SwiftTLSContext::get()' traffic somehow.
+      private var recyclableNodeInfos: ContiguousArray<Syntax.Info?>
+      """
+    )
+
+    DeclSyntax(
+      """
       public init(viewMode: SyntaxTreeViewMode = .sourceAccurate) {
         self.viewMode = viewMode
+        self.recyclableNodeInfos = []
+        self.recyclableNodeInfos.reserveCapacity(64)
       }
       """
     )
@@ -44,7 +64,8 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       /// Rewrite `node`, keeping its parent unless `detach` is `true`.
       public func rewrite(_ node: some SyntaxProtocol, detach: Bool = false) -> Syntax {
-        let rewritten = self.dispatchVisit(Syntax(node))
+        var rewritten = Syntax(node)
+        self.dispatchVisit(&rewritten)
         if detach {
           return rewritten
         }
@@ -105,7 +126,9 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       ///   - Returns: the rewritten node
       @available(*, deprecated, renamed: "rewrite(_:detach:)")
       public func visit(_ node: Syntax) -> Syntax {
-        return dispatchVisit(node)
+        var rewritten = node
+        dispatchVisit(&rewritten)
+        return rewritten
       }
       """
     )
@@ -113,7 +136,9 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     DeclSyntax(
       """
       public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
-        return dispatchVisit(Syntax(node)).cast(T.self)
+        var rewritten = Syntax(node)
+        dispatchVisit(&rewritten)
+        return rewritten.cast(T.self)
       }
       """
     )
@@ -156,7 +181,9 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         ///   - Returns: the rewritten node
         \(baseNode.apiAttributes())\
         public func visit(_ node: \(baseKind.syntaxType)) -> \(baseKind.syntaxType) {
-          return dispatchVisit(Syntax(node)).cast(\(baseKind.syntaxType).self)
+          var node: Syntax = Syntax(node)
+          dispatchVisit(&node)
+          return node.cast(\(baseKind.syntaxType).self)
         }
         """
       )
@@ -166,21 +193,16 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       /// Interpret `node` as a node of type `nodeType`, visit it, calling
       /// the `visit` to transform the node.
+      @inline(__always)
       private func visitImpl<NodeType: SyntaxProtocol>(
-        _ node: Syntax,
+        _ node: inout Syntax,
         _ nodeType: NodeType.Type,
         _ visit: (NodeType) -> some SyntaxProtocol
-      ) -> Syntax {
-        let castedNode = node.cast(NodeType.self)
-        // Accessing _syntaxNode directly is faster than calling Syntax(node)
-        visitPre(node)
-        defer {
-          visitPost(node)
-        }
-        if let newNode = visitAny(node) {
-          return newNode
-        }
-        return Syntax(visit(castedNode))
+      ) {
+        let origNode = node
+        visitPre(origNode)
+        node = visitAny(origNode) ?? Syntax(visit(origNode.cast(NodeType.self)))
+        visitPost(origNode)
       }
       """
     )
@@ -221,17 +243,17 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                 /// that determines the correct visitation function will be popped of the
                 /// stack before the function is being called, making the switch's stack
                 /// space transient instead of having it linger in the call stack.
-                private func visitationFunc(for node: Syntax) -> ((Syntax) -> Syntax)
+                private func visitationFunc(for node: Syntax) -> ((inout Syntax) -> Void)
                 """
               ) {
                 try SwitchExprSyntax("switch node.raw.kind") {
                   SwitchCaseSyntax("case .token:") {
-                    StmtSyntax("return { self.visitImpl($0, TokenSyntax.self, self.visit) }")
+                    StmtSyntax("return { self.visitImpl(&$0, TokenSyntax.self, self.visit) }")
                   }
 
                   for node in NON_BASE_SYNTAX_NODES {
                     SwitchCaseSyntax("case .\(node.varOrCaseName):") {
-                      StmtSyntax("return { self.visitImpl($0, \(node.kind.syntaxType).self, self.visit) }")
+                      StmtSyntax("return { self.visitImpl(&$0, \(node.kind.syntaxType).self, self.visit) }")
                     }
                   }
                 }
@@ -239,8 +261,8 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
               DeclSyntax(
                 """
-                private func dispatchVisit(_ node: Syntax) -> Syntax {
-                  return visitationFunc(for: node)(node)
+                private func dispatchVisit(_ node: inout Syntax) {
+                  visitationFunc(for: node)(&node)
                 }
                 """
               )
@@ -251,15 +273,15 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           poundKeyword: .poundElseToken(),
           elements: .statements(
             CodeBlockItemListSyntax {
-              try! FunctionDeclSyntax("private func dispatchVisit(_ node: Syntax) -> Syntax") {
+              try! FunctionDeclSyntax("private func dispatchVisit(_ node: inout Syntax)") {
                 try SwitchExprSyntax("switch node.raw.kind") {
                   SwitchCaseSyntax("case .token:") {
-                    StmtSyntax("return visitImpl(node, TokenSyntax.self, visit)")
+                    StmtSyntax("return visitImpl(&node, TokenSyntax.self, visit)")
                   }
 
                   for node in NON_BASE_SYNTAX_NODES {
                     SwitchCaseSyntax("case .\(node.varOrCaseName):") {
-                      StmtSyntax("return visitImpl(node, \(node.kind.syntaxType).self, visit)")
+                      StmtSyntax("return visitImpl(&node, \(node.kind.syntaxType).self, visit)")
                     }
                   }
                 }
@@ -286,9 +308,9 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         // nodes are being collected.
         var newLayout: ContiguousArray<RawSyntax?>?
 
-        // Rewritten children just to keep their 'SyntaxArena' alive until they are
-        // wrapped with 'Syntax'
-        var rewrittens: ContiguousArray<Syntax> = []
+        // Keep 'SyntaxArena' of rewritten nodes alive until they are wrapped
+        // with 'Syntax'
+        var rewrittens: ContiguousArray<RetainedSyntaxArena> = []
 
         let syntaxNode = node._syntaxNode
 
@@ -308,10 +330,18 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           }
 
           // Build the Syntax node to rewrite
-          let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
+          var childNode: Syntax
+          if !recyclableNodeInfos.isEmpty {
+            let recycledInfo: Syntax.Info = recyclableNodeInfos.removeLast()!
+            recycledInfo.info = .nonRoot(.init(parent: Syntax(node), absoluteInfo: info))
+            childNode = Syntax(child, info: recycledInfo)
+          } else {
+            let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
+            childNode = Syntax(absoluteRaw, parent: syntaxNode)
+          }
 
-          let rewritten = dispatchVisit(Syntax(absoluteRaw, parent: syntaxNode))
-          if rewritten.id != info.nodeId {
+          dispatchVisit(&childNode)
+          if childNode.raw.id != child.id {
             // The node was rewritten, let's handle it
             if newLayout == nil {
               // We have not yet collected any previous rewritten nodes. Initialize
@@ -329,14 +359,23 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
             // Now that we know we have a new layout in which we collect rewritten
             // nodes, add it.
-            rewrittens.append(rewritten)
-            newLayout!.append(rewritten.raw)
+            rewrittens.append(childNode.raw.arenaReference.retained)
+            newLayout!.append(childNode.raw)
           } else {
             // The node was not changed by the rewriter. Only store it if a previous
             // node has been rewritten and we are collecting a rewritten layout.
             if newLayout != nil {
               newLayout!.append(raw)
             }
+          }
+
+          if recyclableNodeInfos.capacity > recyclableNodeInfos.count,
+             isKnownUniquelyReferenced(&childNode.info) {
+            var info: Syntax.Info! = nil
+            // 'swap' to avoid ref-counting traffic.
+            swap(&childNode.info, &info)
+            info.info = nil
+            recyclableNodeInfos.append(info)
           }
         }
 

--- a/Sources/SwiftOperators/OperatorTable+Defaults.swift
+++ b/Sources/SwiftOperators/OperatorTable+Defaults.swift
@@ -64,7 +64,7 @@ extension OperatorTable {
   /// without requiring access to the standard library source code. However,
   /// because it does not incorporate user-defined operators, it will only
   /// ever be useful for a quick approximation.
-  public static var standardOperators: OperatorTable {
+  public static let standardOperators: OperatorTable = {
     let precedenceGroups: [PrecedenceGroup] = [
       PrecedenceGroup(
         name: "AssignmentPrecedence",
@@ -437,5 +437,5 @@ extension OperatorTable {
       precedenceGroups: precedenceGroups,
       operators: operators
     )
-  }
+  }()
 }

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -30,6 +30,7 @@ add_swift_syntax_library(SwiftSyntax
   SyntaxCollection.swift
   SyntaxHashable.swift
   SyntaxIdentifier.swift
+  SyntaxNodeFactory.swift
   SyntaxNodeStructure.swift
   SyntaxProtocol.swift
   SyntaxText.swift

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -310,17 +310,17 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
   // Inline always so the optimizer can optimize this to a member access on `syntax` without having to go through
   // generics.
   @inline(__always)
-  public init(_ syntax: some SyntaxProtocol) {
+  public init(_ syntax: __shared some SyntaxProtocol) {
     self = syntax._syntaxNode
   }
 
   /// Creates a new ``Syntax`` node from any node that conforms to ``SyntaxProtocol``.
-  public init(fromProtocol syntax: SyntaxProtocol) {
+  public init(fromProtocol syntax: __shared SyntaxProtocol) {
     self = syntax._syntaxNode
   }
 
   /// Same as ``init(fromProtocol:)`` but returns `nil` if `syntax` is `nil`.
-  public init?(fromProtocol syntax: SyntaxProtocol?) {
+  public init?(fromProtocol syntax: __shared SyntaxProtocol?) {
     guard let syntax = syntax else { return nil }
     self = syntax._syntaxNode
   }

--- a/Sources/SwiftSyntax/SyntaxArenaAllocatedBuffer.swift
+++ b/Sources/SwiftSyntax/SyntaxArenaAllocatedBuffer.swift
@@ -107,4 +107,8 @@ public struct SyntaxArenaAllocatedBufferPointer<Element: Sendable>: RandomAccess
   var unsafeRawBufferPointer: UnsafeRawBufferPointer {
     return UnsafeRawBufferPointer(buffer)
   }
+
+  public func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<Element>) throws -> R) rethrows -> R? {
+    try body(buffer)
+  }
 }

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -274,7 +274,7 @@ struct RawSyntaxChildren: BidirectionalCollection, Sendable {
     }
   }
 
-  init(_ base: Syntax) {
+  init(_ base: __shared Syntax) {
     self.init(base.absoluteRaw)
   }
 }

--- a/Sources/SwiftSyntax/SyntaxNodeFactory.swift
+++ b/Sources/SwiftSyntax/SyntaxNodeFactory.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Reusable 'Syntax.Info' storage.
+private struct SyntaxInfoRepository {
+  private final class _Buffer: ManagedBuffer<Int, Syntax.Info?> {
+    deinit {
+      self.withUnsafeMutablePointers { headerPtr, elementPtr in
+        _ = elementPtr.deinitialize(count: headerPtr.pointee)
+      }
+    }
+  }
+
+  /// Fixed capacity which is enough for most use cases.
+  static var capacity: Int { 64 }
+
+  private let buffer: _Buffer
+
+  init() {
+    let buffer = _Buffer.create(minimumCapacity: Self.capacity, makingHeaderWith: { _ in 0 })
+    self.buffer = buffer as! _Buffer
+  }
+
+  /// Take the 'Syntax.Info' object from the address.
+  func push(_ info: UnsafeMutablePointer<Syntax.Info?>) {
+    buffer.withUnsafeMutablePointers { headerPtr, elementPtr in
+      guard headerPtr.pointee < Self.capacity else {
+        return
+      }
+      assert(info.pointee != nil, "tried to push 'nil' info")
+      elementPtr.advanced(by: headerPtr.pointee).moveInitialize(from: info, count: 1)
+      info.initialize(to: nil)
+      headerPtr.pointee += 1
+    }
+  }
+
+  /// Vend a 'Swift.Info' object if available.
+  func pop() -> Syntax.Info? {
+    return buffer.withUnsafeMutablePointers { headerPtr, elementPtr in
+      guard headerPtr.pointee > 0 else {
+        return nil
+      }
+      headerPtr.pointee -= 1
+      return elementPtr.advanced(by: headerPtr.pointee).move()
+    }
+  }
+}
+
+/// 'Syntax' object factory. This may hold some stocks of recycled 'Syntax.Info'.
+struct SyntaxNodeFactory {
+  private let syntaxInfoRepo: SyntaxInfoRepository = SyntaxInfoRepository()
+
+  /// Create a 'Syntax' instance using the supplied info.
+  ///
+  /// If this factory has a recycled 'Syntax.Info', use one of them. Otherwise, just create a instance by allocating a new one.
+  @inline(__always)
+  func create(parent: Syntax, raw: RawSyntax, absoluteInfo: AbsoluteSyntaxInfo) -> Syntax {
+    if let info = syntaxInfoRepo.pop() {
+      info.info = .nonRoot(.init(parent: parent, absoluteInfo: absoluteInfo))
+      return Syntax(raw, info: info)
+    } else {
+      return Syntax(raw, parent: parent, absoluteInfo: absoluteInfo)
+    }
+  }
+
+  /// Dispose a 'Syntax' object.
+  ///
+  /// 'node.info' is collected for future reuse. 'node' is not usable after calling this.
+  @inline(__always)
+  func dispose(_ node: inout Syntax) {
+    if isKnownUniquelyReferenced(&node.info) {
+      node.info.unsafelyUnwrapped.info = nil
+      syntaxInfoRepo.push(&node.info)
+    }
+  }
+}

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -24,7 +24,7 @@ public protocol SyntaxProtocol: CustomStringConvertible,
 
   /// Converts the given specialized node to this type. Returns `nil` if the
   /// conversion is not possible.
-  init?(_ node: some SyntaxProtocol)
+  init?(_ node: __shared some SyntaxProtocol)
 
   /// The statically allowed structure of the syntax node.
   static var structure: SyntaxNodeStructure { get }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -183,7 +183,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a ``DeclSyntax`` node from a specialized syntax node.
-  public init(_ syntax: some DeclSyntaxProtocol) {
+  public init(_ syntax: __shared some DeclSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -191,14 +191,14 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``DeclSyntax`` node from a specialized optional syntax node.
-  public init?(_ syntax: (some DeclSyntaxProtocol)?) {
+  public init?(_ syntax: __shared (some DeclSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(syntax)
   }
   
-  public init(fromProtocol syntax: DeclSyntaxProtocol) {
+  public init(fromProtocol syntax: __shared DeclSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -206,14 +206,14 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``DeclSyntax`` node from a specialized optional syntax node.
-  public init?(fromProtocol syntax: DeclSyntaxProtocol?) {
+  public init?(fromProtocol syntax: __shared DeclSyntaxProtocol?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(fromProtocol: syntax)
   }
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     switch node.raw.kind {
     case .accessorDecl, .actorDecl, .associatedTypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typeAliasDecl, .variableDecl:
       self._syntaxNode = node._syntaxNode
@@ -510,7 +510,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a ``ExprSyntax`` node from a specialized syntax node.
-  public init(_ syntax: some ExprSyntaxProtocol) {
+  public init(_ syntax: __shared some ExprSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -518,14 +518,14 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``ExprSyntax`` node from a specialized optional syntax node.
-  public init?(_ syntax: (some ExprSyntaxProtocol)?) {
+  public init?(_ syntax: __shared (some ExprSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(syntax)
   }
   
-  public init(fromProtocol syntax: ExprSyntaxProtocol) {
+  public init(fromProtocol syntax: __shared ExprSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -533,14 +533,14 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``ExprSyntax`` node from a specialized optional syntax node.
-  public init?(fromProtocol syntax: ExprSyntaxProtocol?) {
+  public init?(fromProtocol syntax: __shared ExprSyntaxProtocol?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(fromProtocol: syntax)
   }
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     switch node.raw.kind {
     case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, ._canImportExpr, ._canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .declReferenceExpr, .dictionaryExpr, .discardAssignmentExpr, .doExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .simpleStringLiteralExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
       self._syntaxNode = node._syntaxNode
@@ -823,7 +823,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a ``PatternSyntax`` node from a specialized syntax node.
-  public init(_ syntax: some PatternSyntaxProtocol) {
+  public init(_ syntax: __shared some PatternSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -831,14 +831,14 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``PatternSyntax`` node from a specialized optional syntax node.
-  public init?(_ syntax: (some PatternSyntaxProtocol)?) {
+  public init?(_ syntax: __shared (some PatternSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(syntax)
   }
   
-  public init(fromProtocol syntax: PatternSyntaxProtocol) {
+  public init(fromProtocol syntax: __shared PatternSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -846,14 +846,14 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``PatternSyntax`` node from a specialized optional syntax node.
-  public init?(fromProtocol syntax: PatternSyntaxProtocol?) {
+  public init?(fromProtocol syntax: __shared PatternSyntaxProtocol?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(fromProtocol: syntax)
   }
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     switch node.raw.kind {
     case .expressionPattern, .identifierPattern, .isTypePattern, .missingPattern, .tuplePattern, .valueBindingPattern, .wildcardPattern:
       self._syntaxNode = node._syntaxNode
@@ -1099,7 +1099,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a ``StmtSyntax`` node from a specialized syntax node.
-  public init(_ syntax: some StmtSyntaxProtocol) {
+  public init(_ syntax: __shared some StmtSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -1107,14 +1107,14 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``StmtSyntax`` node from a specialized optional syntax node.
-  public init?(_ syntax: (some StmtSyntaxProtocol)?) {
+  public init?(_ syntax: __shared (some StmtSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(syntax)
   }
   
-  public init(fromProtocol syntax: StmtSyntaxProtocol) {
+  public init(fromProtocol syntax: __shared StmtSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -1122,14 +1122,14 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``StmtSyntax`` node from a specialized optional syntax node.
-  public init?(fromProtocol syntax: StmtSyntaxProtocol?) {
+  public init?(fromProtocol syntax: __shared StmtSyntaxProtocol?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(fromProtocol: syntax)
   }
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     switch node.raw.kind {
     case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .thenStmt, .throwStmt, .whileStmt, .yieldStmt:
       self._syntaxNode = node._syntaxNode
@@ -1387,7 +1387,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a ``TypeSyntax`` node from a specialized syntax node.
-  public init(_ syntax: some TypeSyntaxProtocol) {
+  public init(_ syntax: __shared some TypeSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -1395,14 +1395,14 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``TypeSyntax`` node from a specialized optional syntax node.
-  public init?(_ syntax: (some TypeSyntaxProtocol)?) {
+  public init?(_ syntax: __shared (some TypeSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(syntax)
   }
   
-  public init(fromProtocol syntax: TypeSyntaxProtocol) {
+  public init(fromProtocol syntax: __shared TypeSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -1410,14 +1410,14 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a ``TypeSyntax`` node from a specialized optional syntax node.
-  public init?(fromProtocol syntax: TypeSyntaxProtocol?) {
+  public init?(fromProtocol syntax: __shared TypeSyntaxProtocol?) {
     guard let syntax = syntax else {
       return nil
     }
     self.init(fromProtocol: syntax)
   }
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     switch node.raw.kind {
     case .arrayType, .attributedType, .classRestrictionType, .compositionType, .dictionaryType, .functionType, .identifierType, .implicitlyUnwrappedOptionalType, .memberType, .metatypeType, .missingType, .namedOpaqueReturnType, .optionalType, .packElementType, .packExpansionType, .someOrAnyType, .suppressedType, .tupleType:
       self._syntaxNode = node._syntaxNode

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -3901,17 +3901,7 @@ open class SyntaxRewriter {
     // with 'Syntax'
     var rewrittens: ContiguousArray<RetainedSyntaxArena> = []
 
-    // Incrementing i manually is faster than using .enumerated()
-    var childIndex = 0
-    for (raw, info) in RawSyntaxChildren(node) {
-      defer {
-        childIndex += 1
-      }
-
-      guard let child = raw, viewMode.shouldTraverse(node: child) else {
-        // Node does not exist or should not be visited.
-        continue
-      }
+    for case let (child?, info) in RawSyntaxChildren(node) where viewMode.shouldTraverse(node: child) {
 
       // Build the Syntax node to rewrite
       var childNode = nodeFactory.create(parent: node, raw: child, absoluteInfo: info)
@@ -3928,7 +3918,7 @@ open class SyntaxRewriter {
         }
 
         // Update the rewritten child.
-        newLayout[childIndex] = childNode.raw
+        newLayout[Int(info.indexInParent)] = childNode.raw
         // Retain the syntax arena of the new node until it's wrapped with Syntax node.
         rewrittens.append(childNode.raw.arenaReference.retained)
       }

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -23,14 +23,31 @@
 
 open class SyntaxRewriter {
   public let viewMode: SyntaxTreeViewMode
+
+  /// `Syntax.Info` salvaged from the node being deinitialized in 'visitChildren'.
+  ///
+  /// Instead of deallocating them and allocating memory for new syntax nodes, store the allocated memory in an array.
+  /// We can then re-use them to create new syntax nodes.
+  ///
+  /// The array's size should be a typical nesting depth of a Swift file. That way we can store all allocated syntax
+  /// nodes when unwinding the visitation stack.
+  ///
+  /// The actual `info` stored in the `Syntax.Info` objects is garbage. It needs to be set when any of the `Syntax.Info`
+  /// objects get re-used.
+  ///
+  /// Note: making the element non-nil causes 'swift::runtime::SwiftTLSContext::get()' traffic somehow.
+  private var recyclableNodeInfos: ContiguousArray<Syntax.Info?>
   
   public init(viewMode: SyntaxTreeViewMode = .sourceAccurate) {
     self.viewMode = viewMode
+    self.recyclableNodeInfos = []
+    self.recyclableNodeInfos.reserveCapacity(64)
   }
   
   /// Rewrite `node`, keeping its parent unless `detach` is `true`.
   public func rewrite(_ node: some SyntaxProtocol, detach: Bool = false) -> Syntax {
-    let rewritten = self.dispatchVisit(Syntax(node))
+    var rewritten = Syntax(node)
+    self.dispatchVisit(&rewritten)
     if detach {
       return rewritten
     }
@@ -73,11 +90,15 @@ open class SyntaxRewriter {
   ///   - Returns: the rewritten node
   @available(*, deprecated, renamed: "rewrite(_:detach:)")
   public func visit(_ node: Syntax) -> Syntax {
-    return dispatchVisit(node)
+    var rewritten = node
+    dispatchVisit(&rewritten)
+    return rewritten
   }
   
   public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
-    return dispatchVisit(Syntax(node)).cast(T.self)
+    var rewritten = Syntax(node)
+    dispatchVisit(&rewritten)
+    return rewritten.cast(T.self)
   }
   
   /// Visit a ``AccessorBlockSyntax``.
@@ -2080,54 +2101,59 @@ open class SyntaxRewriter {
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: DeclSyntax) -> DeclSyntax {
-    return dispatchVisit(Syntax(node)).cast(DeclSyntax.self)
+    var node: Syntax = Syntax(node)
+    dispatchVisit(&node)
+    return node.cast(DeclSyntax.self)
   }
   
   /// Visit any ExprSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: ExprSyntax) -> ExprSyntax {
-    return dispatchVisit(Syntax(node)).cast(ExprSyntax.self)
+    var node: Syntax = Syntax(node)
+    dispatchVisit(&node)
+    return node.cast(ExprSyntax.self)
   }
   
   /// Visit any PatternSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: PatternSyntax) -> PatternSyntax {
-    return dispatchVisit(Syntax(node)).cast(PatternSyntax.self)
+    var node: Syntax = Syntax(node)
+    dispatchVisit(&node)
+    return node.cast(PatternSyntax.self)
   }
   
   /// Visit any StmtSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: StmtSyntax) -> StmtSyntax {
-    return dispatchVisit(Syntax(node)).cast(StmtSyntax.self)
+    var node: Syntax = Syntax(node)
+    dispatchVisit(&node)
+    return node.cast(StmtSyntax.self)
   }
   
   /// Visit any TypeSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: TypeSyntax) -> TypeSyntax {
-    return dispatchVisit(Syntax(node)).cast(TypeSyntax.self)
+    var node: Syntax = Syntax(node)
+    dispatchVisit(&node)
+    return node.cast(TypeSyntax.self)
   }
   
   /// Interpret `node` as a node of type `nodeType`, visit it, calling
   /// the `visit` to transform the node.
+  @inline(__always)
   private func visitImpl<NodeType: SyntaxProtocol>(
-    _ node: Syntax,
+    _ node: inout Syntax,
     _ nodeType: NodeType.Type,
     _ visit: (NodeType) -> some SyntaxProtocol
-  ) -> Syntax {
-    let castedNode = node.cast(NodeType.self)
-    // Accessing _syntaxNode directly is faster than calling Syntax(node)
-    visitPre(node)
-    defer {
-      visitPost(node)
-    }
-    if let newNode = visitAny(node) {
-      return newNode
-    }
-    return Syntax(visit(castedNode))
+  ) {
+    let origNode = node
+    visitPre(origNode)
+    node = visitAny(origNode) ?? Syntax(visit(origNode.cast(NodeType.self)))
+    visitPost(origNode)
   }
   
   // SwiftSyntax requires a lot of stack space in debug builds for syntax tree
@@ -2154,1720 +2180,1720 @@ open class SyntaxRewriter {
   /// that determines the correct visitation function will be popped of the
   /// stack before the function is being called, making the switch's stack
   /// space transient instead of having it linger in the call stack.
-  private func visitationFunc(for node: Syntax) -> ((Syntax) -> Syntax) {
+  private func visitationFunc(for node: Syntax) -> ((inout Syntax) -> Void) {
     switch node.raw.kind {
     case .token:
       return {
-        self.visitImpl($0, TokenSyntax.self, self.visit)
+        self.visitImpl(&$0, TokenSyntax.self, self.visit)
       }
     case .accessorBlock:
       return {
-        self.visitImpl($0, AccessorBlockSyntax.self, self.visit)
+        self.visitImpl(&$0, AccessorBlockSyntax.self, self.visit)
       }
     case .accessorDeclList:
       return {
-        self.visitImpl($0, AccessorDeclListSyntax.self, self.visit)
+        self.visitImpl(&$0, AccessorDeclListSyntax.self, self.visit)
       }
     case .accessorDecl:
       return {
-        self.visitImpl($0, AccessorDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, AccessorDeclSyntax.self, self.visit)
       }
     case .accessorEffectSpecifiers:
       return {
-        self.visitImpl($0, AccessorEffectSpecifiersSyntax.self, self.visit)
+        self.visitImpl(&$0, AccessorEffectSpecifiersSyntax.self, self.visit)
       }
     case .accessorParameters:
       return {
-        self.visitImpl($0, AccessorParametersSyntax.self, self.visit)
+        self.visitImpl(&$0, AccessorParametersSyntax.self, self.visit)
       }
     case .actorDecl:
       return {
-        self.visitImpl($0, ActorDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, ActorDeclSyntax.self, self.visit)
       }
     case .arrayElementList:
       return {
-        self.visitImpl($0, ArrayElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, ArrayElementListSyntax.self, self.visit)
       }
     case .arrayElement:
       return {
-        self.visitImpl($0, ArrayElementSyntax.self, self.visit)
+        self.visitImpl(&$0, ArrayElementSyntax.self, self.visit)
       }
     case .arrayExpr:
       return {
-        self.visitImpl($0, ArrayExprSyntax.self, self.visit)
+        self.visitImpl(&$0, ArrayExprSyntax.self, self.visit)
       }
     case .arrayType:
       return {
-        self.visitImpl($0, ArrayTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, ArrayTypeSyntax.self, self.visit)
       }
     case .arrowExpr:
       return {
-        self.visitImpl($0, ArrowExprSyntax.self, self.visit)
+        self.visitImpl(&$0, ArrowExprSyntax.self, self.visit)
       }
     case .asExpr:
       return {
-        self.visitImpl($0, AsExprSyntax.self, self.visit)
+        self.visitImpl(&$0, AsExprSyntax.self, self.visit)
       }
     case .assignmentExpr:
       return {
-        self.visitImpl($0, AssignmentExprSyntax.self, self.visit)
+        self.visitImpl(&$0, AssignmentExprSyntax.self, self.visit)
       }
     case .associatedTypeDecl:
       return {
-        self.visitImpl($0, AssociatedTypeDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, AssociatedTypeDeclSyntax.self, self.visit)
       }
     case .attributeList:
       return {
-        self.visitImpl($0, AttributeListSyntax.self, self.visit)
+        self.visitImpl(&$0, AttributeListSyntax.self, self.visit)
       }
     case .attribute:
       return {
-        self.visitImpl($0, AttributeSyntax.self, self.visit)
+        self.visitImpl(&$0, AttributeSyntax.self, self.visit)
       }
     case .attributedType:
       return {
-        self.visitImpl($0, AttributedTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, AttributedTypeSyntax.self, self.visit)
       }
     case .availabilityArgumentList:
       return {
-        self.visitImpl($0, AvailabilityArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, AvailabilityArgumentListSyntax.self, self.visit)
       }
     case .availabilityArgument:
       return {
-        self.visitImpl($0, AvailabilityArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, AvailabilityArgumentSyntax.self, self.visit)
       }
     case .availabilityCondition:
       return {
-        self.visitImpl($0, AvailabilityConditionSyntax.self, self.visit)
+        self.visitImpl(&$0, AvailabilityConditionSyntax.self, self.visit)
       }
     case .availabilityLabeledArgument:
       return {
-        self.visitImpl($0, AvailabilityLabeledArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, AvailabilityLabeledArgumentSyntax.self, self.visit)
       }
     case .awaitExpr:
       return {
-        self.visitImpl($0, AwaitExprSyntax.self, self.visit)
+        self.visitImpl(&$0, AwaitExprSyntax.self, self.visit)
       }
     case .backDeployedAttributeArguments:
       return {
-        self.visitImpl($0, BackDeployedAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, BackDeployedAttributeArgumentsSyntax.self, self.visit)
       }
     case .binaryOperatorExpr:
       return {
-        self.visitImpl($0, BinaryOperatorExprSyntax.self, self.visit)
+        self.visitImpl(&$0, BinaryOperatorExprSyntax.self, self.visit)
       }
     case .booleanLiteralExpr:
       return {
-        self.visitImpl($0, BooleanLiteralExprSyntax.self, self.visit)
+        self.visitImpl(&$0, BooleanLiteralExprSyntax.self, self.visit)
       }
     case .borrowExpr:
       return {
-        self.visitImpl($0, BorrowExprSyntax.self, self.visit)
+        self.visitImpl(&$0, BorrowExprSyntax.self, self.visit)
       }
     case .breakStmt:
       return {
-        self.visitImpl($0, BreakStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, BreakStmtSyntax.self, self.visit)
       }
     case ._canImportExpr:
       return {
-        self.visitImpl($0, _CanImportExprSyntax.self, self.visit)
+        self.visitImpl(&$0, _CanImportExprSyntax.self, self.visit)
       }
     case ._canImportVersionInfo:
       return {
-        self.visitImpl($0, _CanImportVersionInfoSyntax.self, self.visit)
+        self.visitImpl(&$0, _CanImportVersionInfoSyntax.self, self.visit)
       }
     case .catchClauseList:
       return {
-        self.visitImpl($0, CatchClauseListSyntax.self, self.visit)
+        self.visitImpl(&$0, CatchClauseListSyntax.self, self.visit)
       }
     case .catchClause:
       return {
-        self.visitImpl($0, CatchClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, CatchClauseSyntax.self, self.visit)
       }
     case .catchItemList:
       return {
-        self.visitImpl($0, CatchItemListSyntax.self, self.visit)
+        self.visitImpl(&$0, CatchItemListSyntax.self, self.visit)
       }
     case .catchItem:
       return {
-        self.visitImpl($0, CatchItemSyntax.self, self.visit)
+        self.visitImpl(&$0, CatchItemSyntax.self, self.visit)
       }
     case .classDecl:
       return {
-        self.visitImpl($0, ClassDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, ClassDeclSyntax.self, self.visit)
       }
     case .classRestrictionType:
       return {
-        self.visitImpl($0, ClassRestrictionTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, ClassRestrictionTypeSyntax.self, self.visit)
       }
     case .closureCaptureClause:
       return {
-        self.visitImpl($0, ClosureCaptureClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureCaptureClauseSyntax.self, self.visit)
       }
     case .closureCaptureList:
       return {
-        self.visitImpl($0, ClosureCaptureListSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureCaptureListSyntax.self, self.visit)
       }
     case .closureCaptureSpecifier:
       return {
-        self.visitImpl($0, ClosureCaptureSpecifierSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureCaptureSpecifierSyntax.self, self.visit)
       }
     case .closureCapture:
       return {
-        self.visitImpl($0, ClosureCaptureSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureCaptureSyntax.self, self.visit)
       }
     case .closureExpr:
       return {
-        self.visitImpl($0, ClosureExprSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureExprSyntax.self, self.visit)
       }
     case .closureParameterClause:
       return {
-        self.visitImpl($0, ClosureParameterClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureParameterClauseSyntax.self, self.visit)
       }
     case .closureParameterList:
       return {
-        self.visitImpl($0, ClosureParameterListSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureParameterListSyntax.self, self.visit)
       }
     case .closureParameter:
       return {
-        self.visitImpl($0, ClosureParameterSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureParameterSyntax.self, self.visit)
       }
     case .closureShorthandParameterList:
       return {
-        self.visitImpl($0, ClosureShorthandParameterListSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureShorthandParameterListSyntax.self, self.visit)
       }
     case .closureShorthandParameter:
       return {
-        self.visitImpl($0, ClosureShorthandParameterSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureShorthandParameterSyntax.self, self.visit)
       }
     case .closureSignature:
       return {
-        self.visitImpl($0, ClosureSignatureSyntax.self, self.visit)
+        self.visitImpl(&$0, ClosureSignatureSyntax.self, self.visit)
       }
     case .codeBlockItemList:
       return {
-        self.visitImpl($0, CodeBlockItemListSyntax.self, self.visit)
+        self.visitImpl(&$0, CodeBlockItemListSyntax.self, self.visit)
       }
     case .codeBlockItem:
       return {
-        self.visitImpl($0, CodeBlockItemSyntax.self, self.visit)
+        self.visitImpl(&$0, CodeBlockItemSyntax.self, self.visit)
       }
     case .codeBlock:
       return {
-        self.visitImpl($0, CodeBlockSyntax.self, self.visit)
+        self.visitImpl(&$0, CodeBlockSyntax.self, self.visit)
       }
     case .compositionTypeElementList:
       return {
-        self.visitImpl($0, CompositionTypeElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, CompositionTypeElementListSyntax.self, self.visit)
       }
     case .compositionTypeElement:
       return {
-        self.visitImpl($0, CompositionTypeElementSyntax.self, self.visit)
+        self.visitImpl(&$0, CompositionTypeElementSyntax.self, self.visit)
       }
     case .compositionType:
       return {
-        self.visitImpl($0, CompositionTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, CompositionTypeSyntax.self, self.visit)
       }
     case .conditionElementList:
       return {
-        self.visitImpl($0, ConditionElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, ConditionElementListSyntax.self, self.visit)
       }
     case .conditionElement:
       return {
-        self.visitImpl($0, ConditionElementSyntax.self, self.visit)
+        self.visitImpl(&$0, ConditionElementSyntax.self, self.visit)
       }
     case .conformanceRequirement:
       return {
-        self.visitImpl($0, ConformanceRequirementSyntax.self, self.visit)
+        self.visitImpl(&$0, ConformanceRequirementSyntax.self, self.visit)
       }
     case .consumeExpr:
       return {
-        self.visitImpl($0, ConsumeExprSyntax.self, self.visit)
+        self.visitImpl(&$0, ConsumeExprSyntax.self, self.visit)
       }
     case .continueStmt:
       return {
-        self.visitImpl($0, ContinueStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, ContinueStmtSyntax.self, self.visit)
       }
     case .conventionAttributeArguments:
       return {
-        self.visitImpl($0, ConventionAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, ConventionAttributeArgumentsSyntax.self, self.visit)
       }
     case .conventionWitnessMethodAttributeArguments:
       return {
-        self.visitImpl($0, ConventionWitnessMethodAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, ConventionWitnessMethodAttributeArgumentsSyntax.self, self.visit)
       }
     case .copyExpr:
       return {
-        self.visitImpl($0, CopyExprSyntax.self, self.visit)
+        self.visitImpl(&$0, CopyExprSyntax.self, self.visit)
       }
     case .declModifierDetail:
       return {
-        self.visitImpl($0, DeclModifierDetailSyntax.self, self.visit)
+        self.visitImpl(&$0, DeclModifierDetailSyntax.self, self.visit)
       }
     case .declModifierList:
       return {
-        self.visitImpl($0, DeclModifierListSyntax.self, self.visit)
+        self.visitImpl(&$0, DeclModifierListSyntax.self, self.visit)
       }
     case .declModifier:
       return {
-        self.visitImpl($0, DeclModifierSyntax.self, self.visit)
+        self.visitImpl(&$0, DeclModifierSyntax.self, self.visit)
       }
     case .declNameArgumentList:
       return {
-        self.visitImpl($0, DeclNameArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, DeclNameArgumentListSyntax.self, self.visit)
       }
     case .declNameArgument:
       return {
-        self.visitImpl($0, DeclNameArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, DeclNameArgumentSyntax.self, self.visit)
       }
     case .declNameArguments:
       return {
-        self.visitImpl($0, DeclNameArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, DeclNameArgumentsSyntax.self, self.visit)
       }
     case .declReferenceExpr:
       return {
-        self.visitImpl($0, DeclReferenceExprSyntax.self, self.visit)
+        self.visitImpl(&$0, DeclReferenceExprSyntax.self, self.visit)
       }
     case .deferStmt:
       return {
-        self.visitImpl($0, DeferStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, DeferStmtSyntax.self, self.visit)
       }
     case .deinitializerDecl:
       return {
-        self.visitImpl($0, DeinitializerDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, DeinitializerDeclSyntax.self, self.visit)
       }
     case .deinitializerEffectSpecifiers:
       return {
-        self.visitImpl($0, DeinitializerEffectSpecifiersSyntax.self, self.visit)
+        self.visitImpl(&$0, DeinitializerEffectSpecifiersSyntax.self, self.visit)
       }
     case .derivativeAttributeArguments:
       return {
-        self.visitImpl($0, DerivativeAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, DerivativeAttributeArgumentsSyntax.self, self.visit)
       }
     case .designatedTypeList:
       return {
-        self.visitImpl($0, DesignatedTypeListSyntax.self, self.visit)
+        self.visitImpl(&$0, DesignatedTypeListSyntax.self, self.visit)
       }
     case .designatedType:
       return {
-        self.visitImpl($0, DesignatedTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, DesignatedTypeSyntax.self, self.visit)
       }
     case .dictionaryElementList:
       return {
-        self.visitImpl($0, DictionaryElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, DictionaryElementListSyntax.self, self.visit)
       }
     case .dictionaryElement:
       return {
-        self.visitImpl($0, DictionaryElementSyntax.self, self.visit)
+        self.visitImpl(&$0, DictionaryElementSyntax.self, self.visit)
       }
     case .dictionaryExpr:
       return {
-        self.visitImpl($0, DictionaryExprSyntax.self, self.visit)
+        self.visitImpl(&$0, DictionaryExprSyntax.self, self.visit)
       }
     case .dictionaryType:
       return {
-        self.visitImpl($0, DictionaryTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, DictionaryTypeSyntax.self, self.visit)
       }
     case .differentiabilityArgumentList:
       return {
-        self.visitImpl($0, DifferentiabilityArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, DifferentiabilityArgumentListSyntax.self, self.visit)
       }
     case .differentiabilityArgument:
       return {
-        self.visitImpl($0, DifferentiabilityArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, DifferentiabilityArgumentSyntax.self, self.visit)
       }
     case .differentiabilityArguments:
       return {
-        self.visitImpl($0, DifferentiabilityArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, DifferentiabilityArgumentsSyntax.self, self.visit)
       }
     case .differentiabilityWithRespectToArgument:
       return {
-        self.visitImpl($0, DifferentiabilityWithRespectToArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, DifferentiabilityWithRespectToArgumentSyntax.self, self.visit)
       }
     case .differentiableAttributeArguments:
       return {
-        self.visitImpl($0, DifferentiableAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, DifferentiableAttributeArgumentsSyntax.self, self.visit)
       }
     case .discardAssignmentExpr:
       return {
-        self.visitImpl($0, DiscardAssignmentExprSyntax.self, self.visit)
+        self.visitImpl(&$0, DiscardAssignmentExprSyntax.self, self.visit)
       }
     case .discardStmt:
       return {
-        self.visitImpl($0, DiscardStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, DiscardStmtSyntax.self, self.visit)
       }
     case .doExpr:
       return {
-        self.visitImpl($0, DoExprSyntax.self, self.visit)
+        self.visitImpl(&$0, DoExprSyntax.self, self.visit)
       }
     case .doStmt:
       return {
-        self.visitImpl($0, DoStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, DoStmtSyntax.self, self.visit)
       }
     case .documentationAttributeArgumentList:
       return {
-        self.visitImpl($0, DocumentationAttributeArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, DocumentationAttributeArgumentListSyntax.self, self.visit)
       }
     case .documentationAttributeArgument:
       return {
-        self.visitImpl($0, DocumentationAttributeArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, DocumentationAttributeArgumentSyntax.self, self.visit)
       }
     case .dynamicReplacementAttributeArguments:
       return {
-        self.visitImpl($0, DynamicReplacementAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, DynamicReplacementAttributeArgumentsSyntax.self, self.visit)
       }
     case .editorPlaceholderDecl:
       return {
-        self.visitImpl($0, EditorPlaceholderDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, EditorPlaceholderDeclSyntax.self, self.visit)
       }
     case .editorPlaceholderExpr:
       return {
-        self.visitImpl($0, EditorPlaceholderExprSyntax.self, self.visit)
+        self.visitImpl(&$0, EditorPlaceholderExprSyntax.self, self.visit)
       }
     case .effectsAttributeArgumentList:
       return {
-        self.visitImpl($0, EffectsAttributeArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, EffectsAttributeArgumentListSyntax.self, self.visit)
       }
     case .enumCaseDecl:
       return {
-        self.visitImpl($0, EnumCaseDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, EnumCaseDeclSyntax.self, self.visit)
       }
     case .enumCaseElementList:
       return {
-        self.visitImpl($0, EnumCaseElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, EnumCaseElementListSyntax.self, self.visit)
       }
     case .enumCaseElement:
       return {
-        self.visitImpl($0, EnumCaseElementSyntax.self, self.visit)
+        self.visitImpl(&$0, EnumCaseElementSyntax.self, self.visit)
       }
     case .enumCaseParameterClause:
       return {
-        self.visitImpl($0, EnumCaseParameterClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, EnumCaseParameterClauseSyntax.self, self.visit)
       }
     case .enumCaseParameterList:
       return {
-        self.visitImpl($0, EnumCaseParameterListSyntax.self, self.visit)
+        self.visitImpl(&$0, EnumCaseParameterListSyntax.self, self.visit)
       }
     case .enumCaseParameter:
       return {
-        self.visitImpl($0, EnumCaseParameterSyntax.self, self.visit)
+        self.visitImpl(&$0, EnumCaseParameterSyntax.self, self.visit)
       }
     case .enumDecl:
       return {
-        self.visitImpl($0, EnumDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, EnumDeclSyntax.self, self.visit)
       }
     case .exposeAttributeArguments:
       return {
-        self.visitImpl($0, ExposeAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, ExposeAttributeArgumentsSyntax.self, self.visit)
       }
     case .exprList:
       return {
-        self.visitImpl($0, ExprListSyntax.self, self.visit)
+        self.visitImpl(&$0, ExprListSyntax.self, self.visit)
       }
     case .expressionPattern:
       return {
-        self.visitImpl($0, ExpressionPatternSyntax.self, self.visit)
+        self.visitImpl(&$0, ExpressionPatternSyntax.self, self.visit)
       }
     case .expressionSegment:
       return {
-        self.visitImpl($0, ExpressionSegmentSyntax.self, self.visit)
+        self.visitImpl(&$0, ExpressionSegmentSyntax.self, self.visit)
       }
     case .expressionStmt:
       return {
-        self.visitImpl($0, ExpressionStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, ExpressionStmtSyntax.self, self.visit)
       }
     case .extensionDecl:
       return {
-        self.visitImpl($0, ExtensionDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, ExtensionDeclSyntax.self, self.visit)
       }
     case .fallThroughStmt:
       return {
-        self.visitImpl($0, FallThroughStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, FallThroughStmtSyntax.self, self.visit)
       }
     case .floatLiteralExpr:
       return {
-        self.visitImpl($0, FloatLiteralExprSyntax.self, self.visit)
+        self.visitImpl(&$0, FloatLiteralExprSyntax.self, self.visit)
       }
     case .forStmt:
       return {
-        self.visitImpl($0, ForStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, ForStmtSyntax.self, self.visit)
       }
     case .forceUnwrapExpr:
       return {
-        self.visitImpl($0, ForceUnwrapExprSyntax.self, self.visit)
+        self.visitImpl(&$0, ForceUnwrapExprSyntax.self, self.visit)
       }
     case .functionCallExpr:
       return {
-        self.visitImpl($0, FunctionCallExprSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionCallExprSyntax.self, self.visit)
       }
     case .functionDecl:
       return {
-        self.visitImpl($0, FunctionDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionDeclSyntax.self, self.visit)
       }
     case .functionEffectSpecifiers:
       return {
-        self.visitImpl($0, FunctionEffectSpecifiersSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionEffectSpecifiersSyntax.self, self.visit)
       }
     case .functionParameterClause:
       return {
-        self.visitImpl($0, FunctionParameterClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionParameterClauseSyntax.self, self.visit)
       }
     case .functionParameterList:
       return {
-        self.visitImpl($0, FunctionParameterListSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionParameterListSyntax.self, self.visit)
       }
     case .functionParameter:
       return {
-        self.visitImpl($0, FunctionParameterSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionParameterSyntax.self, self.visit)
       }
     case .functionSignature:
       return {
-        self.visitImpl($0, FunctionSignatureSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionSignatureSyntax.self, self.visit)
       }
     case .functionType:
       return {
-        self.visitImpl($0, FunctionTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, FunctionTypeSyntax.self, self.visit)
       }
     case .genericArgumentClause:
       return {
-        self.visitImpl($0, GenericArgumentClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericArgumentClauseSyntax.self, self.visit)
       }
     case .genericArgumentList:
       return {
-        self.visitImpl($0, GenericArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericArgumentListSyntax.self, self.visit)
       }
     case .genericArgument:
       return {
-        self.visitImpl($0, GenericArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericArgumentSyntax.self, self.visit)
       }
     case .genericParameterClause:
       return {
-        self.visitImpl($0, GenericParameterClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericParameterClauseSyntax.self, self.visit)
       }
     case .genericParameterList:
       return {
-        self.visitImpl($0, GenericParameterListSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericParameterListSyntax.self, self.visit)
       }
     case .genericParameter:
       return {
-        self.visitImpl($0, GenericParameterSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericParameterSyntax.self, self.visit)
       }
     case .genericRequirementList:
       return {
-        self.visitImpl($0, GenericRequirementListSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericRequirementListSyntax.self, self.visit)
       }
     case .genericRequirement:
       return {
-        self.visitImpl($0, GenericRequirementSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericRequirementSyntax.self, self.visit)
       }
     case .genericSpecializationExpr:
       return {
-        self.visitImpl($0, GenericSpecializationExprSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericSpecializationExprSyntax.self, self.visit)
       }
     case .genericWhereClause:
       return {
-        self.visitImpl($0, GenericWhereClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, GenericWhereClauseSyntax.self, self.visit)
       }
     case .guardStmt:
       return {
-        self.visitImpl($0, GuardStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, GuardStmtSyntax.self, self.visit)
       }
     case .identifierPattern:
       return {
-        self.visitImpl($0, IdentifierPatternSyntax.self, self.visit)
+        self.visitImpl(&$0, IdentifierPatternSyntax.self, self.visit)
       }
     case .identifierType:
       return {
-        self.visitImpl($0, IdentifierTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, IdentifierTypeSyntax.self, self.visit)
       }
     case .ifConfigClauseList:
       return {
-        self.visitImpl($0, IfConfigClauseListSyntax.self, self.visit)
+        self.visitImpl(&$0, IfConfigClauseListSyntax.self, self.visit)
       }
     case .ifConfigClause:
       return {
-        self.visitImpl($0, IfConfigClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, IfConfigClauseSyntax.self, self.visit)
       }
     case .ifConfigDecl:
       return {
-        self.visitImpl($0, IfConfigDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, IfConfigDeclSyntax.self, self.visit)
       }
     case .ifExpr:
       return {
-        self.visitImpl($0, IfExprSyntax.self, self.visit)
+        self.visitImpl(&$0, IfExprSyntax.self, self.visit)
       }
     case .implementsAttributeArguments:
       return {
-        self.visitImpl($0, ImplementsAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, ImplementsAttributeArgumentsSyntax.self, self.visit)
       }
     case .implicitlyUnwrappedOptionalType:
       return {
-        self.visitImpl($0, ImplicitlyUnwrappedOptionalTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, ImplicitlyUnwrappedOptionalTypeSyntax.self, self.visit)
       }
     case .importDecl:
       return {
-        self.visitImpl($0, ImportDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, ImportDeclSyntax.self, self.visit)
       }
     case .importPathComponentList:
       return {
-        self.visitImpl($0, ImportPathComponentListSyntax.self, self.visit)
+        self.visitImpl(&$0, ImportPathComponentListSyntax.self, self.visit)
       }
     case .importPathComponent:
       return {
-        self.visitImpl($0, ImportPathComponentSyntax.self, self.visit)
+        self.visitImpl(&$0, ImportPathComponentSyntax.self, self.visit)
       }
     case .inOutExpr:
       return {
-        self.visitImpl($0, InOutExprSyntax.self, self.visit)
+        self.visitImpl(&$0, InOutExprSyntax.self, self.visit)
       }
     case .infixOperatorExpr:
       return {
-        self.visitImpl($0, InfixOperatorExprSyntax.self, self.visit)
+        self.visitImpl(&$0, InfixOperatorExprSyntax.self, self.visit)
       }
     case .inheritanceClause:
       return {
-        self.visitImpl($0, InheritanceClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, InheritanceClauseSyntax.self, self.visit)
       }
     case .inheritedTypeList:
       return {
-        self.visitImpl($0, InheritedTypeListSyntax.self, self.visit)
+        self.visitImpl(&$0, InheritedTypeListSyntax.self, self.visit)
       }
     case .inheritedType:
       return {
-        self.visitImpl($0, InheritedTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, InheritedTypeSyntax.self, self.visit)
       }
     case .initializerClause:
       return {
-        self.visitImpl($0, InitializerClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, InitializerClauseSyntax.self, self.visit)
       }
     case .initializerDecl:
       return {
-        self.visitImpl($0, InitializerDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, InitializerDeclSyntax.self, self.visit)
       }
     case .integerLiteralExpr:
       return {
-        self.visitImpl($0, IntegerLiteralExprSyntax.self, self.visit)
+        self.visitImpl(&$0, IntegerLiteralExprSyntax.self, self.visit)
       }
     case .isExpr:
       return {
-        self.visitImpl($0, IsExprSyntax.self, self.visit)
+        self.visitImpl(&$0, IsExprSyntax.self, self.visit)
       }
     case .isTypePattern:
       return {
-        self.visitImpl($0, IsTypePatternSyntax.self, self.visit)
+        self.visitImpl(&$0, IsTypePatternSyntax.self, self.visit)
       }
     case .keyPathComponentList:
       return {
-        self.visitImpl($0, KeyPathComponentListSyntax.self, self.visit)
+        self.visitImpl(&$0, KeyPathComponentListSyntax.self, self.visit)
       }
     case .keyPathComponent:
       return {
-        self.visitImpl($0, KeyPathComponentSyntax.self, self.visit)
+        self.visitImpl(&$0, KeyPathComponentSyntax.self, self.visit)
       }
     case .keyPathExpr:
       return {
-        self.visitImpl($0, KeyPathExprSyntax.self, self.visit)
+        self.visitImpl(&$0, KeyPathExprSyntax.self, self.visit)
       }
     case .keyPathOptionalComponent:
       return {
-        self.visitImpl($0, KeyPathOptionalComponentSyntax.self, self.visit)
+        self.visitImpl(&$0, KeyPathOptionalComponentSyntax.self, self.visit)
       }
     case .keyPathPropertyComponent:
       return {
-        self.visitImpl($0, KeyPathPropertyComponentSyntax.self, self.visit)
+        self.visitImpl(&$0, KeyPathPropertyComponentSyntax.self, self.visit)
       }
     case .keyPathSubscriptComponent:
       return {
-        self.visitImpl($0, KeyPathSubscriptComponentSyntax.self, self.visit)
+        self.visitImpl(&$0, KeyPathSubscriptComponentSyntax.self, self.visit)
       }
     case .labeledExprList:
       return {
-        self.visitImpl($0, LabeledExprListSyntax.self, self.visit)
+        self.visitImpl(&$0, LabeledExprListSyntax.self, self.visit)
       }
     case .labeledExpr:
       return {
-        self.visitImpl($0, LabeledExprSyntax.self, self.visit)
+        self.visitImpl(&$0, LabeledExprSyntax.self, self.visit)
       }
     case .labeledSpecializeArgument:
       return {
-        self.visitImpl($0, LabeledSpecializeArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, LabeledSpecializeArgumentSyntax.self, self.visit)
       }
     case .labeledStmt:
       return {
-        self.visitImpl($0, LabeledStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, LabeledStmtSyntax.self, self.visit)
       }
     case .layoutRequirement:
       return {
-        self.visitImpl($0, LayoutRequirementSyntax.self, self.visit)
+        self.visitImpl(&$0, LayoutRequirementSyntax.self, self.visit)
       }
     case .lifetimeSpecifierArgumentList:
       return {
-        self.visitImpl($0, LifetimeSpecifierArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, LifetimeSpecifierArgumentListSyntax.self, self.visit)
       }
     case .lifetimeSpecifierArgument:
       return {
-        self.visitImpl($0, LifetimeSpecifierArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, LifetimeSpecifierArgumentSyntax.self, self.visit)
       }
     case .lifetimeTypeSpecifier:
       return {
-        self.visitImpl($0, LifetimeTypeSpecifierSyntax.self, self.visit)
+        self.visitImpl(&$0, LifetimeTypeSpecifierSyntax.self, self.visit)
       }
     case .macroDecl:
       return {
-        self.visitImpl($0, MacroDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, MacroDeclSyntax.self, self.visit)
       }
     case .macroExpansionDecl:
       return {
-        self.visitImpl($0, MacroExpansionDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, MacroExpansionDeclSyntax.self, self.visit)
       }
     case .macroExpansionExpr:
       return {
-        self.visitImpl($0, MacroExpansionExprSyntax.self, self.visit)
+        self.visitImpl(&$0, MacroExpansionExprSyntax.self, self.visit)
       }
     case .matchingPatternCondition:
       return {
-        self.visitImpl($0, MatchingPatternConditionSyntax.self, self.visit)
+        self.visitImpl(&$0, MatchingPatternConditionSyntax.self, self.visit)
       }
     case .memberAccessExpr:
       return {
-        self.visitImpl($0, MemberAccessExprSyntax.self, self.visit)
+        self.visitImpl(&$0, MemberAccessExprSyntax.self, self.visit)
       }
     case .memberBlockItemList:
       return {
-        self.visitImpl($0, MemberBlockItemListSyntax.self, self.visit)
+        self.visitImpl(&$0, MemberBlockItemListSyntax.self, self.visit)
       }
     case .memberBlockItem:
       return {
-        self.visitImpl($0, MemberBlockItemSyntax.self, self.visit)
+        self.visitImpl(&$0, MemberBlockItemSyntax.self, self.visit)
       }
     case .memberBlock:
       return {
-        self.visitImpl($0, MemberBlockSyntax.self, self.visit)
+        self.visitImpl(&$0, MemberBlockSyntax.self, self.visit)
       }
     case .memberType:
       return {
-        self.visitImpl($0, MemberTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, MemberTypeSyntax.self, self.visit)
       }
     case .metatypeType:
       return {
-        self.visitImpl($0, MetatypeTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, MetatypeTypeSyntax.self, self.visit)
       }
     case .missingDecl:
       return {
-        self.visitImpl($0, MissingDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, MissingDeclSyntax.self, self.visit)
       }
     case .missingExpr:
       return {
-        self.visitImpl($0, MissingExprSyntax.self, self.visit)
+        self.visitImpl(&$0, MissingExprSyntax.self, self.visit)
       }
     case .missingPattern:
       return {
-        self.visitImpl($0, MissingPatternSyntax.self, self.visit)
+        self.visitImpl(&$0, MissingPatternSyntax.self, self.visit)
       }
     case .missingStmt:
       return {
-        self.visitImpl($0, MissingStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, MissingStmtSyntax.self, self.visit)
       }
     case .missing:
       return {
-        self.visitImpl($0, MissingSyntax.self, self.visit)
+        self.visitImpl(&$0, MissingSyntax.self, self.visit)
       }
     case .missingType:
       return {
-        self.visitImpl($0, MissingTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, MissingTypeSyntax.self, self.visit)
       }
     case .multipleTrailingClosureElementList:
       return {
-        self.visitImpl($0, MultipleTrailingClosureElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, MultipleTrailingClosureElementListSyntax.self, self.visit)
       }
     case .multipleTrailingClosureElement:
       return {
-        self.visitImpl($0, MultipleTrailingClosureElementSyntax.self, self.visit)
+        self.visitImpl(&$0, MultipleTrailingClosureElementSyntax.self, self.visit)
       }
     case .namedOpaqueReturnType:
       return {
-        self.visitImpl($0, NamedOpaqueReturnTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, NamedOpaqueReturnTypeSyntax.self, self.visit)
       }
     case .nilLiteralExpr:
       return {
-        self.visitImpl($0, NilLiteralExprSyntax.self, self.visit)
+        self.visitImpl(&$0, NilLiteralExprSyntax.self, self.visit)
       }
     case .objCSelectorPieceList:
       return {
-        self.visitImpl($0, ObjCSelectorPieceListSyntax.self, self.visit)
+        self.visitImpl(&$0, ObjCSelectorPieceListSyntax.self, self.visit)
       }
     case .objCSelectorPiece:
       return {
-        self.visitImpl($0, ObjCSelectorPieceSyntax.self, self.visit)
+        self.visitImpl(&$0, ObjCSelectorPieceSyntax.self, self.visit)
       }
     case .opaqueReturnTypeOfAttributeArguments:
       return {
-        self.visitImpl($0, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, self.visit)
       }
     case .operatorDecl:
       return {
-        self.visitImpl($0, OperatorDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, OperatorDeclSyntax.self, self.visit)
       }
     case .operatorPrecedenceAndTypes:
       return {
-        self.visitImpl($0, OperatorPrecedenceAndTypesSyntax.self, self.visit)
+        self.visitImpl(&$0, OperatorPrecedenceAndTypesSyntax.self, self.visit)
       }
     case .optionalBindingCondition:
       return {
-        self.visitImpl($0, OptionalBindingConditionSyntax.self, self.visit)
+        self.visitImpl(&$0, OptionalBindingConditionSyntax.self, self.visit)
       }
     case .optionalChainingExpr:
       return {
-        self.visitImpl($0, OptionalChainingExprSyntax.self, self.visit)
+        self.visitImpl(&$0, OptionalChainingExprSyntax.self, self.visit)
       }
     case .optionalType:
       return {
-        self.visitImpl($0, OptionalTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, OptionalTypeSyntax.self, self.visit)
       }
     case .originallyDefinedInAttributeArguments:
       return {
-        self.visitImpl($0, OriginallyDefinedInAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, OriginallyDefinedInAttributeArgumentsSyntax.self, self.visit)
       }
     case .packElementExpr:
       return {
-        self.visitImpl($0, PackElementExprSyntax.self, self.visit)
+        self.visitImpl(&$0, PackElementExprSyntax.self, self.visit)
       }
     case .packElementType:
       return {
-        self.visitImpl($0, PackElementTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, PackElementTypeSyntax.self, self.visit)
       }
     case .packExpansionExpr:
       return {
-        self.visitImpl($0, PackExpansionExprSyntax.self, self.visit)
+        self.visitImpl(&$0, PackExpansionExprSyntax.self, self.visit)
       }
     case .packExpansionType:
       return {
-        self.visitImpl($0, PackExpansionTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, PackExpansionTypeSyntax.self, self.visit)
       }
     case .patternBindingList:
       return {
-        self.visitImpl($0, PatternBindingListSyntax.self, self.visit)
+        self.visitImpl(&$0, PatternBindingListSyntax.self, self.visit)
       }
     case .patternBinding:
       return {
-        self.visitImpl($0, PatternBindingSyntax.self, self.visit)
+        self.visitImpl(&$0, PatternBindingSyntax.self, self.visit)
       }
     case .patternExpr:
       return {
-        self.visitImpl($0, PatternExprSyntax.self, self.visit)
+        self.visitImpl(&$0, PatternExprSyntax.self, self.visit)
       }
     case .platformVersionItemList:
       return {
-        self.visitImpl($0, PlatformVersionItemListSyntax.self, self.visit)
+        self.visitImpl(&$0, PlatformVersionItemListSyntax.self, self.visit)
       }
     case .platformVersionItem:
       return {
-        self.visitImpl($0, PlatformVersionItemSyntax.self, self.visit)
+        self.visitImpl(&$0, PlatformVersionItemSyntax.self, self.visit)
       }
     case .platformVersion:
       return {
-        self.visitImpl($0, PlatformVersionSyntax.self, self.visit)
+        self.visitImpl(&$0, PlatformVersionSyntax.self, self.visit)
       }
     case .postfixIfConfigExpr:
       return {
-        self.visitImpl($0, PostfixIfConfigExprSyntax.self, self.visit)
+        self.visitImpl(&$0, PostfixIfConfigExprSyntax.self, self.visit)
       }
     case .postfixOperatorExpr:
       return {
-        self.visitImpl($0, PostfixOperatorExprSyntax.self, self.visit)
+        self.visitImpl(&$0, PostfixOperatorExprSyntax.self, self.visit)
       }
     case .poundSourceLocationArguments:
       return {
-        self.visitImpl($0, PoundSourceLocationArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, PoundSourceLocationArgumentsSyntax.self, self.visit)
       }
     case .poundSourceLocation:
       return {
-        self.visitImpl($0, PoundSourceLocationSyntax.self, self.visit)
+        self.visitImpl(&$0, PoundSourceLocationSyntax.self, self.visit)
       }
     case .precedenceGroupAssignment:
       return {
-        self.visitImpl($0, PrecedenceGroupAssignmentSyntax.self, self.visit)
+        self.visitImpl(&$0, PrecedenceGroupAssignmentSyntax.self, self.visit)
       }
     case .precedenceGroupAssociativity:
       return {
-        self.visitImpl($0, PrecedenceGroupAssociativitySyntax.self, self.visit)
+        self.visitImpl(&$0, PrecedenceGroupAssociativitySyntax.self, self.visit)
       }
     case .precedenceGroupAttributeList:
       return {
-        self.visitImpl($0, PrecedenceGroupAttributeListSyntax.self, self.visit)
+        self.visitImpl(&$0, PrecedenceGroupAttributeListSyntax.self, self.visit)
       }
     case .precedenceGroupDecl:
       return {
-        self.visitImpl($0, PrecedenceGroupDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, PrecedenceGroupDeclSyntax.self, self.visit)
       }
     case .precedenceGroupNameList:
       return {
-        self.visitImpl($0, PrecedenceGroupNameListSyntax.self, self.visit)
+        self.visitImpl(&$0, PrecedenceGroupNameListSyntax.self, self.visit)
       }
     case .precedenceGroupName:
       return {
-        self.visitImpl($0, PrecedenceGroupNameSyntax.self, self.visit)
+        self.visitImpl(&$0, PrecedenceGroupNameSyntax.self, self.visit)
       }
     case .precedenceGroupRelation:
       return {
-        self.visitImpl($0, PrecedenceGroupRelationSyntax.self, self.visit)
+        self.visitImpl(&$0, PrecedenceGroupRelationSyntax.self, self.visit)
       }
     case .prefixOperatorExpr:
       return {
-        self.visitImpl($0, PrefixOperatorExprSyntax.self, self.visit)
+        self.visitImpl(&$0, PrefixOperatorExprSyntax.self, self.visit)
       }
     case .primaryAssociatedTypeClause:
       return {
-        self.visitImpl($0, PrimaryAssociatedTypeClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, PrimaryAssociatedTypeClauseSyntax.self, self.visit)
       }
     case .primaryAssociatedTypeList:
       return {
-        self.visitImpl($0, PrimaryAssociatedTypeListSyntax.self, self.visit)
+        self.visitImpl(&$0, PrimaryAssociatedTypeListSyntax.self, self.visit)
       }
     case .primaryAssociatedType:
       return {
-        self.visitImpl($0, PrimaryAssociatedTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, PrimaryAssociatedTypeSyntax.self, self.visit)
       }
     case .protocolDecl:
       return {
-        self.visitImpl($0, ProtocolDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, ProtocolDeclSyntax.self, self.visit)
       }
     case .regexLiteralExpr:
       return {
-        self.visitImpl($0, RegexLiteralExprSyntax.self, self.visit)
+        self.visitImpl(&$0, RegexLiteralExprSyntax.self, self.visit)
       }
     case .repeatStmt:
       return {
-        self.visitImpl($0, RepeatStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, RepeatStmtSyntax.self, self.visit)
       }
     case .returnClause:
       return {
-        self.visitImpl($0, ReturnClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, ReturnClauseSyntax.self, self.visit)
       }
     case .returnStmt:
       return {
-        self.visitImpl($0, ReturnStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, ReturnStmtSyntax.self, self.visit)
       }
     case .sameTypeRequirement:
       return {
-        self.visitImpl($0, SameTypeRequirementSyntax.self, self.visit)
+        self.visitImpl(&$0, SameTypeRequirementSyntax.self, self.visit)
       }
     case .sequenceExpr:
       return {
-        self.visitImpl($0, SequenceExprSyntax.self, self.visit)
+        self.visitImpl(&$0, SequenceExprSyntax.self, self.visit)
       }
     case .simpleStringLiteralExpr:
       return {
-        self.visitImpl($0, SimpleStringLiteralExprSyntax.self, self.visit)
+        self.visitImpl(&$0, SimpleStringLiteralExprSyntax.self, self.visit)
       }
     case .simpleStringLiteralSegmentList:
       return {
-        self.visitImpl($0, SimpleStringLiteralSegmentListSyntax.self, self.visit)
+        self.visitImpl(&$0, SimpleStringLiteralSegmentListSyntax.self, self.visit)
       }
     case .simpleTypeSpecifier:
       return {
-        self.visitImpl($0, SimpleTypeSpecifierSyntax.self, self.visit)
+        self.visitImpl(&$0, SimpleTypeSpecifierSyntax.self, self.visit)
       }
     case .someOrAnyType:
       return {
-        self.visitImpl($0, SomeOrAnyTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, SomeOrAnyTypeSyntax.self, self.visit)
       }
     case .sourceFile:
       return {
-        self.visitImpl($0, SourceFileSyntax.self, self.visit)
+        self.visitImpl(&$0, SourceFileSyntax.self, self.visit)
       }
     case .specializeAttributeArgumentList:
       return {
-        self.visitImpl($0, SpecializeAttributeArgumentListSyntax.self, self.visit)
+        self.visitImpl(&$0, SpecializeAttributeArgumentListSyntax.self, self.visit)
       }
     case .specializeAvailabilityArgument:
       return {
-        self.visitImpl($0, SpecializeAvailabilityArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, SpecializeAvailabilityArgumentSyntax.self, self.visit)
       }
     case .specializeTargetFunctionArgument:
       return {
-        self.visitImpl($0, SpecializeTargetFunctionArgumentSyntax.self, self.visit)
+        self.visitImpl(&$0, SpecializeTargetFunctionArgumentSyntax.self, self.visit)
       }
     case .stringLiteralExpr:
       return {
-        self.visitImpl($0, StringLiteralExprSyntax.self, self.visit)
+        self.visitImpl(&$0, StringLiteralExprSyntax.self, self.visit)
       }
     case .stringLiteralSegmentList:
       return {
-        self.visitImpl($0, StringLiteralSegmentListSyntax.self, self.visit)
+        self.visitImpl(&$0, StringLiteralSegmentListSyntax.self, self.visit)
       }
     case .stringSegment:
       return {
-        self.visitImpl($0, StringSegmentSyntax.self, self.visit)
+        self.visitImpl(&$0, StringSegmentSyntax.self, self.visit)
       }
     case .structDecl:
       return {
-        self.visitImpl($0, StructDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, StructDeclSyntax.self, self.visit)
       }
     case .subscriptCallExpr:
       return {
-        self.visitImpl($0, SubscriptCallExprSyntax.self, self.visit)
+        self.visitImpl(&$0, SubscriptCallExprSyntax.self, self.visit)
       }
     case .subscriptDecl:
       return {
-        self.visitImpl($0, SubscriptDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, SubscriptDeclSyntax.self, self.visit)
       }
     case .superExpr:
       return {
-        self.visitImpl($0, SuperExprSyntax.self, self.visit)
+        self.visitImpl(&$0, SuperExprSyntax.self, self.visit)
       }
     case .suppressedType:
       return {
-        self.visitImpl($0, SuppressedTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, SuppressedTypeSyntax.self, self.visit)
       }
     case .switchCaseItemList:
       return {
-        self.visitImpl($0, SwitchCaseItemListSyntax.self, self.visit)
+        self.visitImpl(&$0, SwitchCaseItemListSyntax.self, self.visit)
       }
     case .switchCaseItem:
       return {
-        self.visitImpl($0, SwitchCaseItemSyntax.self, self.visit)
+        self.visitImpl(&$0, SwitchCaseItemSyntax.self, self.visit)
       }
     case .switchCaseLabel:
       return {
-        self.visitImpl($0, SwitchCaseLabelSyntax.self, self.visit)
+        self.visitImpl(&$0, SwitchCaseLabelSyntax.self, self.visit)
       }
     case .switchCaseList:
       return {
-        self.visitImpl($0, SwitchCaseListSyntax.self, self.visit)
+        self.visitImpl(&$0, SwitchCaseListSyntax.self, self.visit)
       }
     case .switchCase:
       return {
-        self.visitImpl($0, SwitchCaseSyntax.self, self.visit)
+        self.visitImpl(&$0, SwitchCaseSyntax.self, self.visit)
       }
     case .switchDefaultLabel:
       return {
-        self.visitImpl($0, SwitchDefaultLabelSyntax.self, self.visit)
+        self.visitImpl(&$0, SwitchDefaultLabelSyntax.self, self.visit)
       }
     case .switchExpr:
       return {
-        self.visitImpl($0, SwitchExprSyntax.self, self.visit)
+        self.visitImpl(&$0, SwitchExprSyntax.self, self.visit)
       }
     case .ternaryExpr:
       return {
-        self.visitImpl($0, TernaryExprSyntax.self, self.visit)
+        self.visitImpl(&$0, TernaryExprSyntax.self, self.visit)
       }
     case .thenStmt:
       return {
-        self.visitImpl($0, ThenStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, ThenStmtSyntax.self, self.visit)
       }
     case .throwStmt:
       return {
-        self.visitImpl($0, ThrowStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, ThrowStmtSyntax.self, self.visit)
       }
     case .throwsClause:
       return {
-        self.visitImpl($0, ThrowsClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, ThrowsClauseSyntax.self, self.visit)
       }
     case .tryExpr:
       return {
-        self.visitImpl($0, TryExprSyntax.self, self.visit)
+        self.visitImpl(&$0, TryExprSyntax.self, self.visit)
       }
     case .tupleExpr:
       return {
-        self.visitImpl($0, TupleExprSyntax.self, self.visit)
+        self.visitImpl(&$0, TupleExprSyntax.self, self.visit)
       }
     case .tuplePatternElementList:
       return {
-        self.visitImpl($0, TuplePatternElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, TuplePatternElementListSyntax.self, self.visit)
       }
     case .tuplePatternElement:
       return {
-        self.visitImpl($0, TuplePatternElementSyntax.self, self.visit)
+        self.visitImpl(&$0, TuplePatternElementSyntax.self, self.visit)
       }
     case .tuplePattern:
       return {
-        self.visitImpl($0, TuplePatternSyntax.self, self.visit)
+        self.visitImpl(&$0, TuplePatternSyntax.self, self.visit)
       }
     case .tupleTypeElementList:
       return {
-        self.visitImpl($0, TupleTypeElementListSyntax.self, self.visit)
+        self.visitImpl(&$0, TupleTypeElementListSyntax.self, self.visit)
       }
     case .tupleTypeElement:
       return {
-        self.visitImpl($0, TupleTypeElementSyntax.self, self.visit)
+        self.visitImpl(&$0, TupleTypeElementSyntax.self, self.visit)
       }
     case .tupleType:
       return {
-        self.visitImpl($0, TupleTypeSyntax.self, self.visit)
+        self.visitImpl(&$0, TupleTypeSyntax.self, self.visit)
       }
     case .typeAliasDecl:
       return {
-        self.visitImpl($0, TypeAliasDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, TypeAliasDeclSyntax.self, self.visit)
       }
     case .typeAnnotation:
       return {
-        self.visitImpl($0, TypeAnnotationSyntax.self, self.visit)
+        self.visitImpl(&$0, TypeAnnotationSyntax.self, self.visit)
       }
     case .typeEffectSpecifiers:
       return {
-        self.visitImpl($0, TypeEffectSpecifiersSyntax.self, self.visit)
+        self.visitImpl(&$0, TypeEffectSpecifiersSyntax.self, self.visit)
       }
     case .typeExpr:
       return {
-        self.visitImpl($0, TypeExprSyntax.self, self.visit)
+        self.visitImpl(&$0, TypeExprSyntax.self, self.visit)
       }
     case .typeInitializerClause:
       return {
-        self.visitImpl($0, TypeInitializerClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, TypeInitializerClauseSyntax.self, self.visit)
       }
     case .typeSpecifierList:
       return {
-        self.visitImpl($0, TypeSpecifierListSyntax.self, self.visit)
+        self.visitImpl(&$0, TypeSpecifierListSyntax.self, self.visit)
       }
     case .unavailableFromAsyncAttributeArguments:
       return {
-        self.visitImpl($0, UnavailableFromAsyncAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, UnavailableFromAsyncAttributeArgumentsSyntax.self, self.visit)
       }
     case .underscorePrivateAttributeArguments:
       return {
-        self.visitImpl($0, UnderscorePrivateAttributeArgumentsSyntax.self, self.visit)
+        self.visitImpl(&$0, UnderscorePrivateAttributeArgumentsSyntax.self, self.visit)
       }
     case .unexpectedNodes:
       return {
-        self.visitImpl($0, UnexpectedNodesSyntax.self, self.visit)
+        self.visitImpl(&$0, UnexpectedNodesSyntax.self, self.visit)
       }
     case .unresolvedAsExpr:
       return {
-        self.visitImpl($0, UnresolvedAsExprSyntax.self, self.visit)
+        self.visitImpl(&$0, UnresolvedAsExprSyntax.self, self.visit)
       }
     case .unresolvedIsExpr:
       return {
-        self.visitImpl($0, UnresolvedIsExprSyntax.self, self.visit)
+        self.visitImpl(&$0, UnresolvedIsExprSyntax.self, self.visit)
       }
     case .unresolvedTernaryExpr:
       return {
-        self.visitImpl($0, UnresolvedTernaryExprSyntax.self, self.visit)
+        self.visitImpl(&$0, UnresolvedTernaryExprSyntax.self, self.visit)
       }
     case .valueBindingPattern:
       return {
-        self.visitImpl($0, ValueBindingPatternSyntax.self, self.visit)
+        self.visitImpl(&$0, ValueBindingPatternSyntax.self, self.visit)
       }
     case .variableDecl:
       return {
-        self.visitImpl($0, VariableDeclSyntax.self, self.visit)
+        self.visitImpl(&$0, VariableDeclSyntax.self, self.visit)
       }
     case .versionComponentList:
       return {
-        self.visitImpl($0, VersionComponentListSyntax.self, self.visit)
+        self.visitImpl(&$0, VersionComponentListSyntax.self, self.visit)
       }
     case .versionComponent:
       return {
-        self.visitImpl($0, VersionComponentSyntax.self, self.visit)
+        self.visitImpl(&$0, VersionComponentSyntax.self, self.visit)
       }
     case .versionTuple:
       return {
-        self.visitImpl($0, VersionTupleSyntax.self, self.visit)
+        self.visitImpl(&$0, VersionTupleSyntax.self, self.visit)
       }
     case .whereClause:
       return {
-        self.visitImpl($0, WhereClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, WhereClauseSyntax.self, self.visit)
       }
     case .whileStmt:
       return {
-        self.visitImpl($0, WhileStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, WhileStmtSyntax.self, self.visit)
       }
     case .wildcardPattern:
       return {
-        self.visitImpl($0, WildcardPatternSyntax.self, self.visit)
+        self.visitImpl(&$0, WildcardPatternSyntax.self, self.visit)
       }
     case .yieldStmt:
       return {
-        self.visitImpl($0, YieldStmtSyntax.self, self.visit)
+        self.visitImpl(&$0, YieldStmtSyntax.self, self.visit)
       }
     case .yieldedExpressionList:
       return {
-        self.visitImpl($0, YieldedExpressionListSyntax.self, self.visit)
+        self.visitImpl(&$0, YieldedExpressionListSyntax.self, self.visit)
       }
     case .yieldedExpression:
       return {
-        self.visitImpl($0, YieldedExpressionSyntax.self, self.visit)
+        self.visitImpl(&$0, YieldedExpressionSyntax.self, self.visit)
       }
     case .yieldedExpressionsClause:
       return {
-        self.visitImpl($0, YieldedExpressionsClauseSyntax.self, self.visit)
+        self.visitImpl(&$0, YieldedExpressionsClauseSyntax.self, self.visit)
       }
     }
   }
-  private func dispatchVisit(_ node: Syntax) -> Syntax {
-    return visitationFunc(for: node)(node)
+  private func dispatchVisit(_ node: inout Syntax) {
+    visitationFunc(for: node)(&node)
   }
   #else
-  private func dispatchVisit(_ node: Syntax) -> Syntax {
+  private func dispatchVisit(_ node: inout Syntax) {
     switch node.raw.kind {
     case .token:
-      return visitImpl(node, TokenSyntax.self, visit)
+      return visitImpl(&node, TokenSyntax.self, visit)
     case .accessorBlock:
-      return visitImpl(node, AccessorBlockSyntax.self, visit)
+      return visitImpl(&node, AccessorBlockSyntax.self, visit)
     case .accessorDeclList:
-      return visitImpl(node, AccessorDeclListSyntax.self, visit)
+      return visitImpl(&node, AccessorDeclListSyntax.self, visit)
     case .accessorDecl:
-      return visitImpl(node, AccessorDeclSyntax.self, visit)
+      return visitImpl(&node, AccessorDeclSyntax.self, visit)
     case .accessorEffectSpecifiers:
-      return visitImpl(node, AccessorEffectSpecifiersSyntax.self, visit)
+      return visitImpl(&node, AccessorEffectSpecifiersSyntax.self, visit)
     case .accessorParameters:
-      return visitImpl(node, AccessorParametersSyntax.self, visit)
+      return visitImpl(&node, AccessorParametersSyntax.self, visit)
     case .actorDecl:
-      return visitImpl(node, ActorDeclSyntax.self, visit)
+      return visitImpl(&node, ActorDeclSyntax.self, visit)
     case .arrayElementList:
-      return visitImpl(node, ArrayElementListSyntax.self, visit)
+      return visitImpl(&node, ArrayElementListSyntax.self, visit)
     case .arrayElement:
-      return visitImpl(node, ArrayElementSyntax.self, visit)
+      return visitImpl(&node, ArrayElementSyntax.self, visit)
     case .arrayExpr:
-      return visitImpl(node, ArrayExprSyntax.self, visit)
+      return visitImpl(&node, ArrayExprSyntax.self, visit)
     case .arrayType:
-      return visitImpl(node, ArrayTypeSyntax.self, visit)
+      return visitImpl(&node, ArrayTypeSyntax.self, visit)
     case .arrowExpr:
-      return visitImpl(node, ArrowExprSyntax.self, visit)
+      return visitImpl(&node, ArrowExprSyntax.self, visit)
     case .asExpr:
-      return visitImpl(node, AsExprSyntax.self, visit)
+      return visitImpl(&node, AsExprSyntax.self, visit)
     case .assignmentExpr:
-      return visitImpl(node, AssignmentExprSyntax.self, visit)
+      return visitImpl(&node, AssignmentExprSyntax.self, visit)
     case .associatedTypeDecl:
-      return visitImpl(node, AssociatedTypeDeclSyntax.self, visit)
+      return visitImpl(&node, AssociatedTypeDeclSyntax.self, visit)
     case .attributeList:
-      return visitImpl(node, AttributeListSyntax.self, visit)
+      return visitImpl(&node, AttributeListSyntax.self, visit)
     case .attribute:
-      return visitImpl(node, AttributeSyntax.self, visit)
+      return visitImpl(&node, AttributeSyntax.self, visit)
     case .attributedType:
-      return visitImpl(node, AttributedTypeSyntax.self, visit)
+      return visitImpl(&node, AttributedTypeSyntax.self, visit)
     case .availabilityArgumentList:
-      return visitImpl(node, AvailabilityArgumentListSyntax.self, visit)
+      return visitImpl(&node, AvailabilityArgumentListSyntax.self, visit)
     case .availabilityArgument:
-      return visitImpl(node, AvailabilityArgumentSyntax.self, visit)
+      return visitImpl(&node, AvailabilityArgumentSyntax.self, visit)
     case .availabilityCondition:
-      return visitImpl(node, AvailabilityConditionSyntax.self, visit)
+      return visitImpl(&node, AvailabilityConditionSyntax.self, visit)
     case .availabilityLabeledArgument:
-      return visitImpl(node, AvailabilityLabeledArgumentSyntax.self, visit)
+      return visitImpl(&node, AvailabilityLabeledArgumentSyntax.self, visit)
     case .awaitExpr:
-      return visitImpl(node, AwaitExprSyntax.self, visit)
+      return visitImpl(&node, AwaitExprSyntax.self, visit)
     case .backDeployedAttributeArguments:
-      return visitImpl(node, BackDeployedAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, BackDeployedAttributeArgumentsSyntax.self, visit)
     case .binaryOperatorExpr:
-      return visitImpl(node, BinaryOperatorExprSyntax.self, visit)
+      return visitImpl(&node, BinaryOperatorExprSyntax.self, visit)
     case .booleanLiteralExpr:
-      return visitImpl(node, BooleanLiteralExprSyntax.self, visit)
+      return visitImpl(&node, BooleanLiteralExprSyntax.self, visit)
     case .borrowExpr:
-      return visitImpl(node, BorrowExprSyntax.self, visit)
+      return visitImpl(&node, BorrowExprSyntax.self, visit)
     case .breakStmt:
-      return visitImpl(node, BreakStmtSyntax.self, visit)
+      return visitImpl(&node, BreakStmtSyntax.self, visit)
     case ._canImportExpr:
-      return visitImpl(node, _CanImportExprSyntax.self, visit)
+      return visitImpl(&node, _CanImportExprSyntax.self, visit)
     case ._canImportVersionInfo:
-      return visitImpl(node, _CanImportVersionInfoSyntax.self, visit)
+      return visitImpl(&node, _CanImportVersionInfoSyntax.self, visit)
     case .catchClauseList:
-      return visitImpl(node, CatchClauseListSyntax.self, visit)
+      return visitImpl(&node, CatchClauseListSyntax.self, visit)
     case .catchClause:
-      return visitImpl(node, CatchClauseSyntax.self, visit)
+      return visitImpl(&node, CatchClauseSyntax.self, visit)
     case .catchItemList:
-      return visitImpl(node, CatchItemListSyntax.self, visit)
+      return visitImpl(&node, CatchItemListSyntax.self, visit)
     case .catchItem:
-      return visitImpl(node, CatchItemSyntax.self, visit)
+      return visitImpl(&node, CatchItemSyntax.self, visit)
     case .classDecl:
-      return visitImpl(node, ClassDeclSyntax.self, visit)
+      return visitImpl(&node, ClassDeclSyntax.self, visit)
     case .classRestrictionType:
-      return visitImpl(node, ClassRestrictionTypeSyntax.self, visit)
+      return visitImpl(&node, ClassRestrictionTypeSyntax.self, visit)
     case .closureCaptureClause:
-      return visitImpl(node, ClosureCaptureClauseSyntax.self, visit)
+      return visitImpl(&node, ClosureCaptureClauseSyntax.self, visit)
     case .closureCaptureList:
-      return visitImpl(node, ClosureCaptureListSyntax.self, visit)
+      return visitImpl(&node, ClosureCaptureListSyntax.self, visit)
     case .closureCaptureSpecifier:
-      return visitImpl(node, ClosureCaptureSpecifierSyntax.self, visit)
+      return visitImpl(&node, ClosureCaptureSpecifierSyntax.self, visit)
     case .closureCapture:
-      return visitImpl(node, ClosureCaptureSyntax.self, visit)
+      return visitImpl(&node, ClosureCaptureSyntax.self, visit)
     case .closureExpr:
-      return visitImpl(node, ClosureExprSyntax.self, visit)
+      return visitImpl(&node, ClosureExprSyntax.self, visit)
     case .closureParameterClause:
-      return visitImpl(node, ClosureParameterClauseSyntax.self, visit)
+      return visitImpl(&node, ClosureParameterClauseSyntax.self, visit)
     case .closureParameterList:
-      return visitImpl(node, ClosureParameterListSyntax.self, visit)
+      return visitImpl(&node, ClosureParameterListSyntax.self, visit)
     case .closureParameter:
-      return visitImpl(node, ClosureParameterSyntax.self, visit)
+      return visitImpl(&node, ClosureParameterSyntax.self, visit)
     case .closureShorthandParameterList:
-      return visitImpl(node, ClosureShorthandParameterListSyntax.self, visit)
+      return visitImpl(&node, ClosureShorthandParameterListSyntax.self, visit)
     case .closureShorthandParameter:
-      return visitImpl(node, ClosureShorthandParameterSyntax.self, visit)
+      return visitImpl(&node, ClosureShorthandParameterSyntax.self, visit)
     case .closureSignature:
-      return visitImpl(node, ClosureSignatureSyntax.self, visit)
+      return visitImpl(&node, ClosureSignatureSyntax.self, visit)
     case .codeBlockItemList:
-      return visitImpl(node, CodeBlockItemListSyntax.self, visit)
+      return visitImpl(&node, CodeBlockItemListSyntax.self, visit)
     case .codeBlockItem:
-      return visitImpl(node, CodeBlockItemSyntax.self, visit)
+      return visitImpl(&node, CodeBlockItemSyntax.self, visit)
     case .codeBlock:
-      return visitImpl(node, CodeBlockSyntax.self, visit)
+      return visitImpl(&node, CodeBlockSyntax.self, visit)
     case .compositionTypeElementList:
-      return visitImpl(node, CompositionTypeElementListSyntax.self, visit)
+      return visitImpl(&node, CompositionTypeElementListSyntax.self, visit)
     case .compositionTypeElement:
-      return visitImpl(node, CompositionTypeElementSyntax.self, visit)
+      return visitImpl(&node, CompositionTypeElementSyntax.self, visit)
     case .compositionType:
-      return visitImpl(node, CompositionTypeSyntax.self, visit)
+      return visitImpl(&node, CompositionTypeSyntax.self, visit)
     case .conditionElementList:
-      return visitImpl(node, ConditionElementListSyntax.self, visit)
+      return visitImpl(&node, ConditionElementListSyntax.self, visit)
     case .conditionElement:
-      return visitImpl(node, ConditionElementSyntax.self, visit)
+      return visitImpl(&node, ConditionElementSyntax.self, visit)
     case .conformanceRequirement:
-      return visitImpl(node, ConformanceRequirementSyntax.self, visit)
+      return visitImpl(&node, ConformanceRequirementSyntax.self, visit)
     case .consumeExpr:
-      return visitImpl(node, ConsumeExprSyntax.self, visit)
+      return visitImpl(&node, ConsumeExprSyntax.self, visit)
     case .continueStmt:
-      return visitImpl(node, ContinueStmtSyntax.self, visit)
+      return visitImpl(&node, ContinueStmtSyntax.self, visit)
     case .conventionAttributeArguments:
-      return visitImpl(node, ConventionAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, ConventionAttributeArgumentsSyntax.self, visit)
     case .conventionWitnessMethodAttributeArguments:
-      return visitImpl(node, ConventionWitnessMethodAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, ConventionWitnessMethodAttributeArgumentsSyntax.self, visit)
     case .copyExpr:
-      return visitImpl(node, CopyExprSyntax.self, visit)
+      return visitImpl(&node, CopyExprSyntax.self, visit)
     case .declModifierDetail:
-      return visitImpl(node, DeclModifierDetailSyntax.self, visit)
+      return visitImpl(&node, DeclModifierDetailSyntax.self, visit)
     case .declModifierList:
-      return visitImpl(node, DeclModifierListSyntax.self, visit)
+      return visitImpl(&node, DeclModifierListSyntax.self, visit)
     case .declModifier:
-      return visitImpl(node, DeclModifierSyntax.self, visit)
+      return visitImpl(&node, DeclModifierSyntax.self, visit)
     case .declNameArgumentList:
-      return visitImpl(node, DeclNameArgumentListSyntax.self, visit)
+      return visitImpl(&node, DeclNameArgumentListSyntax.self, visit)
     case .declNameArgument:
-      return visitImpl(node, DeclNameArgumentSyntax.self, visit)
+      return visitImpl(&node, DeclNameArgumentSyntax.self, visit)
     case .declNameArguments:
-      return visitImpl(node, DeclNameArgumentsSyntax.self, visit)
+      return visitImpl(&node, DeclNameArgumentsSyntax.self, visit)
     case .declReferenceExpr:
-      return visitImpl(node, DeclReferenceExprSyntax.self, visit)
+      return visitImpl(&node, DeclReferenceExprSyntax.self, visit)
     case .deferStmt:
-      return visitImpl(node, DeferStmtSyntax.self, visit)
+      return visitImpl(&node, DeferStmtSyntax.self, visit)
     case .deinitializerDecl:
-      return visitImpl(node, DeinitializerDeclSyntax.self, visit)
+      return visitImpl(&node, DeinitializerDeclSyntax.self, visit)
     case .deinitializerEffectSpecifiers:
-      return visitImpl(node, DeinitializerEffectSpecifiersSyntax.self, visit)
+      return visitImpl(&node, DeinitializerEffectSpecifiersSyntax.self, visit)
     case .derivativeAttributeArguments:
-      return visitImpl(node, DerivativeAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, DerivativeAttributeArgumentsSyntax.self, visit)
     case .designatedTypeList:
-      return visitImpl(node, DesignatedTypeListSyntax.self, visit)
+      return visitImpl(&node, DesignatedTypeListSyntax.self, visit)
     case .designatedType:
-      return visitImpl(node, DesignatedTypeSyntax.self, visit)
+      return visitImpl(&node, DesignatedTypeSyntax.self, visit)
     case .dictionaryElementList:
-      return visitImpl(node, DictionaryElementListSyntax.self, visit)
+      return visitImpl(&node, DictionaryElementListSyntax.self, visit)
     case .dictionaryElement:
-      return visitImpl(node, DictionaryElementSyntax.self, visit)
+      return visitImpl(&node, DictionaryElementSyntax.self, visit)
     case .dictionaryExpr:
-      return visitImpl(node, DictionaryExprSyntax.self, visit)
+      return visitImpl(&node, DictionaryExprSyntax.self, visit)
     case .dictionaryType:
-      return visitImpl(node, DictionaryTypeSyntax.self, visit)
+      return visitImpl(&node, DictionaryTypeSyntax.self, visit)
     case .differentiabilityArgumentList:
-      return visitImpl(node, DifferentiabilityArgumentListSyntax.self, visit)
+      return visitImpl(&node, DifferentiabilityArgumentListSyntax.self, visit)
     case .differentiabilityArgument:
-      return visitImpl(node, DifferentiabilityArgumentSyntax.self, visit)
+      return visitImpl(&node, DifferentiabilityArgumentSyntax.self, visit)
     case .differentiabilityArguments:
-      return visitImpl(node, DifferentiabilityArgumentsSyntax.self, visit)
+      return visitImpl(&node, DifferentiabilityArgumentsSyntax.self, visit)
     case .differentiabilityWithRespectToArgument:
-      return visitImpl(node, DifferentiabilityWithRespectToArgumentSyntax.self, visit)
+      return visitImpl(&node, DifferentiabilityWithRespectToArgumentSyntax.self, visit)
     case .differentiableAttributeArguments:
-      return visitImpl(node, DifferentiableAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, DifferentiableAttributeArgumentsSyntax.self, visit)
     case .discardAssignmentExpr:
-      return visitImpl(node, DiscardAssignmentExprSyntax.self, visit)
+      return visitImpl(&node, DiscardAssignmentExprSyntax.self, visit)
     case .discardStmt:
-      return visitImpl(node, DiscardStmtSyntax.self, visit)
+      return visitImpl(&node, DiscardStmtSyntax.self, visit)
     case .doExpr:
-      return visitImpl(node, DoExprSyntax.self, visit)
+      return visitImpl(&node, DoExprSyntax.self, visit)
     case .doStmt:
-      return visitImpl(node, DoStmtSyntax.self, visit)
+      return visitImpl(&node, DoStmtSyntax.self, visit)
     case .documentationAttributeArgumentList:
-      return visitImpl(node, DocumentationAttributeArgumentListSyntax.self, visit)
+      return visitImpl(&node, DocumentationAttributeArgumentListSyntax.self, visit)
     case .documentationAttributeArgument:
-      return visitImpl(node, DocumentationAttributeArgumentSyntax.self, visit)
+      return visitImpl(&node, DocumentationAttributeArgumentSyntax.self, visit)
     case .dynamicReplacementAttributeArguments:
-      return visitImpl(node, DynamicReplacementAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, DynamicReplacementAttributeArgumentsSyntax.self, visit)
     case .editorPlaceholderDecl:
-      return visitImpl(node, EditorPlaceholderDeclSyntax.self, visit)
+      return visitImpl(&node, EditorPlaceholderDeclSyntax.self, visit)
     case .editorPlaceholderExpr:
-      return visitImpl(node, EditorPlaceholderExprSyntax.self, visit)
+      return visitImpl(&node, EditorPlaceholderExprSyntax.self, visit)
     case .effectsAttributeArgumentList:
-      return visitImpl(node, EffectsAttributeArgumentListSyntax.self, visit)
+      return visitImpl(&node, EffectsAttributeArgumentListSyntax.self, visit)
     case .enumCaseDecl:
-      return visitImpl(node, EnumCaseDeclSyntax.self, visit)
+      return visitImpl(&node, EnumCaseDeclSyntax.self, visit)
     case .enumCaseElementList:
-      return visitImpl(node, EnumCaseElementListSyntax.self, visit)
+      return visitImpl(&node, EnumCaseElementListSyntax.self, visit)
     case .enumCaseElement:
-      return visitImpl(node, EnumCaseElementSyntax.self, visit)
+      return visitImpl(&node, EnumCaseElementSyntax.self, visit)
     case .enumCaseParameterClause:
-      return visitImpl(node, EnumCaseParameterClauseSyntax.self, visit)
+      return visitImpl(&node, EnumCaseParameterClauseSyntax.self, visit)
     case .enumCaseParameterList:
-      return visitImpl(node, EnumCaseParameterListSyntax.self, visit)
+      return visitImpl(&node, EnumCaseParameterListSyntax.self, visit)
     case .enumCaseParameter:
-      return visitImpl(node, EnumCaseParameterSyntax.self, visit)
+      return visitImpl(&node, EnumCaseParameterSyntax.self, visit)
     case .enumDecl:
-      return visitImpl(node, EnumDeclSyntax.self, visit)
+      return visitImpl(&node, EnumDeclSyntax.self, visit)
     case .exposeAttributeArguments:
-      return visitImpl(node, ExposeAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, ExposeAttributeArgumentsSyntax.self, visit)
     case .exprList:
-      return visitImpl(node, ExprListSyntax.self, visit)
+      return visitImpl(&node, ExprListSyntax.self, visit)
     case .expressionPattern:
-      return visitImpl(node, ExpressionPatternSyntax.self, visit)
+      return visitImpl(&node, ExpressionPatternSyntax.self, visit)
     case .expressionSegment:
-      return visitImpl(node, ExpressionSegmentSyntax.self, visit)
+      return visitImpl(&node, ExpressionSegmentSyntax.self, visit)
     case .expressionStmt:
-      return visitImpl(node, ExpressionStmtSyntax.self, visit)
+      return visitImpl(&node, ExpressionStmtSyntax.self, visit)
     case .extensionDecl:
-      return visitImpl(node, ExtensionDeclSyntax.self, visit)
+      return visitImpl(&node, ExtensionDeclSyntax.self, visit)
     case .fallThroughStmt:
-      return visitImpl(node, FallThroughStmtSyntax.self, visit)
+      return visitImpl(&node, FallThroughStmtSyntax.self, visit)
     case .floatLiteralExpr:
-      return visitImpl(node, FloatLiteralExprSyntax.self, visit)
+      return visitImpl(&node, FloatLiteralExprSyntax.self, visit)
     case .forStmt:
-      return visitImpl(node, ForStmtSyntax.self, visit)
+      return visitImpl(&node, ForStmtSyntax.self, visit)
     case .forceUnwrapExpr:
-      return visitImpl(node, ForceUnwrapExprSyntax.self, visit)
+      return visitImpl(&node, ForceUnwrapExprSyntax.self, visit)
     case .functionCallExpr:
-      return visitImpl(node, FunctionCallExprSyntax.self, visit)
+      return visitImpl(&node, FunctionCallExprSyntax.self, visit)
     case .functionDecl:
-      return visitImpl(node, FunctionDeclSyntax.self, visit)
+      return visitImpl(&node, FunctionDeclSyntax.self, visit)
     case .functionEffectSpecifiers:
-      return visitImpl(node, FunctionEffectSpecifiersSyntax.self, visit)
+      return visitImpl(&node, FunctionEffectSpecifiersSyntax.self, visit)
     case .functionParameterClause:
-      return visitImpl(node, FunctionParameterClauseSyntax.self, visit)
+      return visitImpl(&node, FunctionParameterClauseSyntax.self, visit)
     case .functionParameterList:
-      return visitImpl(node, FunctionParameterListSyntax.self, visit)
+      return visitImpl(&node, FunctionParameterListSyntax.self, visit)
     case .functionParameter:
-      return visitImpl(node, FunctionParameterSyntax.self, visit)
+      return visitImpl(&node, FunctionParameterSyntax.self, visit)
     case .functionSignature:
-      return visitImpl(node, FunctionSignatureSyntax.self, visit)
+      return visitImpl(&node, FunctionSignatureSyntax.self, visit)
     case .functionType:
-      return visitImpl(node, FunctionTypeSyntax.self, visit)
+      return visitImpl(&node, FunctionTypeSyntax.self, visit)
     case .genericArgumentClause:
-      return visitImpl(node, GenericArgumentClauseSyntax.self, visit)
+      return visitImpl(&node, GenericArgumentClauseSyntax.self, visit)
     case .genericArgumentList:
-      return visitImpl(node, GenericArgumentListSyntax.self, visit)
+      return visitImpl(&node, GenericArgumentListSyntax.self, visit)
     case .genericArgument:
-      return visitImpl(node, GenericArgumentSyntax.self, visit)
+      return visitImpl(&node, GenericArgumentSyntax.self, visit)
     case .genericParameterClause:
-      return visitImpl(node, GenericParameterClauseSyntax.self, visit)
+      return visitImpl(&node, GenericParameterClauseSyntax.self, visit)
     case .genericParameterList:
-      return visitImpl(node, GenericParameterListSyntax.self, visit)
+      return visitImpl(&node, GenericParameterListSyntax.self, visit)
     case .genericParameter:
-      return visitImpl(node, GenericParameterSyntax.self, visit)
+      return visitImpl(&node, GenericParameterSyntax.self, visit)
     case .genericRequirementList:
-      return visitImpl(node, GenericRequirementListSyntax.self, visit)
+      return visitImpl(&node, GenericRequirementListSyntax.self, visit)
     case .genericRequirement:
-      return visitImpl(node, GenericRequirementSyntax.self, visit)
+      return visitImpl(&node, GenericRequirementSyntax.self, visit)
     case .genericSpecializationExpr:
-      return visitImpl(node, GenericSpecializationExprSyntax.self, visit)
+      return visitImpl(&node, GenericSpecializationExprSyntax.self, visit)
     case .genericWhereClause:
-      return visitImpl(node, GenericWhereClauseSyntax.self, visit)
+      return visitImpl(&node, GenericWhereClauseSyntax.self, visit)
     case .guardStmt:
-      return visitImpl(node, GuardStmtSyntax.self, visit)
+      return visitImpl(&node, GuardStmtSyntax.self, visit)
     case .identifierPattern:
-      return visitImpl(node, IdentifierPatternSyntax.self, visit)
+      return visitImpl(&node, IdentifierPatternSyntax.self, visit)
     case .identifierType:
-      return visitImpl(node, IdentifierTypeSyntax.self, visit)
+      return visitImpl(&node, IdentifierTypeSyntax.self, visit)
     case .ifConfigClauseList:
-      return visitImpl(node, IfConfigClauseListSyntax.self, visit)
+      return visitImpl(&node, IfConfigClauseListSyntax.self, visit)
     case .ifConfigClause:
-      return visitImpl(node, IfConfigClauseSyntax.self, visit)
+      return visitImpl(&node, IfConfigClauseSyntax.self, visit)
     case .ifConfigDecl:
-      return visitImpl(node, IfConfigDeclSyntax.self, visit)
+      return visitImpl(&node, IfConfigDeclSyntax.self, visit)
     case .ifExpr:
-      return visitImpl(node, IfExprSyntax.self, visit)
+      return visitImpl(&node, IfExprSyntax.self, visit)
     case .implementsAttributeArguments:
-      return visitImpl(node, ImplementsAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, ImplementsAttributeArgumentsSyntax.self, visit)
     case .implicitlyUnwrappedOptionalType:
-      return visitImpl(node, ImplicitlyUnwrappedOptionalTypeSyntax.self, visit)
+      return visitImpl(&node, ImplicitlyUnwrappedOptionalTypeSyntax.self, visit)
     case .importDecl:
-      return visitImpl(node, ImportDeclSyntax.self, visit)
+      return visitImpl(&node, ImportDeclSyntax.self, visit)
     case .importPathComponentList:
-      return visitImpl(node, ImportPathComponentListSyntax.self, visit)
+      return visitImpl(&node, ImportPathComponentListSyntax.self, visit)
     case .importPathComponent:
-      return visitImpl(node, ImportPathComponentSyntax.self, visit)
+      return visitImpl(&node, ImportPathComponentSyntax.self, visit)
     case .inOutExpr:
-      return visitImpl(node, InOutExprSyntax.self, visit)
+      return visitImpl(&node, InOutExprSyntax.self, visit)
     case .infixOperatorExpr:
-      return visitImpl(node, InfixOperatorExprSyntax.self, visit)
+      return visitImpl(&node, InfixOperatorExprSyntax.self, visit)
     case .inheritanceClause:
-      return visitImpl(node, InheritanceClauseSyntax.self, visit)
+      return visitImpl(&node, InheritanceClauseSyntax.self, visit)
     case .inheritedTypeList:
-      return visitImpl(node, InheritedTypeListSyntax.self, visit)
+      return visitImpl(&node, InheritedTypeListSyntax.self, visit)
     case .inheritedType:
-      return visitImpl(node, InheritedTypeSyntax.self, visit)
+      return visitImpl(&node, InheritedTypeSyntax.self, visit)
     case .initializerClause:
-      return visitImpl(node, InitializerClauseSyntax.self, visit)
+      return visitImpl(&node, InitializerClauseSyntax.self, visit)
     case .initializerDecl:
-      return visitImpl(node, InitializerDeclSyntax.self, visit)
+      return visitImpl(&node, InitializerDeclSyntax.self, visit)
     case .integerLiteralExpr:
-      return visitImpl(node, IntegerLiteralExprSyntax.self, visit)
+      return visitImpl(&node, IntegerLiteralExprSyntax.self, visit)
     case .isExpr:
-      return visitImpl(node, IsExprSyntax.self, visit)
+      return visitImpl(&node, IsExprSyntax.self, visit)
     case .isTypePattern:
-      return visitImpl(node, IsTypePatternSyntax.self, visit)
+      return visitImpl(&node, IsTypePatternSyntax.self, visit)
     case .keyPathComponentList:
-      return visitImpl(node, KeyPathComponentListSyntax.self, visit)
+      return visitImpl(&node, KeyPathComponentListSyntax.self, visit)
     case .keyPathComponent:
-      return visitImpl(node, KeyPathComponentSyntax.self, visit)
+      return visitImpl(&node, KeyPathComponentSyntax.self, visit)
     case .keyPathExpr:
-      return visitImpl(node, KeyPathExprSyntax.self, visit)
+      return visitImpl(&node, KeyPathExprSyntax.self, visit)
     case .keyPathOptionalComponent:
-      return visitImpl(node, KeyPathOptionalComponentSyntax.self, visit)
+      return visitImpl(&node, KeyPathOptionalComponentSyntax.self, visit)
     case .keyPathPropertyComponent:
-      return visitImpl(node, KeyPathPropertyComponentSyntax.self, visit)
+      return visitImpl(&node, KeyPathPropertyComponentSyntax.self, visit)
     case .keyPathSubscriptComponent:
-      return visitImpl(node, KeyPathSubscriptComponentSyntax.self, visit)
+      return visitImpl(&node, KeyPathSubscriptComponentSyntax.self, visit)
     case .labeledExprList:
-      return visitImpl(node, LabeledExprListSyntax.self, visit)
+      return visitImpl(&node, LabeledExprListSyntax.self, visit)
     case .labeledExpr:
-      return visitImpl(node, LabeledExprSyntax.self, visit)
+      return visitImpl(&node, LabeledExprSyntax.self, visit)
     case .labeledSpecializeArgument:
-      return visitImpl(node, LabeledSpecializeArgumentSyntax.self, visit)
+      return visitImpl(&node, LabeledSpecializeArgumentSyntax.self, visit)
     case .labeledStmt:
-      return visitImpl(node, LabeledStmtSyntax.self, visit)
+      return visitImpl(&node, LabeledStmtSyntax.self, visit)
     case .layoutRequirement:
-      return visitImpl(node, LayoutRequirementSyntax.self, visit)
+      return visitImpl(&node, LayoutRequirementSyntax.self, visit)
     case .lifetimeSpecifierArgumentList:
-      return visitImpl(node, LifetimeSpecifierArgumentListSyntax.self, visit)
+      return visitImpl(&node, LifetimeSpecifierArgumentListSyntax.self, visit)
     case .lifetimeSpecifierArgument:
-      return visitImpl(node, LifetimeSpecifierArgumentSyntax.self, visit)
+      return visitImpl(&node, LifetimeSpecifierArgumentSyntax.self, visit)
     case .lifetimeTypeSpecifier:
-      return visitImpl(node, LifetimeTypeSpecifierSyntax.self, visit)
+      return visitImpl(&node, LifetimeTypeSpecifierSyntax.self, visit)
     case .macroDecl:
-      return visitImpl(node, MacroDeclSyntax.self, visit)
+      return visitImpl(&node, MacroDeclSyntax.self, visit)
     case .macroExpansionDecl:
-      return visitImpl(node, MacroExpansionDeclSyntax.self, visit)
+      return visitImpl(&node, MacroExpansionDeclSyntax.self, visit)
     case .macroExpansionExpr:
-      return visitImpl(node, MacroExpansionExprSyntax.self, visit)
+      return visitImpl(&node, MacroExpansionExprSyntax.self, visit)
     case .matchingPatternCondition:
-      return visitImpl(node, MatchingPatternConditionSyntax.self, visit)
+      return visitImpl(&node, MatchingPatternConditionSyntax.self, visit)
     case .memberAccessExpr:
-      return visitImpl(node, MemberAccessExprSyntax.self, visit)
+      return visitImpl(&node, MemberAccessExprSyntax.self, visit)
     case .memberBlockItemList:
-      return visitImpl(node, MemberBlockItemListSyntax.self, visit)
+      return visitImpl(&node, MemberBlockItemListSyntax.self, visit)
     case .memberBlockItem:
-      return visitImpl(node, MemberBlockItemSyntax.self, visit)
+      return visitImpl(&node, MemberBlockItemSyntax.self, visit)
     case .memberBlock:
-      return visitImpl(node, MemberBlockSyntax.self, visit)
+      return visitImpl(&node, MemberBlockSyntax.self, visit)
     case .memberType:
-      return visitImpl(node, MemberTypeSyntax.self, visit)
+      return visitImpl(&node, MemberTypeSyntax.self, visit)
     case .metatypeType:
-      return visitImpl(node, MetatypeTypeSyntax.self, visit)
+      return visitImpl(&node, MetatypeTypeSyntax.self, visit)
     case .missingDecl:
-      return visitImpl(node, MissingDeclSyntax.self, visit)
+      return visitImpl(&node, MissingDeclSyntax.self, visit)
     case .missingExpr:
-      return visitImpl(node, MissingExprSyntax.self, visit)
+      return visitImpl(&node, MissingExprSyntax.self, visit)
     case .missingPattern:
-      return visitImpl(node, MissingPatternSyntax.self, visit)
+      return visitImpl(&node, MissingPatternSyntax.self, visit)
     case .missingStmt:
-      return visitImpl(node, MissingStmtSyntax.self, visit)
+      return visitImpl(&node, MissingStmtSyntax.self, visit)
     case .missing:
-      return visitImpl(node, MissingSyntax.self, visit)
+      return visitImpl(&node, MissingSyntax.self, visit)
     case .missingType:
-      return visitImpl(node, MissingTypeSyntax.self, visit)
+      return visitImpl(&node, MissingTypeSyntax.self, visit)
     case .multipleTrailingClosureElementList:
-      return visitImpl(node, MultipleTrailingClosureElementListSyntax.self, visit)
+      return visitImpl(&node, MultipleTrailingClosureElementListSyntax.self, visit)
     case .multipleTrailingClosureElement:
-      return visitImpl(node, MultipleTrailingClosureElementSyntax.self, visit)
+      return visitImpl(&node, MultipleTrailingClosureElementSyntax.self, visit)
     case .namedOpaqueReturnType:
-      return visitImpl(node, NamedOpaqueReturnTypeSyntax.self, visit)
+      return visitImpl(&node, NamedOpaqueReturnTypeSyntax.self, visit)
     case .nilLiteralExpr:
-      return visitImpl(node, NilLiteralExprSyntax.self, visit)
+      return visitImpl(&node, NilLiteralExprSyntax.self, visit)
     case .objCSelectorPieceList:
-      return visitImpl(node, ObjCSelectorPieceListSyntax.self, visit)
+      return visitImpl(&node, ObjCSelectorPieceListSyntax.self, visit)
     case .objCSelectorPiece:
-      return visitImpl(node, ObjCSelectorPieceSyntax.self, visit)
+      return visitImpl(&node, ObjCSelectorPieceSyntax.self, visit)
     case .opaqueReturnTypeOfAttributeArguments:
-      return visitImpl(node, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, visit)
     case .operatorDecl:
-      return visitImpl(node, OperatorDeclSyntax.self, visit)
+      return visitImpl(&node, OperatorDeclSyntax.self, visit)
     case .operatorPrecedenceAndTypes:
-      return visitImpl(node, OperatorPrecedenceAndTypesSyntax.self, visit)
+      return visitImpl(&node, OperatorPrecedenceAndTypesSyntax.self, visit)
     case .optionalBindingCondition:
-      return visitImpl(node, OptionalBindingConditionSyntax.self, visit)
+      return visitImpl(&node, OptionalBindingConditionSyntax.self, visit)
     case .optionalChainingExpr:
-      return visitImpl(node, OptionalChainingExprSyntax.self, visit)
+      return visitImpl(&node, OptionalChainingExprSyntax.self, visit)
     case .optionalType:
-      return visitImpl(node, OptionalTypeSyntax.self, visit)
+      return visitImpl(&node, OptionalTypeSyntax.self, visit)
     case .originallyDefinedInAttributeArguments:
-      return visitImpl(node, OriginallyDefinedInAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, OriginallyDefinedInAttributeArgumentsSyntax.self, visit)
     case .packElementExpr:
-      return visitImpl(node, PackElementExprSyntax.self, visit)
+      return visitImpl(&node, PackElementExprSyntax.self, visit)
     case .packElementType:
-      return visitImpl(node, PackElementTypeSyntax.self, visit)
+      return visitImpl(&node, PackElementTypeSyntax.self, visit)
     case .packExpansionExpr:
-      return visitImpl(node, PackExpansionExprSyntax.self, visit)
+      return visitImpl(&node, PackExpansionExprSyntax.self, visit)
     case .packExpansionType:
-      return visitImpl(node, PackExpansionTypeSyntax.self, visit)
+      return visitImpl(&node, PackExpansionTypeSyntax.self, visit)
     case .patternBindingList:
-      return visitImpl(node, PatternBindingListSyntax.self, visit)
+      return visitImpl(&node, PatternBindingListSyntax.self, visit)
     case .patternBinding:
-      return visitImpl(node, PatternBindingSyntax.self, visit)
+      return visitImpl(&node, PatternBindingSyntax.self, visit)
     case .patternExpr:
-      return visitImpl(node, PatternExprSyntax.self, visit)
+      return visitImpl(&node, PatternExprSyntax.self, visit)
     case .platformVersionItemList:
-      return visitImpl(node, PlatformVersionItemListSyntax.self, visit)
+      return visitImpl(&node, PlatformVersionItemListSyntax.self, visit)
     case .platformVersionItem:
-      return visitImpl(node, PlatformVersionItemSyntax.self, visit)
+      return visitImpl(&node, PlatformVersionItemSyntax.self, visit)
     case .platformVersion:
-      return visitImpl(node, PlatformVersionSyntax.self, visit)
+      return visitImpl(&node, PlatformVersionSyntax.self, visit)
     case .postfixIfConfigExpr:
-      return visitImpl(node, PostfixIfConfigExprSyntax.self, visit)
+      return visitImpl(&node, PostfixIfConfigExprSyntax.self, visit)
     case .postfixOperatorExpr:
-      return visitImpl(node, PostfixOperatorExprSyntax.self, visit)
+      return visitImpl(&node, PostfixOperatorExprSyntax.self, visit)
     case .poundSourceLocationArguments:
-      return visitImpl(node, PoundSourceLocationArgumentsSyntax.self, visit)
+      return visitImpl(&node, PoundSourceLocationArgumentsSyntax.self, visit)
     case .poundSourceLocation:
-      return visitImpl(node, PoundSourceLocationSyntax.self, visit)
+      return visitImpl(&node, PoundSourceLocationSyntax.self, visit)
     case .precedenceGroupAssignment:
-      return visitImpl(node, PrecedenceGroupAssignmentSyntax.self, visit)
+      return visitImpl(&node, PrecedenceGroupAssignmentSyntax.self, visit)
     case .precedenceGroupAssociativity:
-      return visitImpl(node, PrecedenceGroupAssociativitySyntax.self, visit)
+      return visitImpl(&node, PrecedenceGroupAssociativitySyntax.self, visit)
     case .precedenceGroupAttributeList:
-      return visitImpl(node, PrecedenceGroupAttributeListSyntax.self, visit)
+      return visitImpl(&node, PrecedenceGroupAttributeListSyntax.self, visit)
     case .precedenceGroupDecl:
-      return visitImpl(node, PrecedenceGroupDeclSyntax.self, visit)
+      return visitImpl(&node, PrecedenceGroupDeclSyntax.self, visit)
     case .precedenceGroupNameList:
-      return visitImpl(node, PrecedenceGroupNameListSyntax.self, visit)
+      return visitImpl(&node, PrecedenceGroupNameListSyntax.self, visit)
     case .precedenceGroupName:
-      return visitImpl(node, PrecedenceGroupNameSyntax.self, visit)
+      return visitImpl(&node, PrecedenceGroupNameSyntax.self, visit)
     case .precedenceGroupRelation:
-      return visitImpl(node, PrecedenceGroupRelationSyntax.self, visit)
+      return visitImpl(&node, PrecedenceGroupRelationSyntax.self, visit)
     case .prefixOperatorExpr:
-      return visitImpl(node, PrefixOperatorExprSyntax.self, visit)
+      return visitImpl(&node, PrefixOperatorExprSyntax.self, visit)
     case .primaryAssociatedTypeClause:
-      return visitImpl(node, PrimaryAssociatedTypeClauseSyntax.self, visit)
+      return visitImpl(&node, PrimaryAssociatedTypeClauseSyntax.self, visit)
     case .primaryAssociatedTypeList:
-      return visitImpl(node, PrimaryAssociatedTypeListSyntax.self, visit)
+      return visitImpl(&node, PrimaryAssociatedTypeListSyntax.self, visit)
     case .primaryAssociatedType:
-      return visitImpl(node, PrimaryAssociatedTypeSyntax.self, visit)
+      return visitImpl(&node, PrimaryAssociatedTypeSyntax.self, visit)
     case .protocolDecl:
-      return visitImpl(node, ProtocolDeclSyntax.self, visit)
+      return visitImpl(&node, ProtocolDeclSyntax.self, visit)
     case .regexLiteralExpr:
-      return visitImpl(node, RegexLiteralExprSyntax.self, visit)
+      return visitImpl(&node, RegexLiteralExprSyntax.self, visit)
     case .repeatStmt:
-      return visitImpl(node, RepeatStmtSyntax.self, visit)
+      return visitImpl(&node, RepeatStmtSyntax.self, visit)
     case .returnClause:
-      return visitImpl(node, ReturnClauseSyntax.self, visit)
+      return visitImpl(&node, ReturnClauseSyntax.self, visit)
     case .returnStmt:
-      return visitImpl(node, ReturnStmtSyntax.self, visit)
+      return visitImpl(&node, ReturnStmtSyntax.self, visit)
     case .sameTypeRequirement:
-      return visitImpl(node, SameTypeRequirementSyntax.self, visit)
+      return visitImpl(&node, SameTypeRequirementSyntax.self, visit)
     case .sequenceExpr:
-      return visitImpl(node, SequenceExprSyntax.self, visit)
+      return visitImpl(&node, SequenceExprSyntax.self, visit)
     case .simpleStringLiteralExpr:
-      return visitImpl(node, SimpleStringLiteralExprSyntax.self, visit)
+      return visitImpl(&node, SimpleStringLiteralExprSyntax.self, visit)
     case .simpleStringLiteralSegmentList:
-      return visitImpl(node, SimpleStringLiteralSegmentListSyntax.self, visit)
+      return visitImpl(&node, SimpleStringLiteralSegmentListSyntax.self, visit)
     case .simpleTypeSpecifier:
-      return visitImpl(node, SimpleTypeSpecifierSyntax.self, visit)
+      return visitImpl(&node, SimpleTypeSpecifierSyntax.self, visit)
     case .someOrAnyType:
-      return visitImpl(node, SomeOrAnyTypeSyntax.self, visit)
+      return visitImpl(&node, SomeOrAnyTypeSyntax.self, visit)
     case .sourceFile:
-      return visitImpl(node, SourceFileSyntax.self, visit)
+      return visitImpl(&node, SourceFileSyntax.self, visit)
     case .specializeAttributeArgumentList:
-      return visitImpl(node, SpecializeAttributeArgumentListSyntax.self, visit)
+      return visitImpl(&node, SpecializeAttributeArgumentListSyntax.self, visit)
     case .specializeAvailabilityArgument:
-      return visitImpl(node, SpecializeAvailabilityArgumentSyntax.self, visit)
+      return visitImpl(&node, SpecializeAvailabilityArgumentSyntax.self, visit)
     case .specializeTargetFunctionArgument:
-      return visitImpl(node, SpecializeTargetFunctionArgumentSyntax.self, visit)
+      return visitImpl(&node, SpecializeTargetFunctionArgumentSyntax.self, visit)
     case .stringLiteralExpr:
-      return visitImpl(node, StringLiteralExprSyntax.self, visit)
+      return visitImpl(&node, StringLiteralExprSyntax.self, visit)
     case .stringLiteralSegmentList:
-      return visitImpl(node, StringLiteralSegmentListSyntax.self, visit)
+      return visitImpl(&node, StringLiteralSegmentListSyntax.self, visit)
     case .stringSegment:
-      return visitImpl(node, StringSegmentSyntax.self, visit)
+      return visitImpl(&node, StringSegmentSyntax.self, visit)
     case .structDecl:
-      return visitImpl(node, StructDeclSyntax.self, visit)
+      return visitImpl(&node, StructDeclSyntax.self, visit)
     case .subscriptCallExpr:
-      return visitImpl(node, SubscriptCallExprSyntax.self, visit)
+      return visitImpl(&node, SubscriptCallExprSyntax.self, visit)
     case .subscriptDecl:
-      return visitImpl(node, SubscriptDeclSyntax.self, visit)
+      return visitImpl(&node, SubscriptDeclSyntax.self, visit)
     case .superExpr:
-      return visitImpl(node, SuperExprSyntax.self, visit)
+      return visitImpl(&node, SuperExprSyntax.self, visit)
     case .suppressedType:
-      return visitImpl(node, SuppressedTypeSyntax.self, visit)
+      return visitImpl(&node, SuppressedTypeSyntax.self, visit)
     case .switchCaseItemList:
-      return visitImpl(node, SwitchCaseItemListSyntax.self, visit)
+      return visitImpl(&node, SwitchCaseItemListSyntax.self, visit)
     case .switchCaseItem:
-      return visitImpl(node, SwitchCaseItemSyntax.self, visit)
+      return visitImpl(&node, SwitchCaseItemSyntax.self, visit)
     case .switchCaseLabel:
-      return visitImpl(node, SwitchCaseLabelSyntax.self, visit)
+      return visitImpl(&node, SwitchCaseLabelSyntax.self, visit)
     case .switchCaseList:
-      return visitImpl(node, SwitchCaseListSyntax.self, visit)
+      return visitImpl(&node, SwitchCaseListSyntax.self, visit)
     case .switchCase:
-      return visitImpl(node, SwitchCaseSyntax.self, visit)
+      return visitImpl(&node, SwitchCaseSyntax.self, visit)
     case .switchDefaultLabel:
-      return visitImpl(node, SwitchDefaultLabelSyntax.self, visit)
+      return visitImpl(&node, SwitchDefaultLabelSyntax.self, visit)
     case .switchExpr:
-      return visitImpl(node, SwitchExprSyntax.self, visit)
+      return visitImpl(&node, SwitchExprSyntax.self, visit)
     case .ternaryExpr:
-      return visitImpl(node, TernaryExprSyntax.self, visit)
+      return visitImpl(&node, TernaryExprSyntax.self, visit)
     case .thenStmt:
-      return visitImpl(node, ThenStmtSyntax.self, visit)
+      return visitImpl(&node, ThenStmtSyntax.self, visit)
     case .throwStmt:
-      return visitImpl(node, ThrowStmtSyntax.self, visit)
+      return visitImpl(&node, ThrowStmtSyntax.self, visit)
     case .throwsClause:
-      return visitImpl(node, ThrowsClauseSyntax.self, visit)
+      return visitImpl(&node, ThrowsClauseSyntax.self, visit)
     case .tryExpr:
-      return visitImpl(node, TryExprSyntax.self, visit)
+      return visitImpl(&node, TryExprSyntax.self, visit)
     case .tupleExpr:
-      return visitImpl(node, TupleExprSyntax.self, visit)
+      return visitImpl(&node, TupleExprSyntax.self, visit)
     case .tuplePatternElementList:
-      return visitImpl(node, TuplePatternElementListSyntax.self, visit)
+      return visitImpl(&node, TuplePatternElementListSyntax.self, visit)
     case .tuplePatternElement:
-      return visitImpl(node, TuplePatternElementSyntax.self, visit)
+      return visitImpl(&node, TuplePatternElementSyntax.self, visit)
     case .tuplePattern:
-      return visitImpl(node, TuplePatternSyntax.self, visit)
+      return visitImpl(&node, TuplePatternSyntax.self, visit)
     case .tupleTypeElementList:
-      return visitImpl(node, TupleTypeElementListSyntax.self, visit)
+      return visitImpl(&node, TupleTypeElementListSyntax.self, visit)
     case .tupleTypeElement:
-      return visitImpl(node, TupleTypeElementSyntax.self, visit)
+      return visitImpl(&node, TupleTypeElementSyntax.self, visit)
     case .tupleType:
-      return visitImpl(node, TupleTypeSyntax.self, visit)
+      return visitImpl(&node, TupleTypeSyntax.self, visit)
     case .typeAliasDecl:
-      return visitImpl(node, TypeAliasDeclSyntax.self, visit)
+      return visitImpl(&node, TypeAliasDeclSyntax.self, visit)
     case .typeAnnotation:
-      return visitImpl(node, TypeAnnotationSyntax.self, visit)
+      return visitImpl(&node, TypeAnnotationSyntax.self, visit)
     case .typeEffectSpecifiers:
-      return visitImpl(node, TypeEffectSpecifiersSyntax.self, visit)
+      return visitImpl(&node, TypeEffectSpecifiersSyntax.self, visit)
     case .typeExpr:
-      return visitImpl(node, TypeExprSyntax.self, visit)
+      return visitImpl(&node, TypeExprSyntax.self, visit)
     case .typeInitializerClause:
-      return visitImpl(node, TypeInitializerClauseSyntax.self, visit)
+      return visitImpl(&node, TypeInitializerClauseSyntax.self, visit)
     case .typeSpecifierList:
-      return visitImpl(node, TypeSpecifierListSyntax.self, visit)
+      return visitImpl(&node, TypeSpecifierListSyntax.self, visit)
     case .unavailableFromAsyncAttributeArguments:
-      return visitImpl(node, UnavailableFromAsyncAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, UnavailableFromAsyncAttributeArgumentsSyntax.self, visit)
     case .underscorePrivateAttributeArguments:
-      return visitImpl(node, UnderscorePrivateAttributeArgumentsSyntax.self, visit)
+      return visitImpl(&node, UnderscorePrivateAttributeArgumentsSyntax.self, visit)
     case .unexpectedNodes:
-      return visitImpl(node, UnexpectedNodesSyntax.self, visit)
+      return visitImpl(&node, UnexpectedNodesSyntax.self, visit)
     case .unresolvedAsExpr:
-      return visitImpl(node, UnresolvedAsExprSyntax.self, visit)
+      return visitImpl(&node, UnresolvedAsExprSyntax.self, visit)
     case .unresolvedIsExpr:
-      return visitImpl(node, UnresolvedIsExprSyntax.self, visit)
+      return visitImpl(&node, UnresolvedIsExprSyntax.self, visit)
     case .unresolvedTernaryExpr:
-      return visitImpl(node, UnresolvedTernaryExprSyntax.self, visit)
+      return visitImpl(&node, UnresolvedTernaryExprSyntax.self, visit)
     case .valueBindingPattern:
-      return visitImpl(node, ValueBindingPatternSyntax.self, visit)
+      return visitImpl(&node, ValueBindingPatternSyntax.self, visit)
     case .variableDecl:
-      return visitImpl(node, VariableDeclSyntax.self, visit)
+      return visitImpl(&node, VariableDeclSyntax.self, visit)
     case .versionComponentList:
-      return visitImpl(node, VersionComponentListSyntax.self, visit)
+      return visitImpl(&node, VersionComponentListSyntax.self, visit)
     case .versionComponent:
-      return visitImpl(node, VersionComponentSyntax.self, visit)
+      return visitImpl(&node, VersionComponentSyntax.self, visit)
     case .versionTuple:
-      return visitImpl(node, VersionTupleSyntax.self, visit)
+      return visitImpl(&node, VersionTupleSyntax.self, visit)
     case .whereClause:
-      return visitImpl(node, WhereClauseSyntax.self, visit)
+      return visitImpl(&node, WhereClauseSyntax.self, visit)
     case .whileStmt:
-      return visitImpl(node, WhileStmtSyntax.self, visit)
+      return visitImpl(&node, WhileStmtSyntax.self, visit)
     case .wildcardPattern:
-      return visitImpl(node, WildcardPatternSyntax.self, visit)
+      return visitImpl(&node, WildcardPatternSyntax.self, visit)
     case .yieldStmt:
-      return visitImpl(node, YieldStmtSyntax.self, visit)
+      return visitImpl(&node, YieldStmtSyntax.self, visit)
     case .yieldedExpressionList:
-      return visitImpl(node, YieldedExpressionListSyntax.self, visit)
+      return visitImpl(&node, YieldedExpressionListSyntax.self, visit)
     case .yieldedExpression:
-      return visitImpl(node, YieldedExpressionSyntax.self, visit)
+      return visitImpl(&node, YieldedExpressionSyntax.self, visit)
     case .yieldedExpressionsClause:
-      return visitImpl(node, YieldedExpressionsClauseSyntax.self, visit)
+      return visitImpl(&node, YieldedExpressionsClauseSyntax.self, visit)
     }
   }
   #endif
@@ -3886,9 +3912,9 @@ open class SyntaxRewriter {
     // nodes are being collected.
     var newLayout: ContiguousArray<RawSyntax?>?
 
-    // Rewritten children just to keep their 'SyntaxArena' alive until they are
-    // wrapped with 'Syntax'
-    var rewrittens: ContiguousArray<Syntax> = []
+    // Keep 'SyntaxArena' of rewritten nodes alive until they are wrapped
+    // with 'Syntax'
+    var rewrittens: ContiguousArray<RetainedSyntaxArena> = []
 
     let syntaxNode = node._syntaxNode
 
@@ -3910,10 +3936,18 @@ open class SyntaxRewriter {
       }
 
       // Build the Syntax node to rewrite
-      let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
+      var childNode: Syntax
+      if !recyclableNodeInfos.isEmpty {
+        let recycledInfo: Syntax.Info = recyclableNodeInfos.removeLast()!
+        recycledInfo.info = .nonRoot(.init(parent: Syntax(node), absoluteInfo: info))
+        childNode = Syntax(child, info: recycledInfo)
+      } else {
+        let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
+        childNode = Syntax(absoluteRaw, parent: syntaxNode)
+      }
 
-      let rewritten = dispatchVisit(Syntax(absoluteRaw, parent: syntaxNode))
-      if rewritten.id != info.nodeId {
+      dispatchVisit(&childNode)
+      if childNode.raw.id != child.id {
         // The node was rewritten, let's handle it
         if newLayout == nil {
           // We have not yet collected any previous rewritten nodes. Initialize
@@ -3931,14 +3965,23 @@ open class SyntaxRewriter {
 
         // Now that we know we have a new layout in which we collect rewritten
         // nodes, add it.
-        rewrittens.append(rewritten)
-        newLayout!.append(rewritten.raw)
+        rewrittens.append(childNode.raw.arenaReference.retained)
+        newLayout!.append(childNode.raw)
       } else {
         // The node was not changed by the rewriter. Only store it if a previous
         // node has been rewritten and we are collecting a rewritten layout.
         if newLayout != nil {
           newLayout!.append(raw)
         }
+      }
+
+      if recyclableNodeInfos.capacity > recyclableNodeInfos.count,
+         isKnownUniquelyReferenced(&childNode.info) {
+        var info: Syntax.Info! = nil
+        // 'swap' to avoid ref-counting traffic.
+        swap(&childNode.info, &info)
+        info.info = nil
+        recyclableNodeInfos.append(info)
       }
     }
 

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -92,588 +92,588 @@ open class SyntaxRewriter {
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorBlockSyntax) -> AccessorBlockSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AccessorBlockSyntax.self) ?? node
   }
   
   /// Visit a ``AccessorDeclListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorDeclListSyntax) -> AccessorDeclListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AccessorDeclListSyntax.self) ?? node
   }
   
   /// Visit a ``AccessorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(AccessorDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``AccessorEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorEffectSpecifiersSyntax) -> AccessorEffectSpecifiersSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AccessorEffectSpecifiersSyntax.self) ?? node
   }
   
   /// Visit a ``AccessorParametersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorParametersSyntax) -> AccessorParametersSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AccessorParametersSyntax.self) ?? node
   }
   
   /// Visit a ``ActorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ActorDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``ArrayElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayElementListSyntax) -> ArrayElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ArrayElementListSyntax.self) ?? node
   }
   
   /// Visit a ``ArrayElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayElementSyntax) -> ArrayElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ArrayElementSyntax.self) ?? node
   }
   
   /// Visit a ``ArrayExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ArrayExprSyntax.self) ?? node)
   }
   
   /// Visit a ``ArrayTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(ArrayTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``ArrowExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrowExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ArrowExprSyntax.self) ?? node)
   }
   
   /// Visit a ``AsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(AsExprSyntax.self) ?? node)
   }
   
   /// Visit a ``AssignmentExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AssignmentExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(AssignmentExprSyntax.self) ?? node)
   }
   
   /// Visit a ``AssociatedTypeDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AssociatedTypeDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(AssociatedTypeDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``AttributeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributeListSyntax) -> AttributeListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AttributeListSyntax.self) ?? node
   }
   
   /// Visit a ``AttributeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributeSyntax) -> AttributeSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AttributeSyntax.self) ?? node
   }
   
   /// Visit a ``AttributedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributedTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(AttributedTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``AvailabilityArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityArgumentListSyntax) -> AvailabilityArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AvailabilityArgumentListSyntax.self) ?? node
   }
   
   /// Visit a ``AvailabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityArgumentSyntax) -> AvailabilityArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AvailabilityArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``AvailabilityConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityConditionSyntax) -> AvailabilityConditionSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AvailabilityConditionSyntax.self) ?? node
   }
   
   /// Visit a ``AvailabilityLabeledArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityLabeledArgumentSyntax) -> AvailabilityLabeledArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(AvailabilityLabeledArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``AwaitExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AwaitExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(AwaitExprSyntax.self) ?? node)
   }
   
   /// Visit a ``BackDeployedAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BackDeployedAttributeArgumentsSyntax) -> BackDeployedAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(BackDeployedAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``BinaryOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BinaryOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(BinaryOperatorExprSyntax.self) ?? node)
   }
   
   /// Visit a ``BooleanLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BooleanLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(BooleanLiteralExprSyntax.self) ?? node)
   }
   
   /// Visit a ``BorrowExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BorrowExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(BorrowExprSyntax.self) ?? node)
   }
   
   /// Visit a ``BreakStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BreakStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(BreakStmtSyntax.self) ?? node)
   }
   
   /// Visit a `_CanImportExprSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: _CanImportExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(_CanImportExprSyntax.self) ?? node)
   }
   
   /// Visit a `_CanImportVersionInfoSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: _CanImportVersionInfoSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(_CanImportVersionInfoSyntax.self) ?? node)
   }
   
   /// Visit a ``CatchClauseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchClauseListSyntax) -> CatchClauseListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CatchClauseListSyntax.self) ?? node
   }
   
   /// Visit a ``CatchClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchClauseSyntax) -> CatchClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CatchClauseSyntax.self) ?? node
   }
   
   /// Visit a ``CatchItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchItemListSyntax) -> CatchItemListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CatchItemListSyntax.self) ?? node
   }
   
   /// Visit a ``CatchItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchItemSyntax) -> CatchItemSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CatchItemSyntax.self) ?? node
   }
   
   /// Visit a ``ClassDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ClassDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``ClassRestrictionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClassRestrictionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(ClassRestrictionTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``ClosureCaptureClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureClauseSyntax) -> ClosureCaptureClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureClauseSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureCaptureListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureListSyntax) -> ClosureCaptureListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureListSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureCaptureSpecifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureSpecifierSyntax) -> ClosureCaptureSpecifierSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureSpecifierSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureCaptureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureSyntax) -> ClosureCaptureSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ClosureExprSyntax.self) ?? node)
   }
   
   /// Visit a ``ClosureParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterClauseSyntax) -> ClosureParameterClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureParameterClauseSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterListSyntax) -> ClosureParameterListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureParameterListSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterSyntax) -> ClosureParameterSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureParameterSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureShorthandParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureShorthandParameterListSyntax) -> ClosureShorthandParameterListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureShorthandParameterListSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureShorthandParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureShorthandParameterSyntax) -> ClosureShorthandParameterSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureShorthandParameterSyntax.self) ?? node
   }
   
   /// Visit a ``ClosureSignatureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ClosureSignatureSyntax.self) ?? node
   }
   
   /// Visit a ``CodeBlockItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CodeBlockItemListSyntax.self) ?? node
   }
   
   /// Visit a ``CodeBlockItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockItemSyntax) -> CodeBlockItemSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CodeBlockItemSyntax.self) ?? node
   }
   
   /// Visit a ``CodeBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockSyntax) -> CodeBlockSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CodeBlockSyntax.self) ?? node
   }
   
   /// Visit a ``CompositionTypeElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeElementListSyntax) -> CompositionTypeElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CompositionTypeElementListSyntax.self) ?? node
   }
   
   /// Visit a ``CompositionTypeElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeElementSyntax) -> CompositionTypeElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(CompositionTypeElementSyntax.self) ?? node
   }
   
   /// Visit a ``CompositionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(CompositionTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``ConditionElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConditionElementListSyntax) -> ConditionElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ConditionElementListSyntax.self) ?? node
   }
   
   /// Visit a ``ConditionElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConditionElementSyntax) -> ConditionElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ConditionElementSyntax.self) ?? node
   }
   
   /// Visit a ``ConformanceRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConformanceRequirementSyntax) -> ConformanceRequirementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ConformanceRequirementSyntax.self) ?? node
   }
   
   /// Visit a ``ConsumeExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConsumeExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ConsumeExprSyntax.self) ?? node)
   }
   
   /// Visit a ``ContinueStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ContinueStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ContinueStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``ConventionAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConventionAttributeArgumentsSyntax) -> ConventionAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ConventionAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``ConventionWitnessMethodAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ConventionWitnessMethodAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``CopyExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CopyExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(CopyExprSyntax.self) ?? node)
   }
   
   /// Visit a ``DeclModifierDetailSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierDetailSyntax) -> DeclModifierDetailSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DeclModifierDetailSyntax.self) ?? node
   }
   
   /// Visit a ``DeclModifierListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierListSyntax) -> DeclModifierListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DeclModifierListSyntax.self) ?? node
   }
   
   /// Visit a ``DeclModifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierSyntax) -> DeclModifierSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DeclModifierSyntax.self) ?? node
   }
   
   /// Visit a ``DeclNameArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentListSyntax) -> DeclNameArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DeclNameArgumentListSyntax.self) ?? node
   }
   
   /// Visit a ``DeclNameArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentSyntax) -> DeclNameArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DeclNameArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``DeclNameArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentsSyntax) -> DeclNameArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DeclNameArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``DeclReferenceExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DeclReferenceExprSyntax.self) ?? node)
   }
   
   /// Visit a ``DeferStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeferStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(DeferStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``DeinitializerDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeinitializerDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(DeinitializerDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``DeinitializerEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeinitializerEffectSpecifiersSyntax) -> DeinitializerEffectSpecifiersSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DeinitializerEffectSpecifiersSyntax.self) ?? node
   }
   
   /// Visit a ``DerivativeAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DerivativeAttributeArgumentsSyntax) -> DerivativeAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DerivativeAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``DesignatedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DesignatedTypeListSyntax) -> DesignatedTypeListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DesignatedTypeListSyntax.self) ?? node
   }
   
   /// Visit a ``DesignatedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DesignatedTypeSyntax) -> DesignatedTypeSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DesignatedTypeSyntax.self) ?? node
   }
   
   /// Visit a ``DictionaryElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryElementListSyntax) -> DictionaryElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DictionaryElementListSyntax.self) ?? node
   }
   
   /// Visit a ``DictionaryElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryElementSyntax) -> DictionaryElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DictionaryElementSyntax.self) ?? node
   }
   
   /// Visit a ``DictionaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DictionaryExprSyntax.self) ?? node)
   }
   
   /// Visit a ``DictionaryTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(DictionaryTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``DifferentiabilityArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentListSyntax) -> DifferentiabilityArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityArgumentListSyntax.self) ?? node
   }
   
   /// Visit a ``DifferentiabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentSyntax) -> DifferentiabilityArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``DifferentiabilityArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentsSyntax) -> DifferentiabilityArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``DifferentiabilityWithRespectToArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityWithRespectToArgumentSyntax) -> DifferentiabilityWithRespectToArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityWithRespectToArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``DifferentiableAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiableAttributeArgumentsSyntax) -> DifferentiableAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DifferentiableAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``DiscardAssignmentExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DiscardAssignmentExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DiscardAssignmentExprSyntax.self) ?? node)
   }
   
   /// Visit a ``DiscardStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DiscardStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(DiscardStmtSyntax.self) ?? node)
   }
   
   /// Visit a `DoExprSyntax`.
@@ -683,532 +683,532 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: DoExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DoExprSyntax.self) ?? node)
   }
   
   /// Visit a ``DoStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DoStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(DoStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``DocumentationAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DocumentationAttributeArgumentListSyntax) -> DocumentationAttributeArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DocumentationAttributeArgumentListSyntax.self) ?? node
   }
   
   /// Visit a ``DocumentationAttributeArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DocumentationAttributeArgumentSyntax) -> DocumentationAttributeArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DocumentationAttributeArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``DynamicReplacementAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DynamicReplacementAttributeArgumentsSyntax) -> DynamicReplacementAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(DynamicReplacementAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``EditorPlaceholderDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EditorPlaceholderDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(EditorPlaceholderDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``EditorPlaceholderExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EditorPlaceholderExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(EditorPlaceholderExprSyntax.self) ?? node)
   }
   
   /// Visit a ``EffectsAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EffectsAttributeArgumentListSyntax) -> EffectsAttributeArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(EffectsAttributeArgumentListSyntax.self) ?? node
   }
   
   /// Visit a ``EnumCaseDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(EnumCaseDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``EnumCaseElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseElementListSyntax) -> EnumCaseElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(EnumCaseElementListSyntax.self) ?? node
   }
   
   /// Visit a ``EnumCaseElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseElementSyntax) -> EnumCaseElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(EnumCaseElementSyntax.self) ?? node
   }
   
   /// Visit a ``EnumCaseParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterClauseSyntax) -> EnumCaseParameterClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(EnumCaseParameterClauseSyntax.self) ?? node
   }
   
   /// Visit a ``EnumCaseParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterListSyntax) -> EnumCaseParameterListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(EnumCaseParameterListSyntax.self) ?? node
   }
   
   /// Visit a ``EnumCaseParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterSyntax) -> EnumCaseParameterSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(EnumCaseParameterSyntax.self) ?? node
   }
   
   /// Visit a ``EnumDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(EnumDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``ExposeAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExposeAttributeArgumentsSyntax) -> ExposeAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ExposeAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``ExprListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExprListSyntax) -> ExprListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ExprListSyntax.self) ?? node
   }
   
   /// Visit a ``ExpressionPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node))
+    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(ExpressionPatternSyntax.self) ?? node)
   }
   
   /// Visit a ``ExpressionSegmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionSegmentSyntax) -> ExpressionSegmentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ExpressionSegmentSyntax.self) ?? node
   }
   
   /// Visit a ``ExpressionStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ExpressionStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``ExtensionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExtensionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ExtensionDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``FallThroughStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FallThroughStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(FallThroughStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``FloatLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FloatLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(FloatLiteralExprSyntax.self) ?? node)
   }
   
   /// Visit a ``ForStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ForStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ForStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``ForceUnwrapExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ForceUnwrapExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ForceUnwrapExprSyntax.self) ?? node)
   }
   
   /// Visit a ``FunctionCallExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(FunctionCallExprSyntax.self) ?? node)
   }
   
   /// Visit a ``FunctionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(FunctionDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``FunctionEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionEffectSpecifiersSyntax) -> FunctionEffectSpecifiersSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(FunctionEffectSpecifiersSyntax.self) ?? node
   }
   
   /// Visit a ``FunctionParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterClauseSyntax) -> FunctionParameterClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(FunctionParameterClauseSyntax.self) ?? node
   }
   
   /// Visit a ``FunctionParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterListSyntax) -> FunctionParameterListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(FunctionParameterListSyntax.self) ?? node
   }
   
   /// Visit a ``FunctionParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterSyntax) -> FunctionParameterSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(FunctionParameterSyntax.self) ?? node
   }
   
   /// Visit a ``FunctionSignatureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(FunctionSignatureSyntax.self) ?? node
   }
   
   /// Visit a ``FunctionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(FunctionTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``GenericArgumentClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentClauseSyntax) -> GenericArgumentClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericArgumentClauseSyntax.self) ?? node
   }
   
   /// Visit a ``GenericArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentListSyntax) -> GenericArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericArgumentListSyntax.self) ?? node
   }
   
   /// Visit a ``GenericArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentSyntax) -> GenericArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``GenericParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterClauseSyntax) -> GenericParameterClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericParameterClauseSyntax.self) ?? node
   }
   
   /// Visit a ``GenericParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterListSyntax) -> GenericParameterListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericParameterListSyntax.self) ?? node
   }
   
   /// Visit a ``GenericParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterSyntax) -> GenericParameterSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericParameterSyntax.self) ?? node
   }
   
   /// Visit a ``GenericRequirementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericRequirementListSyntax) -> GenericRequirementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericRequirementListSyntax.self) ?? node
   }
   
   /// Visit a ``GenericRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericRequirementSyntax) -> GenericRequirementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericRequirementSyntax.self) ?? node
   }
   
   /// Visit a ``GenericSpecializationExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericSpecializationExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(GenericSpecializationExprSyntax.self) ?? node)
   }
   
   /// Visit a ``GenericWhereClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericWhereClauseSyntax) -> GenericWhereClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(GenericWhereClauseSyntax.self) ?? node
   }
   
   /// Visit a ``GuardStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GuardStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(GuardStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``IdentifierPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IdentifierPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node))
+    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(IdentifierPatternSyntax.self) ?? node)
   }
   
   /// Visit a ``IdentifierTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(IdentifierTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``IfConfigClauseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigClauseListSyntax) -> IfConfigClauseListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(IfConfigClauseListSyntax.self) ?? node
   }
   
   /// Visit a ``IfConfigClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigClauseSyntax) -> IfConfigClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(IfConfigClauseSyntax.self) ?? node
   }
   
   /// Visit a ``IfConfigDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(IfConfigDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``IfExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(IfExprSyntax.self) ?? node)
   }
   
   /// Visit a ``ImplementsAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImplementsAttributeArgumentsSyntax) -> ImplementsAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ImplementsAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``ImplicitlyUnwrappedOptionalTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(ImplicitlyUnwrappedOptionalTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``ImportDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ImportDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``ImportPathComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportPathComponentListSyntax) -> ImportPathComponentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ImportPathComponentListSyntax.self) ?? node
   }
   
   /// Visit a ``ImportPathComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportPathComponentSyntax) -> ImportPathComponentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ImportPathComponentSyntax.self) ?? node
   }
   
   /// Visit a ``InOutExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InOutExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(InOutExprSyntax.self) ?? node)
   }
   
   /// Visit a ``InfixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InfixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(InfixOperatorExprSyntax.self) ?? node)
   }
   
   /// Visit a ``InheritanceClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritanceClauseSyntax) -> InheritanceClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(InheritanceClauseSyntax.self) ?? node
   }
   
   /// Visit a ``InheritedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritedTypeListSyntax) -> InheritedTypeListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(InheritedTypeListSyntax.self) ?? node
   }
   
   /// Visit a ``InheritedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritedTypeSyntax) -> InheritedTypeSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(InheritedTypeSyntax.self) ?? node
   }
   
   /// Visit a ``InitializerClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InitializerClauseSyntax) -> InitializerClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(InitializerClauseSyntax.self) ?? node
   }
   
   /// Visit a ``InitializerDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(InitializerDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``IntegerLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IntegerLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(IntegerLiteralExprSyntax.self) ?? node)
   }
   
   /// Visit a ``IsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(IsExprSyntax.self) ?? node)
   }
   
   /// Visit a ``IsTypePatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IsTypePatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node))
+    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(IsTypePatternSyntax.self) ?? node)
   }
   
   /// Visit a ``KeyPathComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathComponentListSyntax) -> KeyPathComponentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(KeyPathComponentListSyntax.self) ?? node
   }
   
   /// Visit a ``KeyPathComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathComponentSyntax) -> KeyPathComponentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(KeyPathComponentSyntax.self) ?? node
   }
   
   /// Visit a ``KeyPathExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(KeyPathExprSyntax.self) ?? node)
   }
   
   /// Visit a ``KeyPathOptionalComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathOptionalComponentSyntax) -> KeyPathOptionalComponentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(KeyPathOptionalComponentSyntax.self) ?? node
   }
   
   /// Visit a ``KeyPathPropertyComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathPropertyComponentSyntax) -> KeyPathPropertyComponentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(KeyPathPropertyComponentSyntax.self) ?? node
   }
   
   /// Visit a ``KeyPathSubscriptComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathSubscriptComponentSyntax) -> KeyPathSubscriptComponentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(KeyPathSubscriptComponentSyntax.self) ?? node
   }
   
   /// Visit a ``LabeledExprListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledExprListSyntax) -> LabeledExprListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(LabeledExprListSyntax.self) ?? node
   }
   
   /// Visit a ``LabeledExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledExprSyntax) -> LabeledExprSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(LabeledExprSyntax.self) ?? node
   }
   
   /// Visit a ``LabeledSpecializeArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledSpecializeArgumentSyntax) -> LabeledSpecializeArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(LabeledSpecializeArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``LabeledStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(LabeledStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``LayoutRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LayoutRequirementSyntax) -> LayoutRequirementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(LayoutRequirementSyntax.self) ?? node
   }
   
   /// Visit a `LifetimeSpecifierArgumentListSyntax`.
@@ -1218,7 +1218,7 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeSpecifierArgumentListSyntax) -> LifetimeSpecifierArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(LifetimeSpecifierArgumentListSyntax.self) ?? node
   }
   
   /// Visit a `LifetimeSpecifierArgumentSyntax`.
@@ -1228,7 +1228,7 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeSpecifierArgumentSyntax) -> LifetimeSpecifierArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(LifetimeSpecifierArgumentSyntax.self) ?? node
   }
   
   /// Visit a `LifetimeTypeSpecifierSyntax`.
@@ -1238,602 +1238,602 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeTypeSpecifierSyntax) -> LifetimeTypeSpecifierSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(LifetimeTypeSpecifierSyntax.self) ?? node
   }
   
   /// Visit a ``MacroDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(MacroDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``MacroExpansionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroExpansionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(MacroExpansionDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``MacroExpansionExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroExpansionExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(MacroExpansionExprSyntax.self) ?? node)
   }
   
   /// Visit a ``MatchingPatternConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MatchingPatternConditionSyntax) -> MatchingPatternConditionSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(MatchingPatternConditionSyntax.self) ?? node
   }
   
   /// Visit a ``MemberAccessExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(MemberAccessExprSyntax.self) ?? node)
   }
   
   /// Visit a ``MemberBlockItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockItemListSyntax) -> MemberBlockItemListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(MemberBlockItemListSyntax.self) ?? node
   }
   
   /// Visit a ``MemberBlockItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockItemSyntax) -> MemberBlockItemSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(MemberBlockItemSyntax.self) ?? node
   }
   
   /// Visit a ``MemberBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockSyntax) -> MemberBlockSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(MemberBlockSyntax.self) ?? node
   }
   
   /// Visit a ``MemberTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(MemberTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``MetatypeTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MetatypeTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(MetatypeTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``MissingDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(MissingDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``MissingExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(MissingExprSyntax.self) ?? node)
   }
   
   /// Visit a ``MissingPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node))
+    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(MissingPatternSyntax.self) ?? node)
   }
   
   /// Visit a ``MissingStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(MissingStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``MissingSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingSyntax) -> Syntax {
-    return Syntax(visitChildren(node))
+    return Syntax(visitChildren(node._syntaxNode)?.cast(MissingSyntax.self) ?? node)
   }
   
   /// Visit a ``MissingTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(MissingTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``MultipleTrailingClosureElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MultipleTrailingClosureElementListSyntax) -> MultipleTrailingClosureElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(MultipleTrailingClosureElementListSyntax.self) ?? node
   }
   
   /// Visit a ``MultipleTrailingClosureElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MultipleTrailingClosureElementSyntax) -> MultipleTrailingClosureElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(MultipleTrailingClosureElementSyntax.self) ?? node
   }
   
   /// Visit a ``NamedOpaqueReturnTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: NamedOpaqueReturnTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(NamedOpaqueReturnTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``NilLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: NilLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(NilLiteralExprSyntax.self) ?? node)
   }
   
   /// Visit a ``ObjCSelectorPieceListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ObjCSelectorPieceListSyntax) -> ObjCSelectorPieceListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ObjCSelectorPieceListSyntax.self) ?? node
   }
   
   /// Visit a ``ObjCSelectorPieceSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ObjCSelectorPieceSyntax) -> ObjCSelectorPieceSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ObjCSelectorPieceSyntax.self) ?? node
   }
   
   /// Visit a ``OpaqueReturnTypeOfAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(OpaqueReturnTypeOfAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``OperatorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OperatorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(OperatorDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``OperatorPrecedenceAndTypesSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OperatorPrecedenceAndTypesSyntax) -> OperatorPrecedenceAndTypesSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(OperatorPrecedenceAndTypesSyntax.self) ?? node
   }
   
   /// Visit a ``OptionalBindingConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalBindingConditionSyntax) -> OptionalBindingConditionSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(OptionalBindingConditionSyntax.self) ?? node
   }
   
   /// Visit a ``OptionalChainingExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalChainingExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(OptionalChainingExprSyntax.self) ?? node)
   }
   
   /// Visit a ``OptionalTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(OptionalTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``OriginallyDefinedInAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> OriginallyDefinedInAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(OriginallyDefinedInAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``PackElementExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackElementExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PackElementExprSyntax.self) ?? node)
   }
   
   /// Visit a ``PackElementTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackElementTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(PackElementTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``PackExpansionExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackExpansionExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PackExpansionExprSyntax.self) ?? node)
   }
   
   /// Visit a ``PackExpansionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackExpansionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(PackExpansionTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``PatternBindingListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternBindingListSyntax) -> PatternBindingListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PatternBindingListSyntax.self) ?? node
   }
   
   /// Visit a ``PatternBindingSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PatternBindingSyntax.self) ?? node
   }
   
   /// Visit a ``PatternExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PatternExprSyntax.self) ?? node)
   }
   
   /// Visit a ``PlatformVersionItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionItemListSyntax) -> PlatformVersionItemListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PlatformVersionItemListSyntax.self) ?? node
   }
   
   /// Visit a ``PlatformVersionItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionItemSyntax) -> PlatformVersionItemSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PlatformVersionItemSyntax.self) ?? node
   }
   
   /// Visit a ``PlatformVersionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionSyntax) -> PlatformVersionSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PlatformVersionSyntax.self) ?? node
   }
   
   /// Visit a ``PostfixIfConfigExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PostfixIfConfigExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PostfixIfConfigExprSyntax.self) ?? node)
   }
   
   /// Visit a ``PostfixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PostfixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PostfixOperatorExprSyntax.self) ?? node)
   }
   
   /// Visit a ``PoundSourceLocationArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PoundSourceLocationArgumentsSyntax) -> PoundSourceLocationArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PoundSourceLocationArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``PoundSourceLocationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PoundSourceLocationSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(PoundSourceLocationSyntax.self) ?? node)
   }
   
   /// Visit a ``PrecedenceGroupAssignmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAssignmentSyntax) -> PrecedenceGroupAssignmentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupAssignmentSyntax.self) ?? node
   }
   
   /// Visit a ``PrecedenceGroupAssociativitySyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAssociativitySyntax) -> PrecedenceGroupAssociativitySyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupAssociativitySyntax.self) ?? node
   }
   
   /// Visit a ``PrecedenceGroupAttributeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAttributeListSyntax) -> PrecedenceGroupAttributeListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupAttributeListSyntax.self) ?? node
   }
   
   /// Visit a ``PrecedenceGroupDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(PrecedenceGroupDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``PrecedenceGroupNameListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupNameListSyntax) -> PrecedenceGroupNameListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupNameListSyntax.self) ?? node
   }
   
   /// Visit a ``PrecedenceGroupNameSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupNameSyntax) -> PrecedenceGroupNameSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupNameSyntax.self) ?? node
   }
   
   /// Visit a ``PrecedenceGroupRelationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupRelationSyntax) -> PrecedenceGroupRelationSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupRelationSyntax.self) ?? node
   }
   
   /// Visit a ``PrefixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrefixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PrefixOperatorExprSyntax.self) ?? node)
   }
   
   /// Visit a ``PrimaryAssociatedTypeClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeClauseSyntax) -> PrimaryAssociatedTypeClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrimaryAssociatedTypeClauseSyntax.self) ?? node
   }
   
   /// Visit a ``PrimaryAssociatedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeListSyntax) -> PrimaryAssociatedTypeListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrimaryAssociatedTypeListSyntax.self) ?? node
   }
   
   /// Visit a ``PrimaryAssociatedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(PrimaryAssociatedTypeSyntax.self) ?? node
   }
   
   /// Visit a ``ProtocolDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ProtocolDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``RegexLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: RegexLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(RegexLiteralExprSyntax.self) ?? node)
   }
   
   /// Visit a ``RepeatStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: RepeatStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(RepeatStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``ReturnClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ReturnClauseSyntax) -> ReturnClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ReturnClauseSyntax.self) ?? node
   }
   
   /// Visit a ``ReturnStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ReturnStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ReturnStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``SameTypeRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SameTypeRequirementSyntax) -> SameTypeRequirementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SameTypeRequirementSyntax.self) ?? node
   }
   
   /// Visit a ``SequenceExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SequenceExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SequenceExprSyntax.self) ?? node)
   }
   
   /// Visit a ``SimpleStringLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleStringLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SimpleStringLiteralExprSyntax.self) ?? node)
   }
   
   /// Visit a ``SimpleStringLiteralSegmentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleStringLiteralSegmentListSyntax) -> SimpleStringLiteralSegmentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SimpleStringLiteralSegmentListSyntax.self) ?? node
   }
   
   /// Visit a ``SimpleTypeSpecifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleTypeSpecifierSyntax) -> SimpleTypeSpecifierSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SimpleTypeSpecifierSyntax.self) ?? node
   }
   
   /// Visit a ``SomeOrAnyTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SomeOrAnyTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(SomeOrAnyTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``SourceFileSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SourceFileSyntax) -> SourceFileSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SourceFileSyntax.self) ?? node
   }
   
   /// Visit a ``SpecializeAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeAttributeArgumentListSyntax) -> SpecializeAttributeArgumentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SpecializeAttributeArgumentListSyntax.self) ?? node
   }
   
   /// Visit a ``SpecializeAvailabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeAvailabilityArgumentSyntax) -> SpecializeAvailabilityArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SpecializeAvailabilityArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``SpecializeTargetFunctionArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeTargetFunctionArgumentSyntax) -> SpecializeTargetFunctionArgumentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SpecializeTargetFunctionArgumentSyntax.self) ?? node
   }
   
   /// Visit a ``StringLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(StringLiteralExprSyntax.self) ?? node)
   }
   
   /// Visit a ``StringLiteralSegmentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringLiteralSegmentListSyntax) -> StringLiteralSegmentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(StringLiteralSegmentListSyntax.self) ?? node
   }
   
   /// Visit a ``StringSegmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringSegmentSyntax) -> StringSegmentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(StringSegmentSyntax.self) ?? node
   }
   
   /// Visit a ``StructDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StructDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(StructDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``SubscriptCallExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SubscriptCallExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SubscriptCallExprSyntax.self) ?? node)
   }
   
   /// Visit a ``SubscriptDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(SubscriptDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``SuperExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SuperExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SuperExprSyntax.self) ?? node)
   }
   
   /// Visit a ``SuppressedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SuppressedTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(SuppressedTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``SwitchCaseItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseItemListSyntax) -> SwitchCaseItemListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SwitchCaseItemListSyntax.self) ?? node
   }
   
   /// Visit a ``SwitchCaseItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseItemSyntax) -> SwitchCaseItemSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SwitchCaseItemSyntax.self) ?? node
   }
   
   /// Visit a ``SwitchCaseLabelSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseLabelSyntax) -> SwitchCaseLabelSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SwitchCaseLabelSyntax.self) ?? node
   }
   
   /// Visit a ``SwitchCaseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseListSyntax) -> SwitchCaseListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SwitchCaseListSyntax.self) ?? node
   }
   
   /// Visit a ``SwitchCaseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SwitchCaseSyntax.self) ?? node
   }
   
   /// Visit a ``SwitchDefaultLabelSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchDefaultLabelSyntax) -> SwitchDefaultLabelSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(SwitchDefaultLabelSyntax.self) ?? node
   }
   
   /// Visit a ``SwitchExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SwitchExprSyntax.self) ?? node)
   }
   
   /// Visit a ``TernaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TernaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TernaryExprSyntax.self) ?? node)
   }
   
   /// Visit a `ThenStmtSyntax`.
@@ -1843,245 +1843,245 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: ThenStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ThenStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``ThrowStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ThrowStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ThrowStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``ThrowsClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ThrowsClauseSyntax) -> ThrowsClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(ThrowsClauseSyntax.self) ?? node
   }
   
   /// Visit a ``TryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TryExprSyntax.self) ?? node)
   }
   
   /// Visit a ``TupleExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TupleExprSyntax.self) ?? node)
   }
   
   /// Visit a ``TuplePatternElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternElementListSyntax) -> TuplePatternElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TuplePatternElementListSyntax.self) ?? node
   }
   
   /// Visit a ``TuplePatternElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternElementSyntax) -> TuplePatternElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TuplePatternElementSyntax.self) ?? node
   }
   
   /// Visit a ``TuplePatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node))
+    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(TuplePatternSyntax.self) ?? node)
   }
   
   /// Visit a ``TupleTypeElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeElementListSyntax) -> TupleTypeElementListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TupleTypeElementListSyntax.self) ?? node
   }
   
   /// Visit a ``TupleTypeElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeElementSyntax) -> TupleTypeElementSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TupleTypeElementSyntax.self) ?? node
   }
   
   /// Visit a ``TupleTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node))
+    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(TupleTypeSyntax.self) ?? node)
   }
   
   /// Visit a ``TypeAliasDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeAliasDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(TypeAliasDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``TypeAnnotationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeAnnotationSyntax) -> TypeAnnotationSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TypeAnnotationSyntax.self) ?? node
   }
   
   /// Visit a ``TypeEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeEffectSpecifiersSyntax) -> TypeEffectSpecifiersSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TypeEffectSpecifiersSyntax.self) ?? node
   }
   
   /// Visit a ``TypeExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TypeExprSyntax.self) ?? node)
   }
   
   /// Visit a ``TypeInitializerClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeInitializerClauseSyntax) -> TypeInitializerClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TypeInitializerClauseSyntax.self) ?? node
   }
   
   /// Visit a ``TypeSpecifierListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeSpecifierListSyntax) -> TypeSpecifierListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(TypeSpecifierListSyntax.self) ?? node
   }
   
   /// Visit a ``UnavailableFromAsyncAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnavailableFromAsyncAttributeArgumentsSyntax) -> UnavailableFromAsyncAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(UnavailableFromAsyncAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``UnderscorePrivateAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnderscorePrivateAttributeArgumentsSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(UnderscorePrivateAttributeArgumentsSyntax.self) ?? node
   }
   
   /// Visit a ``UnexpectedNodesSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnexpectedNodesSyntax) -> UnexpectedNodesSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(UnexpectedNodesSyntax.self) ?? node
   }
   
   /// Visit a ``UnresolvedAsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedAsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(UnresolvedAsExprSyntax.self) ?? node)
   }
   
   /// Visit a ``UnresolvedIsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedIsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(UnresolvedIsExprSyntax.self) ?? node)
   }
   
   /// Visit a ``UnresolvedTernaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedTernaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
+    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(UnresolvedTernaryExprSyntax.self) ?? node)
   }
   
   /// Visit a ``ValueBindingPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ValueBindingPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node))
+    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(ValueBindingPatternSyntax.self) ?? node)
   }
   
   /// Visit a ``VariableDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node))
+    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(VariableDeclSyntax.self) ?? node)
   }
   
   /// Visit a ``VersionComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionComponentListSyntax) -> VersionComponentListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(VersionComponentListSyntax.self) ?? node
   }
   
   /// Visit a ``VersionComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionComponentSyntax) -> VersionComponentSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(VersionComponentSyntax.self) ?? node
   }
   
   /// Visit a ``VersionTupleSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionTupleSyntax) -> VersionTupleSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(VersionTupleSyntax.self) ?? node
   }
   
   /// Visit a ``WhereClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WhereClauseSyntax) -> WhereClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(WhereClauseSyntax.self) ?? node
   }
   
   /// Visit a ``WhileStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WhileStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(WhileStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``WildcardPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WildcardPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node))
+    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(WildcardPatternSyntax.self) ?? node)
   }
   
   /// Visit a ``YieldStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
+    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(YieldStmtSyntax.self) ?? node)
   }
   
   /// Visit a ``YieldedExpressionListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionListSyntax) -> YieldedExpressionListSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(YieldedExpressionListSyntax.self) ?? node
   }
   
   /// Visit a ``YieldedExpressionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionSyntax) -> YieldedExpressionSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(YieldedExpressionSyntax.self) ?? node
   }
   
   /// Visit a ``YieldedExpressionsClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionsClauseSyntax) -> YieldedExpressionsClauseSyntax {
-    return visitChildren(node)
+    return visitChildren(node._syntaxNode)?.cast(YieldedExpressionsClauseSyntax.self) ?? node
   }
   
   /// Visit any DeclSyntax node.
@@ -3885,9 +3885,7 @@ open class SyntaxRewriter {
   }
   #endif
   
-  private func visitChildren<SyntaxType: SyntaxProtocol>(
-    _ node: SyntaxType
-  ) -> SyntaxType {
+  private func visitChildren(_ node: Syntax) -> Syntax? {
     // Walk over all children of this node and rewrite them. Don't store any
     // rewritten nodes until the first non-`nil` value is encountered. When this
     // happens, retrieve all previous syntax nodes from the parent node to
@@ -3903,11 +3901,9 @@ open class SyntaxRewriter {
     // with 'Syntax'
     var rewrittens: ContiguousArray<RetainedSyntaxArena> = []
 
-    let syntaxNode = node._syntaxNode
-
     // Incrementing i manually is faster than using .enumerated()
     var childIndex = 0
-    for (raw, info) in RawSyntaxChildren(syntaxNode) {
+    for (raw, info) in RawSyntaxChildren(node) {
       defer {
         childIndex += 1
       }
@@ -3918,7 +3914,7 @@ open class SyntaxRewriter {
       }
 
       // Build the Syntax node to rewrite
-      var childNode = nodeFactory.create(parent: syntaxNode, raw: child, absoluteInfo: info)
+      var childNode = nodeFactory.create(parent: node, raw: child, absoluteInfo: info)
 
       dispatchVisit(&childNode)
       if childNode.raw.id != child.id {
@@ -3950,11 +3946,11 @@ open class SyntaxRewriter {
       newLayout.deallocate()
       // 'withExtendedLifetime' to keep 'SyntaxArena's of them alive until here.
       return withExtendedLifetime(rewrittens) {
-        Syntax(raw: newRaw, rawNodeArena: arena).cast(SyntaxType.self)
+        Syntax(raw: newRaw, rawNodeArena: arena)
       }
     } else {
       // No child node was rewritten. So no need to change this node as well.
-      return node
+      return nil
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -23,25 +23,12 @@
 
 open class SyntaxRewriter {
   public let viewMode: SyntaxTreeViewMode
-
-  /// `Syntax.Info` salvaged from the node being deinitialized in 'visitChildren'.
-  ///
-  /// Instead of deallocating them and allocating memory for new syntax nodes, store the allocated memory in an array.
-  /// We can then re-use them to create new syntax nodes.
-  ///
-  /// The array's size should be a typical nesting depth of a Swift file. That way we can store all allocated syntax
-  /// nodes when unwinding the visitation stack.
-  ///
-  /// The actual `info` stored in the `Syntax.Info` objects is garbage. It needs to be set when any of the `Syntax.Info`
-  /// objects get re-used.
-  ///
-  /// Note: making the element non-nil causes 'swift::runtime::SwiftTLSContext::get()' traffic somehow.
-  private var recyclableNodeInfos: ContiguousArray<Syntax.Info?>
+  
+  /// 'Syntax' object factory recycling 'Syntax.Info' instances.
+  private let nodeFactory: SyntaxNodeFactory = SyntaxNodeFactory()
   
   public init(viewMode: SyntaxTreeViewMode = .sourceAccurate) {
     self.viewMode = viewMode
-    self.recyclableNodeInfos = []
-    self.recyclableNodeInfos.reserveCapacity(64)
   }
   
   /// Rewrite `node`, keeping its parent unless `detach` is `true`.
@@ -3936,15 +3923,7 @@ open class SyntaxRewriter {
       }
 
       // Build the Syntax node to rewrite
-      var childNode: Syntax
-      if !recyclableNodeInfos.isEmpty {
-        let recycledInfo: Syntax.Info = recyclableNodeInfos.removeLast()!
-        recycledInfo.info = .nonRoot(.init(parent: Syntax(node), absoluteInfo: info))
-        childNode = Syntax(child, info: recycledInfo)
-      } else {
-        let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
-        childNode = Syntax(absoluteRaw, parent: syntaxNode)
-      }
+      var childNode = nodeFactory.create(parent: syntaxNode, raw: child, absoluteInfo: info)
 
       dispatchVisit(&childNode)
       if childNode.raw.id != child.id {
@@ -3975,14 +3954,8 @@ open class SyntaxRewriter {
         }
       }
 
-      if recyclableNodeInfos.capacity > recyclableNodeInfos.count,
-         isKnownUniquelyReferenced(&childNode.info) {
-        var info: Syntax.Info! = nil
-        // 'swap' to avoid ref-counting traffic.
-        swap(&childNode.info, &info)
-        info.info = nil
-        recyclableNodeInfos.append(info)
-      }
+      // Recycle 'childNode.info'
+      nodeFactory.dispose(&childNode)
     }
 
     if let newLayout {

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -92,588 +92,588 @@ open class SyntaxRewriter {
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorBlockSyntax) -> AccessorBlockSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AccessorBlockSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AccessorBlockSyntax.self)
   }
   
   /// Visit a ``AccessorDeclListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorDeclListSyntax) -> AccessorDeclListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AccessorDeclListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AccessorDeclListSyntax.self)
   }
   
   /// Visit a ``AccessorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(AccessorDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(AccessorDeclSyntax.self))
   }
   
   /// Visit a ``AccessorEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorEffectSpecifiersSyntax) -> AccessorEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AccessorEffectSpecifiersSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AccessorEffectSpecifiersSyntax.self)
   }
   
   /// Visit a ``AccessorParametersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorParametersSyntax) -> AccessorParametersSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AccessorParametersSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AccessorParametersSyntax.self)
   }
   
   /// Visit a ``ActorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ActorDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(ActorDeclSyntax.self))
   }
   
   /// Visit a ``ArrayElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayElementListSyntax) -> ArrayElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ArrayElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ArrayElementListSyntax.self)
   }
   
   /// Visit a ``ArrayElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayElementSyntax) -> ArrayElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ArrayElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ArrayElementSyntax.self)
   }
   
   /// Visit a ``ArrayExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ArrayExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(ArrayExprSyntax.self))
   }
   
   /// Visit a ``ArrayTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(ArrayTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(ArrayTypeSyntax.self))
   }
   
   /// Visit a ``ArrowExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrowExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ArrowExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(ArrowExprSyntax.self))
   }
   
   /// Visit a ``AsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(AsExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(AsExprSyntax.self))
   }
   
   /// Visit a ``AssignmentExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AssignmentExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(AssignmentExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(AssignmentExprSyntax.self))
   }
   
   /// Visit a ``AssociatedTypeDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AssociatedTypeDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(AssociatedTypeDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(AssociatedTypeDeclSyntax.self))
   }
   
   /// Visit a ``AttributeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributeListSyntax) -> AttributeListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AttributeListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AttributeListSyntax.self)
   }
   
   /// Visit a ``AttributeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributeSyntax) -> AttributeSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AttributeSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AttributeSyntax.self)
   }
   
   /// Visit a ``AttributedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributedTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(AttributedTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(AttributedTypeSyntax.self))
   }
   
   /// Visit a ``AvailabilityArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityArgumentListSyntax) -> AvailabilityArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AvailabilityArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AvailabilityArgumentListSyntax.self)
   }
   
   /// Visit a ``AvailabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityArgumentSyntax) -> AvailabilityArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AvailabilityArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AvailabilityArgumentSyntax.self)
   }
   
   /// Visit a ``AvailabilityConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityConditionSyntax) -> AvailabilityConditionSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AvailabilityConditionSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AvailabilityConditionSyntax.self)
   }
   
   /// Visit a ``AvailabilityLabeledArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityLabeledArgumentSyntax) -> AvailabilityLabeledArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(AvailabilityLabeledArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(AvailabilityLabeledArgumentSyntax.self)
   }
   
   /// Visit a ``AwaitExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AwaitExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(AwaitExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(AwaitExprSyntax.self))
   }
   
   /// Visit a ``BackDeployedAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BackDeployedAttributeArgumentsSyntax) -> BackDeployedAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(BackDeployedAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(BackDeployedAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``BinaryOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BinaryOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(BinaryOperatorExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(BinaryOperatorExprSyntax.self))
   }
   
   /// Visit a ``BooleanLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BooleanLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(BooleanLiteralExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(BooleanLiteralExprSyntax.self))
   }
   
   /// Visit a ``BorrowExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BorrowExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(BorrowExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(BorrowExprSyntax.self))
   }
   
   /// Visit a ``BreakStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BreakStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(BreakStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(BreakStmtSyntax.self))
   }
   
   /// Visit a `_CanImportExprSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: _CanImportExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(_CanImportExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(_CanImportExprSyntax.self))
   }
   
   /// Visit a `_CanImportVersionInfoSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: _CanImportVersionInfoSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(_CanImportVersionInfoSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(_CanImportVersionInfoSyntax.self))
   }
   
   /// Visit a ``CatchClauseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchClauseListSyntax) -> CatchClauseListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CatchClauseListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CatchClauseListSyntax.self)
   }
   
   /// Visit a ``CatchClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchClauseSyntax) -> CatchClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CatchClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CatchClauseSyntax.self)
   }
   
   /// Visit a ``CatchItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchItemListSyntax) -> CatchItemListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CatchItemListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CatchItemListSyntax.self)
   }
   
   /// Visit a ``CatchItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchItemSyntax) -> CatchItemSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CatchItemSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CatchItemSyntax.self)
   }
   
   /// Visit a ``ClassDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ClassDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(ClassDeclSyntax.self))
   }
   
   /// Visit a ``ClassRestrictionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClassRestrictionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(ClassRestrictionTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(ClassRestrictionTypeSyntax.self))
   }
   
   /// Visit a ``ClosureCaptureClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureClauseSyntax) -> ClosureCaptureClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureCaptureClauseSyntax.self)
   }
   
   /// Visit a ``ClosureCaptureListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureListSyntax) -> ClosureCaptureListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureCaptureListSyntax.self)
   }
   
   /// Visit a ``ClosureCaptureSpecifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureSpecifierSyntax) -> ClosureCaptureSpecifierSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureSpecifierSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureCaptureSpecifierSyntax.self)
   }
   
   /// Visit a ``ClosureCaptureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureSyntax) -> ClosureCaptureSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureCaptureSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureCaptureSyntax.self)
   }
   
   /// Visit a ``ClosureExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ClosureExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(ClosureExprSyntax.self))
   }
   
   /// Visit a ``ClosureParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterClauseSyntax) -> ClosureParameterClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureParameterClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureParameterClauseSyntax.self)
   }
   
   /// Visit a ``ClosureParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterListSyntax) -> ClosureParameterListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureParameterListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureParameterListSyntax.self)
   }
   
   /// Visit a ``ClosureParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterSyntax) -> ClosureParameterSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureParameterSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureParameterSyntax.self)
   }
   
   /// Visit a ``ClosureShorthandParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureShorthandParameterListSyntax) -> ClosureShorthandParameterListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureShorthandParameterListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureShorthandParameterListSyntax.self)
   }
   
   /// Visit a ``ClosureShorthandParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureShorthandParameterSyntax) -> ClosureShorthandParameterSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureShorthandParameterSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureShorthandParameterSyntax.self)
   }
   
   /// Visit a ``ClosureSignatureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ClosureSignatureSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ClosureSignatureSyntax.self)
   }
   
   /// Visit a ``CodeBlockItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CodeBlockItemListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CodeBlockItemListSyntax.self)
   }
   
   /// Visit a ``CodeBlockItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockItemSyntax) -> CodeBlockItemSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CodeBlockItemSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CodeBlockItemSyntax.self)
   }
   
   /// Visit a ``CodeBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockSyntax) -> CodeBlockSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CodeBlockSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CodeBlockSyntax.self)
   }
   
   /// Visit a ``CompositionTypeElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeElementListSyntax) -> CompositionTypeElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CompositionTypeElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CompositionTypeElementListSyntax.self)
   }
   
   /// Visit a ``CompositionTypeElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeElementSyntax) -> CompositionTypeElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(CompositionTypeElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(CompositionTypeElementSyntax.self)
   }
   
   /// Visit a ``CompositionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(CompositionTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(CompositionTypeSyntax.self))
   }
   
   /// Visit a ``ConditionElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConditionElementListSyntax) -> ConditionElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ConditionElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ConditionElementListSyntax.self)
   }
   
   /// Visit a ``ConditionElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConditionElementSyntax) -> ConditionElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ConditionElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ConditionElementSyntax.self)
   }
   
   /// Visit a ``ConformanceRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConformanceRequirementSyntax) -> ConformanceRequirementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ConformanceRequirementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ConformanceRequirementSyntax.self)
   }
   
   /// Visit a ``ConsumeExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConsumeExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ConsumeExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(ConsumeExprSyntax.self))
   }
   
   /// Visit a ``ContinueStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ContinueStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ContinueStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(ContinueStmtSyntax.self))
   }
   
   /// Visit a ``ConventionAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConventionAttributeArgumentsSyntax) -> ConventionAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ConventionAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ConventionAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``ConventionWitnessMethodAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ConventionWitnessMethodAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ConventionWitnessMethodAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``CopyExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CopyExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(CopyExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(CopyExprSyntax.self))
   }
   
   /// Visit a ``DeclModifierDetailSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierDetailSyntax) -> DeclModifierDetailSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DeclModifierDetailSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DeclModifierDetailSyntax.self)
   }
   
   /// Visit a ``DeclModifierListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierListSyntax) -> DeclModifierListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DeclModifierListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DeclModifierListSyntax.self)
   }
   
   /// Visit a ``DeclModifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierSyntax) -> DeclModifierSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DeclModifierSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DeclModifierSyntax.self)
   }
   
   /// Visit a ``DeclNameArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentListSyntax) -> DeclNameArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DeclNameArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DeclNameArgumentListSyntax.self)
   }
   
   /// Visit a ``DeclNameArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentSyntax) -> DeclNameArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DeclNameArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DeclNameArgumentSyntax.self)
   }
   
   /// Visit a ``DeclNameArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentsSyntax) -> DeclNameArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DeclNameArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DeclNameArgumentsSyntax.self)
   }
   
   /// Visit a ``DeclReferenceExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DeclReferenceExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(DeclReferenceExprSyntax.self))
   }
   
   /// Visit a ``DeferStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeferStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(DeferStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(DeferStmtSyntax.self))
   }
   
   /// Visit a ``DeinitializerDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeinitializerDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(DeinitializerDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(DeinitializerDeclSyntax.self))
   }
   
   /// Visit a ``DeinitializerEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeinitializerEffectSpecifiersSyntax) -> DeinitializerEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DeinitializerEffectSpecifiersSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DeinitializerEffectSpecifiersSyntax.self)
   }
   
   /// Visit a ``DerivativeAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DerivativeAttributeArgumentsSyntax) -> DerivativeAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DerivativeAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DerivativeAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``DesignatedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DesignatedTypeListSyntax) -> DesignatedTypeListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DesignatedTypeListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DesignatedTypeListSyntax.self)
   }
   
   /// Visit a ``DesignatedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DesignatedTypeSyntax) -> DesignatedTypeSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DesignatedTypeSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DesignatedTypeSyntax.self)
   }
   
   /// Visit a ``DictionaryElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryElementListSyntax) -> DictionaryElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DictionaryElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DictionaryElementListSyntax.self)
   }
   
   /// Visit a ``DictionaryElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryElementSyntax) -> DictionaryElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DictionaryElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DictionaryElementSyntax.self)
   }
   
   /// Visit a ``DictionaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DictionaryExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(DictionaryExprSyntax.self))
   }
   
   /// Visit a ``DictionaryTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(DictionaryTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(DictionaryTypeSyntax.self))
   }
   
   /// Visit a ``DifferentiabilityArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentListSyntax) -> DifferentiabilityArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DifferentiabilityArgumentListSyntax.self)
   }
   
   /// Visit a ``DifferentiabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentSyntax) -> DifferentiabilityArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DifferentiabilityArgumentSyntax.self)
   }
   
   /// Visit a ``DifferentiabilityArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentsSyntax) -> DifferentiabilityArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DifferentiabilityArgumentsSyntax.self)
   }
   
   /// Visit a ``DifferentiabilityWithRespectToArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityWithRespectToArgumentSyntax) -> DifferentiabilityWithRespectToArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DifferentiabilityWithRespectToArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DifferentiabilityWithRespectToArgumentSyntax.self)
   }
   
   /// Visit a ``DifferentiableAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiableAttributeArgumentsSyntax) -> DifferentiableAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DifferentiableAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DifferentiableAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``DiscardAssignmentExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DiscardAssignmentExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DiscardAssignmentExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(DiscardAssignmentExprSyntax.self))
   }
   
   /// Visit a ``DiscardStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DiscardStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(DiscardStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(DiscardStmtSyntax.self))
   }
   
   /// Visit a `DoExprSyntax`.
@@ -683,532 +683,532 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: DoExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(DoExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(DoExprSyntax.self))
   }
   
   /// Visit a ``DoStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DoStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(DoStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(DoStmtSyntax.self))
   }
   
   /// Visit a ``DocumentationAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DocumentationAttributeArgumentListSyntax) -> DocumentationAttributeArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DocumentationAttributeArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DocumentationAttributeArgumentListSyntax.self)
   }
   
   /// Visit a ``DocumentationAttributeArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DocumentationAttributeArgumentSyntax) -> DocumentationAttributeArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DocumentationAttributeArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DocumentationAttributeArgumentSyntax.self)
   }
   
   /// Visit a ``DynamicReplacementAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DynamicReplacementAttributeArgumentsSyntax) -> DynamicReplacementAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(DynamicReplacementAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(DynamicReplacementAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``EditorPlaceholderDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EditorPlaceholderDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(EditorPlaceholderDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(EditorPlaceholderDeclSyntax.self))
   }
   
   /// Visit a ``EditorPlaceholderExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EditorPlaceholderExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(EditorPlaceholderExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(EditorPlaceholderExprSyntax.self))
   }
   
   /// Visit a ``EffectsAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EffectsAttributeArgumentListSyntax) -> EffectsAttributeArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(EffectsAttributeArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(EffectsAttributeArgumentListSyntax.self)
   }
   
   /// Visit a ``EnumCaseDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(EnumCaseDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(EnumCaseDeclSyntax.self))
   }
   
   /// Visit a ``EnumCaseElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseElementListSyntax) -> EnumCaseElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(EnumCaseElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(EnumCaseElementListSyntax.self)
   }
   
   /// Visit a ``EnumCaseElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseElementSyntax) -> EnumCaseElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(EnumCaseElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(EnumCaseElementSyntax.self)
   }
   
   /// Visit a ``EnumCaseParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterClauseSyntax) -> EnumCaseParameterClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(EnumCaseParameterClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(EnumCaseParameterClauseSyntax.self)
   }
   
   /// Visit a ``EnumCaseParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterListSyntax) -> EnumCaseParameterListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(EnumCaseParameterListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(EnumCaseParameterListSyntax.self)
   }
   
   /// Visit a ``EnumCaseParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterSyntax) -> EnumCaseParameterSyntax {
-    return visitChildren(node._syntaxNode)?.cast(EnumCaseParameterSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(EnumCaseParameterSyntax.self)
   }
   
   /// Visit a ``EnumDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(EnumDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(EnumDeclSyntax.self))
   }
   
   /// Visit a ``ExposeAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExposeAttributeArgumentsSyntax) -> ExposeAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ExposeAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ExposeAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``ExprListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExprListSyntax) -> ExprListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ExprListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ExprListSyntax.self)
   }
   
   /// Visit a ``ExpressionPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(ExpressionPatternSyntax.self) ?? node)
+    return PatternSyntax(visitChildren(node._syntaxNode).cast(ExpressionPatternSyntax.self))
   }
   
   /// Visit a ``ExpressionSegmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionSegmentSyntax) -> ExpressionSegmentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ExpressionSegmentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ExpressionSegmentSyntax.self)
   }
   
   /// Visit a ``ExpressionStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ExpressionStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(ExpressionStmtSyntax.self))
   }
   
   /// Visit a ``ExtensionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExtensionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ExtensionDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(ExtensionDeclSyntax.self))
   }
   
   /// Visit a ``FallThroughStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FallThroughStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(FallThroughStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(FallThroughStmtSyntax.self))
   }
   
   /// Visit a ``FloatLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FloatLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(FloatLiteralExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(FloatLiteralExprSyntax.self))
   }
   
   /// Visit a ``ForStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ForStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ForStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(ForStmtSyntax.self))
   }
   
   /// Visit a ``ForceUnwrapExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ForceUnwrapExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(ForceUnwrapExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(ForceUnwrapExprSyntax.self))
   }
   
   /// Visit a ``FunctionCallExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(FunctionCallExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(FunctionCallExprSyntax.self))
   }
   
   /// Visit a ``FunctionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(FunctionDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(FunctionDeclSyntax.self))
   }
   
   /// Visit a ``FunctionEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionEffectSpecifiersSyntax) -> FunctionEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode)?.cast(FunctionEffectSpecifiersSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(FunctionEffectSpecifiersSyntax.self)
   }
   
   /// Visit a ``FunctionParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterClauseSyntax) -> FunctionParameterClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(FunctionParameterClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(FunctionParameterClauseSyntax.self)
   }
   
   /// Visit a ``FunctionParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterListSyntax) -> FunctionParameterListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(FunctionParameterListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(FunctionParameterListSyntax.self)
   }
   
   /// Visit a ``FunctionParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterSyntax) -> FunctionParameterSyntax {
-    return visitChildren(node._syntaxNode)?.cast(FunctionParameterSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(FunctionParameterSyntax.self)
   }
   
   /// Visit a ``FunctionSignatureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
-    return visitChildren(node._syntaxNode)?.cast(FunctionSignatureSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(FunctionSignatureSyntax.self)
   }
   
   /// Visit a ``FunctionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(FunctionTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(FunctionTypeSyntax.self))
   }
   
   /// Visit a ``GenericArgumentClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentClauseSyntax) -> GenericArgumentClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericArgumentClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericArgumentClauseSyntax.self)
   }
   
   /// Visit a ``GenericArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentListSyntax) -> GenericArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericArgumentListSyntax.self)
   }
   
   /// Visit a ``GenericArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentSyntax) -> GenericArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericArgumentSyntax.self)
   }
   
   /// Visit a ``GenericParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterClauseSyntax) -> GenericParameterClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericParameterClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericParameterClauseSyntax.self)
   }
   
   /// Visit a ``GenericParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterListSyntax) -> GenericParameterListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericParameterListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericParameterListSyntax.self)
   }
   
   /// Visit a ``GenericParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterSyntax) -> GenericParameterSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericParameterSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericParameterSyntax.self)
   }
   
   /// Visit a ``GenericRequirementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericRequirementListSyntax) -> GenericRequirementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericRequirementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericRequirementListSyntax.self)
   }
   
   /// Visit a ``GenericRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericRequirementSyntax) -> GenericRequirementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericRequirementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericRequirementSyntax.self)
   }
   
   /// Visit a ``GenericSpecializationExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericSpecializationExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(GenericSpecializationExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(GenericSpecializationExprSyntax.self))
   }
   
   /// Visit a ``GenericWhereClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericWhereClauseSyntax) -> GenericWhereClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(GenericWhereClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(GenericWhereClauseSyntax.self)
   }
   
   /// Visit a ``GuardStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GuardStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(GuardStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(GuardStmtSyntax.self))
   }
   
   /// Visit a ``IdentifierPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IdentifierPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(IdentifierPatternSyntax.self) ?? node)
+    return PatternSyntax(visitChildren(node._syntaxNode).cast(IdentifierPatternSyntax.self))
   }
   
   /// Visit a ``IdentifierTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(IdentifierTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(IdentifierTypeSyntax.self))
   }
   
   /// Visit a ``IfConfigClauseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigClauseListSyntax) -> IfConfigClauseListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(IfConfigClauseListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(IfConfigClauseListSyntax.self)
   }
   
   /// Visit a ``IfConfigClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigClauseSyntax) -> IfConfigClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(IfConfigClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(IfConfigClauseSyntax.self)
   }
   
   /// Visit a ``IfConfigDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(IfConfigDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(IfConfigDeclSyntax.self))
   }
   
   /// Visit a ``IfExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(IfExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(IfExprSyntax.self))
   }
   
   /// Visit a ``ImplementsAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImplementsAttributeArgumentsSyntax) -> ImplementsAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ImplementsAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ImplementsAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``ImplicitlyUnwrappedOptionalTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(ImplicitlyUnwrappedOptionalTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(ImplicitlyUnwrappedOptionalTypeSyntax.self))
   }
   
   /// Visit a ``ImportDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ImportDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(ImportDeclSyntax.self))
   }
   
   /// Visit a ``ImportPathComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportPathComponentListSyntax) -> ImportPathComponentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ImportPathComponentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ImportPathComponentListSyntax.self)
   }
   
   /// Visit a ``ImportPathComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportPathComponentSyntax) -> ImportPathComponentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ImportPathComponentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ImportPathComponentSyntax.self)
   }
   
   /// Visit a ``InOutExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InOutExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(InOutExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(InOutExprSyntax.self))
   }
   
   /// Visit a ``InfixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InfixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(InfixOperatorExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(InfixOperatorExprSyntax.self))
   }
   
   /// Visit a ``InheritanceClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritanceClauseSyntax) -> InheritanceClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(InheritanceClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(InheritanceClauseSyntax.self)
   }
   
   /// Visit a ``InheritedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritedTypeListSyntax) -> InheritedTypeListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(InheritedTypeListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(InheritedTypeListSyntax.self)
   }
   
   /// Visit a ``InheritedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritedTypeSyntax) -> InheritedTypeSyntax {
-    return visitChildren(node._syntaxNode)?.cast(InheritedTypeSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(InheritedTypeSyntax.self)
   }
   
   /// Visit a ``InitializerClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InitializerClauseSyntax) -> InitializerClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(InitializerClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(InitializerClauseSyntax.self)
   }
   
   /// Visit a ``InitializerDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(InitializerDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(InitializerDeclSyntax.self))
   }
   
   /// Visit a ``IntegerLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IntegerLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(IntegerLiteralExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(IntegerLiteralExprSyntax.self))
   }
   
   /// Visit a ``IsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(IsExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(IsExprSyntax.self))
   }
   
   /// Visit a ``IsTypePatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IsTypePatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(IsTypePatternSyntax.self) ?? node)
+    return PatternSyntax(visitChildren(node._syntaxNode).cast(IsTypePatternSyntax.self))
   }
   
   /// Visit a ``KeyPathComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathComponentListSyntax) -> KeyPathComponentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(KeyPathComponentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(KeyPathComponentListSyntax.self)
   }
   
   /// Visit a ``KeyPathComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathComponentSyntax) -> KeyPathComponentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(KeyPathComponentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(KeyPathComponentSyntax.self)
   }
   
   /// Visit a ``KeyPathExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(KeyPathExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(KeyPathExprSyntax.self))
   }
   
   /// Visit a ``KeyPathOptionalComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathOptionalComponentSyntax) -> KeyPathOptionalComponentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(KeyPathOptionalComponentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(KeyPathOptionalComponentSyntax.self)
   }
   
   /// Visit a ``KeyPathPropertyComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathPropertyComponentSyntax) -> KeyPathPropertyComponentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(KeyPathPropertyComponentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(KeyPathPropertyComponentSyntax.self)
   }
   
   /// Visit a ``KeyPathSubscriptComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathSubscriptComponentSyntax) -> KeyPathSubscriptComponentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(KeyPathSubscriptComponentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(KeyPathSubscriptComponentSyntax.self)
   }
   
   /// Visit a ``LabeledExprListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledExprListSyntax) -> LabeledExprListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(LabeledExprListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(LabeledExprListSyntax.self)
   }
   
   /// Visit a ``LabeledExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledExprSyntax) -> LabeledExprSyntax {
-    return visitChildren(node._syntaxNode)?.cast(LabeledExprSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(LabeledExprSyntax.self)
   }
   
   /// Visit a ``LabeledSpecializeArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledSpecializeArgumentSyntax) -> LabeledSpecializeArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(LabeledSpecializeArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(LabeledSpecializeArgumentSyntax.self)
   }
   
   /// Visit a ``LabeledStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(LabeledStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(LabeledStmtSyntax.self))
   }
   
   /// Visit a ``LayoutRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LayoutRequirementSyntax) -> LayoutRequirementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(LayoutRequirementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(LayoutRequirementSyntax.self)
   }
   
   /// Visit a `LifetimeSpecifierArgumentListSyntax`.
@@ -1218,7 +1218,7 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeSpecifierArgumentListSyntax) -> LifetimeSpecifierArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(LifetimeSpecifierArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(LifetimeSpecifierArgumentListSyntax.self)
   }
   
   /// Visit a `LifetimeSpecifierArgumentSyntax`.
@@ -1228,7 +1228,7 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeSpecifierArgumentSyntax) -> LifetimeSpecifierArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(LifetimeSpecifierArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(LifetimeSpecifierArgumentSyntax.self)
   }
   
   /// Visit a `LifetimeTypeSpecifierSyntax`.
@@ -1238,602 +1238,602 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeTypeSpecifierSyntax) -> LifetimeTypeSpecifierSyntax {
-    return visitChildren(node._syntaxNode)?.cast(LifetimeTypeSpecifierSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(LifetimeTypeSpecifierSyntax.self)
   }
   
   /// Visit a ``MacroDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(MacroDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(MacroDeclSyntax.self))
   }
   
   /// Visit a ``MacroExpansionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroExpansionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(MacroExpansionDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(MacroExpansionDeclSyntax.self))
   }
   
   /// Visit a ``MacroExpansionExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroExpansionExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(MacroExpansionExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(MacroExpansionExprSyntax.self))
   }
   
   /// Visit a ``MatchingPatternConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MatchingPatternConditionSyntax) -> MatchingPatternConditionSyntax {
-    return visitChildren(node._syntaxNode)?.cast(MatchingPatternConditionSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(MatchingPatternConditionSyntax.self)
   }
   
   /// Visit a ``MemberAccessExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(MemberAccessExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(MemberAccessExprSyntax.self))
   }
   
   /// Visit a ``MemberBlockItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockItemListSyntax) -> MemberBlockItemListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(MemberBlockItemListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(MemberBlockItemListSyntax.self)
   }
   
   /// Visit a ``MemberBlockItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockItemSyntax) -> MemberBlockItemSyntax {
-    return visitChildren(node._syntaxNode)?.cast(MemberBlockItemSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(MemberBlockItemSyntax.self)
   }
   
   /// Visit a ``MemberBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockSyntax) -> MemberBlockSyntax {
-    return visitChildren(node._syntaxNode)?.cast(MemberBlockSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(MemberBlockSyntax.self)
   }
   
   /// Visit a ``MemberTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(MemberTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(MemberTypeSyntax.self))
   }
   
   /// Visit a ``MetatypeTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MetatypeTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(MetatypeTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(MetatypeTypeSyntax.self))
   }
   
   /// Visit a ``MissingDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(MissingDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(MissingDeclSyntax.self))
   }
   
   /// Visit a ``MissingExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(MissingExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(MissingExprSyntax.self))
   }
   
   /// Visit a ``MissingPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(MissingPatternSyntax.self) ?? node)
+    return PatternSyntax(visitChildren(node._syntaxNode).cast(MissingPatternSyntax.self))
   }
   
   /// Visit a ``MissingStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(MissingStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(MissingStmtSyntax.self))
   }
   
   /// Visit a ``MissingSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingSyntax) -> Syntax {
-    return Syntax(visitChildren(node._syntaxNode)?.cast(MissingSyntax.self) ?? node)
+    return Syntax(visitChildren(node._syntaxNode).cast(MissingSyntax.self))
   }
   
   /// Visit a ``MissingTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(MissingTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(MissingTypeSyntax.self))
   }
   
   /// Visit a ``MultipleTrailingClosureElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MultipleTrailingClosureElementListSyntax) -> MultipleTrailingClosureElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(MultipleTrailingClosureElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(MultipleTrailingClosureElementListSyntax.self)
   }
   
   /// Visit a ``MultipleTrailingClosureElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MultipleTrailingClosureElementSyntax) -> MultipleTrailingClosureElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(MultipleTrailingClosureElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(MultipleTrailingClosureElementSyntax.self)
   }
   
   /// Visit a ``NamedOpaqueReturnTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: NamedOpaqueReturnTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(NamedOpaqueReturnTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(NamedOpaqueReturnTypeSyntax.self))
   }
   
   /// Visit a ``NilLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: NilLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(NilLiteralExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(NilLiteralExprSyntax.self))
   }
   
   /// Visit a ``ObjCSelectorPieceListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ObjCSelectorPieceListSyntax) -> ObjCSelectorPieceListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ObjCSelectorPieceListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ObjCSelectorPieceListSyntax.self)
   }
   
   /// Visit a ``ObjCSelectorPieceSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ObjCSelectorPieceSyntax) -> ObjCSelectorPieceSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ObjCSelectorPieceSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ObjCSelectorPieceSyntax.self)
   }
   
   /// Visit a ``OpaqueReturnTypeOfAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(OpaqueReturnTypeOfAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(OpaqueReturnTypeOfAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``OperatorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OperatorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(OperatorDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(OperatorDeclSyntax.self))
   }
   
   /// Visit a ``OperatorPrecedenceAndTypesSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OperatorPrecedenceAndTypesSyntax) -> OperatorPrecedenceAndTypesSyntax {
-    return visitChildren(node._syntaxNode)?.cast(OperatorPrecedenceAndTypesSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(OperatorPrecedenceAndTypesSyntax.self)
   }
   
   /// Visit a ``OptionalBindingConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalBindingConditionSyntax) -> OptionalBindingConditionSyntax {
-    return visitChildren(node._syntaxNode)?.cast(OptionalBindingConditionSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(OptionalBindingConditionSyntax.self)
   }
   
   /// Visit a ``OptionalChainingExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalChainingExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(OptionalChainingExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(OptionalChainingExprSyntax.self))
   }
   
   /// Visit a ``OptionalTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(OptionalTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(OptionalTypeSyntax.self))
   }
   
   /// Visit a ``OriginallyDefinedInAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> OriginallyDefinedInAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(OriginallyDefinedInAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(OriginallyDefinedInAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``PackElementExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackElementExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PackElementExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(PackElementExprSyntax.self))
   }
   
   /// Visit a ``PackElementTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackElementTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(PackElementTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(PackElementTypeSyntax.self))
   }
   
   /// Visit a ``PackExpansionExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackExpansionExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PackExpansionExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(PackExpansionExprSyntax.self))
   }
   
   /// Visit a ``PackExpansionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackExpansionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(PackExpansionTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(PackExpansionTypeSyntax.self))
   }
   
   /// Visit a ``PatternBindingListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternBindingListSyntax) -> PatternBindingListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PatternBindingListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PatternBindingListSyntax.self)
   }
   
   /// Visit a ``PatternBindingSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PatternBindingSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PatternBindingSyntax.self)
   }
   
   /// Visit a ``PatternExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PatternExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(PatternExprSyntax.self))
   }
   
   /// Visit a ``PlatformVersionItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionItemListSyntax) -> PlatformVersionItemListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PlatformVersionItemListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PlatformVersionItemListSyntax.self)
   }
   
   /// Visit a ``PlatformVersionItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionItemSyntax) -> PlatformVersionItemSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PlatformVersionItemSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PlatformVersionItemSyntax.self)
   }
   
   /// Visit a ``PlatformVersionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionSyntax) -> PlatformVersionSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PlatformVersionSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PlatformVersionSyntax.self)
   }
   
   /// Visit a ``PostfixIfConfigExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PostfixIfConfigExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PostfixIfConfigExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(PostfixIfConfigExprSyntax.self))
   }
   
   /// Visit a ``PostfixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PostfixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PostfixOperatorExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(PostfixOperatorExprSyntax.self))
   }
   
   /// Visit a ``PoundSourceLocationArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PoundSourceLocationArgumentsSyntax) -> PoundSourceLocationArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PoundSourceLocationArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PoundSourceLocationArgumentsSyntax.self)
   }
   
   /// Visit a ``PoundSourceLocationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PoundSourceLocationSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(PoundSourceLocationSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(PoundSourceLocationSyntax.self))
   }
   
   /// Visit a ``PrecedenceGroupAssignmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAssignmentSyntax) -> PrecedenceGroupAssignmentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupAssignmentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrecedenceGroupAssignmentSyntax.self)
   }
   
   /// Visit a ``PrecedenceGroupAssociativitySyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAssociativitySyntax) -> PrecedenceGroupAssociativitySyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupAssociativitySyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrecedenceGroupAssociativitySyntax.self)
   }
   
   /// Visit a ``PrecedenceGroupAttributeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAttributeListSyntax) -> PrecedenceGroupAttributeListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupAttributeListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrecedenceGroupAttributeListSyntax.self)
   }
   
   /// Visit a ``PrecedenceGroupDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(PrecedenceGroupDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(PrecedenceGroupDeclSyntax.self))
   }
   
   /// Visit a ``PrecedenceGroupNameListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupNameListSyntax) -> PrecedenceGroupNameListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupNameListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrecedenceGroupNameListSyntax.self)
   }
   
   /// Visit a ``PrecedenceGroupNameSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupNameSyntax) -> PrecedenceGroupNameSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupNameSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrecedenceGroupNameSyntax.self)
   }
   
   /// Visit a ``PrecedenceGroupRelationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupRelationSyntax) -> PrecedenceGroupRelationSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrecedenceGroupRelationSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrecedenceGroupRelationSyntax.self)
   }
   
   /// Visit a ``PrefixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrefixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(PrefixOperatorExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(PrefixOperatorExprSyntax.self))
   }
   
   /// Visit a ``PrimaryAssociatedTypeClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeClauseSyntax) -> PrimaryAssociatedTypeClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrimaryAssociatedTypeClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrimaryAssociatedTypeClauseSyntax.self)
   }
   
   /// Visit a ``PrimaryAssociatedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeListSyntax) -> PrimaryAssociatedTypeListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrimaryAssociatedTypeListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrimaryAssociatedTypeListSyntax.self)
   }
   
   /// Visit a ``PrimaryAssociatedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeSyntax {
-    return visitChildren(node._syntaxNode)?.cast(PrimaryAssociatedTypeSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(PrimaryAssociatedTypeSyntax.self)
   }
   
   /// Visit a ``ProtocolDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(ProtocolDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(ProtocolDeclSyntax.self))
   }
   
   /// Visit a ``RegexLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: RegexLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(RegexLiteralExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(RegexLiteralExprSyntax.self))
   }
   
   /// Visit a ``RepeatStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: RepeatStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(RepeatStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(RepeatStmtSyntax.self))
   }
   
   /// Visit a ``ReturnClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ReturnClauseSyntax) -> ReturnClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ReturnClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ReturnClauseSyntax.self)
   }
   
   /// Visit a ``ReturnStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ReturnStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ReturnStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(ReturnStmtSyntax.self))
   }
   
   /// Visit a ``SameTypeRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SameTypeRequirementSyntax) -> SameTypeRequirementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SameTypeRequirementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SameTypeRequirementSyntax.self)
   }
   
   /// Visit a ``SequenceExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SequenceExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SequenceExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(SequenceExprSyntax.self))
   }
   
   /// Visit a ``SimpleStringLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleStringLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SimpleStringLiteralExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(SimpleStringLiteralExprSyntax.self))
   }
   
   /// Visit a ``SimpleStringLiteralSegmentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleStringLiteralSegmentListSyntax) -> SimpleStringLiteralSegmentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SimpleStringLiteralSegmentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SimpleStringLiteralSegmentListSyntax.self)
   }
   
   /// Visit a ``SimpleTypeSpecifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleTypeSpecifierSyntax) -> SimpleTypeSpecifierSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SimpleTypeSpecifierSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SimpleTypeSpecifierSyntax.self)
   }
   
   /// Visit a ``SomeOrAnyTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SomeOrAnyTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(SomeOrAnyTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(SomeOrAnyTypeSyntax.self))
   }
   
   /// Visit a ``SourceFileSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SourceFileSyntax) -> SourceFileSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SourceFileSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SourceFileSyntax.self)
   }
   
   /// Visit a ``SpecializeAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeAttributeArgumentListSyntax) -> SpecializeAttributeArgumentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SpecializeAttributeArgumentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SpecializeAttributeArgumentListSyntax.self)
   }
   
   /// Visit a ``SpecializeAvailabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeAvailabilityArgumentSyntax) -> SpecializeAvailabilityArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SpecializeAvailabilityArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SpecializeAvailabilityArgumentSyntax.self)
   }
   
   /// Visit a ``SpecializeTargetFunctionArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeTargetFunctionArgumentSyntax) -> SpecializeTargetFunctionArgumentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SpecializeTargetFunctionArgumentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SpecializeTargetFunctionArgumentSyntax.self)
   }
   
   /// Visit a ``StringLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(StringLiteralExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(StringLiteralExprSyntax.self))
   }
   
   /// Visit a ``StringLiteralSegmentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringLiteralSegmentListSyntax) -> StringLiteralSegmentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(StringLiteralSegmentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(StringLiteralSegmentListSyntax.self)
   }
   
   /// Visit a ``StringSegmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringSegmentSyntax) -> StringSegmentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(StringSegmentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(StringSegmentSyntax.self)
   }
   
   /// Visit a ``StructDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StructDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(StructDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(StructDeclSyntax.self))
   }
   
   /// Visit a ``SubscriptCallExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SubscriptCallExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SubscriptCallExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(SubscriptCallExprSyntax.self))
   }
   
   /// Visit a ``SubscriptDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(SubscriptDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(SubscriptDeclSyntax.self))
   }
   
   /// Visit a ``SuperExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SuperExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SuperExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(SuperExprSyntax.self))
   }
   
   /// Visit a ``SuppressedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SuppressedTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(SuppressedTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(SuppressedTypeSyntax.self))
   }
   
   /// Visit a ``SwitchCaseItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseItemListSyntax) -> SwitchCaseItemListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SwitchCaseItemListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SwitchCaseItemListSyntax.self)
   }
   
   /// Visit a ``SwitchCaseItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseItemSyntax) -> SwitchCaseItemSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SwitchCaseItemSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SwitchCaseItemSyntax.self)
   }
   
   /// Visit a ``SwitchCaseLabelSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseLabelSyntax) -> SwitchCaseLabelSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SwitchCaseLabelSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SwitchCaseLabelSyntax.self)
   }
   
   /// Visit a ``SwitchCaseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseListSyntax) -> SwitchCaseListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SwitchCaseListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SwitchCaseListSyntax.self)
   }
   
   /// Visit a ``SwitchCaseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SwitchCaseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SwitchCaseSyntax.self)
   }
   
   /// Visit a ``SwitchDefaultLabelSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchDefaultLabelSyntax) -> SwitchDefaultLabelSyntax {
-    return visitChildren(node._syntaxNode)?.cast(SwitchDefaultLabelSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(SwitchDefaultLabelSyntax.self)
   }
   
   /// Visit a ``SwitchExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(SwitchExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(SwitchExprSyntax.self))
   }
   
   /// Visit a ``TernaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TernaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TernaryExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(TernaryExprSyntax.self))
   }
   
   /// Visit a `ThenStmtSyntax`.
@@ -1843,245 +1843,245 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: ThenStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ThenStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(ThenStmtSyntax.self))
   }
   
   /// Visit a ``ThrowStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ThrowStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(ThrowStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(ThrowStmtSyntax.self))
   }
   
   /// Visit a ``ThrowsClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ThrowsClauseSyntax) -> ThrowsClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(ThrowsClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(ThrowsClauseSyntax.self)
   }
   
   /// Visit a ``TryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TryExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(TryExprSyntax.self))
   }
   
   /// Visit a ``TupleExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TupleExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(TupleExprSyntax.self))
   }
   
   /// Visit a ``TuplePatternElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternElementListSyntax) -> TuplePatternElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TuplePatternElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TuplePatternElementListSyntax.self)
   }
   
   /// Visit a ``TuplePatternElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternElementSyntax) -> TuplePatternElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TuplePatternElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TuplePatternElementSyntax.self)
   }
   
   /// Visit a ``TuplePatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(TuplePatternSyntax.self) ?? node)
+    return PatternSyntax(visitChildren(node._syntaxNode).cast(TuplePatternSyntax.self))
   }
   
   /// Visit a ``TupleTypeElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeElementListSyntax) -> TupleTypeElementListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TupleTypeElementListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TupleTypeElementListSyntax.self)
   }
   
   /// Visit a ``TupleTypeElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeElementSyntax) -> TupleTypeElementSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TupleTypeElementSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TupleTypeElementSyntax.self)
   }
   
   /// Visit a ``TupleTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode)?.cast(TupleTypeSyntax.self) ?? node)
+    return TypeSyntax(visitChildren(node._syntaxNode).cast(TupleTypeSyntax.self))
   }
   
   /// Visit a ``TypeAliasDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeAliasDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(TypeAliasDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(TypeAliasDeclSyntax.self))
   }
   
   /// Visit a ``TypeAnnotationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeAnnotationSyntax) -> TypeAnnotationSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TypeAnnotationSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TypeAnnotationSyntax.self)
   }
   
   /// Visit a ``TypeEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeEffectSpecifiersSyntax) -> TypeEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TypeEffectSpecifiersSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TypeEffectSpecifiersSyntax.self)
   }
   
   /// Visit a ``TypeExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(TypeExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(TypeExprSyntax.self))
   }
   
   /// Visit a ``TypeInitializerClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeInitializerClauseSyntax) -> TypeInitializerClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TypeInitializerClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TypeInitializerClauseSyntax.self)
   }
   
   /// Visit a ``TypeSpecifierListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeSpecifierListSyntax) -> TypeSpecifierListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(TypeSpecifierListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(TypeSpecifierListSyntax.self)
   }
   
   /// Visit a ``UnavailableFromAsyncAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnavailableFromAsyncAttributeArgumentsSyntax) -> UnavailableFromAsyncAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(UnavailableFromAsyncAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(UnavailableFromAsyncAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``UnderscorePrivateAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnderscorePrivateAttributeArgumentsSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode)?.cast(UnderscorePrivateAttributeArgumentsSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(UnderscorePrivateAttributeArgumentsSyntax.self)
   }
   
   /// Visit a ``UnexpectedNodesSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnexpectedNodesSyntax) -> UnexpectedNodesSyntax {
-    return visitChildren(node._syntaxNode)?.cast(UnexpectedNodesSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(UnexpectedNodesSyntax.self)
   }
   
   /// Visit a ``UnresolvedAsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedAsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(UnresolvedAsExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(UnresolvedAsExprSyntax.self))
   }
   
   /// Visit a ``UnresolvedIsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedIsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(UnresolvedIsExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(UnresolvedIsExprSyntax.self))
   }
   
   /// Visit a ``UnresolvedTernaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedTernaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode)?.cast(UnresolvedTernaryExprSyntax.self) ?? node)
+    return ExprSyntax(visitChildren(node._syntaxNode).cast(UnresolvedTernaryExprSyntax.self))
   }
   
   /// Visit a ``ValueBindingPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ValueBindingPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(ValueBindingPatternSyntax.self) ?? node)
+    return PatternSyntax(visitChildren(node._syntaxNode).cast(ValueBindingPatternSyntax.self))
   }
   
   /// Visit a ``VariableDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode)?.cast(VariableDeclSyntax.self) ?? node)
+    return DeclSyntax(visitChildren(node._syntaxNode).cast(VariableDeclSyntax.self))
   }
   
   /// Visit a ``VersionComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionComponentListSyntax) -> VersionComponentListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(VersionComponentListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(VersionComponentListSyntax.self)
   }
   
   /// Visit a ``VersionComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionComponentSyntax) -> VersionComponentSyntax {
-    return visitChildren(node._syntaxNode)?.cast(VersionComponentSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(VersionComponentSyntax.self)
   }
   
   /// Visit a ``VersionTupleSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionTupleSyntax) -> VersionTupleSyntax {
-    return visitChildren(node._syntaxNode)?.cast(VersionTupleSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(VersionTupleSyntax.self)
   }
   
   /// Visit a ``WhereClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WhereClauseSyntax) -> WhereClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(WhereClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(WhereClauseSyntax.self)
   }
   
   /// Visit a ``WhileStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WhileStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(WhileStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(WhileStmtSyntax.self))
   }
   
   /// Visit a ``WildcardPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WildcardPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode)?.cast(WildcardPatternSyntax.self) ?? node)
+    return PatternSyntax(visitChildren(node._syntaxNode).cast(WildcardPatternSyntax.self))
   }
   
   /// Visit a ``YieldStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode)?.cast(YieldStmtSyntax.self) ?? node)
+    return StmtSyntax(visitChildren(node._syntaxNode).cast(YieldStmtSyntax.self))
   }
   
   /// Visit a ``YieldedExpressionListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionListSyntax) -> YieldedExpressionListSyntax {
-    return visitChildren(node._syntaxNode)?.cast(YieldedExpressionListSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(YieldedExpressionListSyntax.self)
   }
   
   /// Visit a ``YieldedExpressionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionSyntax) -> YieldedExpressionSyntax {
-    return visitChildren(node._syntaxNode)?.cast(YieldedExpressionSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(YieldedExpressionSyntax.self)
   }
   
   /// Visit a ``YieldedExpressionsClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionsClauseSyntax) -> YieldedExpressionsClauseSyntax {
-    return visitChildren(node._syntaxNode)?.cast(YieldedExpressionsClauseSyntax.self) ?? node
+    return visitChildren(node._syntaxNode).cast(YieldedExpressionsClauseSyntax.self)
   }
   
   /// Visit any DeclSyntax node.
@@ -3885,7 +3885,7 @@ open class SyntaxRewriter {
   }
   #endif
   
-  private func visitChildren(_ node: Syntax) -> Syntax? {
+  private func visitChildren(_ node: Syntax) -> Syntax {
     // Walk over all children of this node and rewrite them. Don't store any
     // rewritten nodes until the first non-`nil` value is encountered. When this
     // happens, retrieve all previous syntax nodes from the parent node to
@@ -3940,7 +3940,7 @@ open class SyntaxRewriter {
       }
     } else {
       // No child node was rewritten. So no need to change this node as well.
-      return nil
+      return node
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -24,23 +24,8 @@ public enum SyntaxVisitorContinueKind {
 open class SyntaxVisitor {
   public let viewMode: SyntaxTreeViewMode
   
-  /// `Syntax.Info` objects created in `visitChildren` but whose `Syntax` nodes were not retained by the `visit`
-  /// functions implemented by a subclass of `SyntaxVisitor`.
-  ///
-  /// Instead of deallocating them and allocating memory for new syntax nodes, store the allocated memory in an array.
-  /// We can then re-use them to create new syntax nodes.
-  ///
-  /// The array's size should be a typical nesting depth of a Swift file. That way we can store all allocated syntax
-  /// nodes when unwinding the visitation stack.
-  ///
-  /// The actual `info` stored in the `Syntax.Info` objects is garbage. It needs to be set when any of the `Syntax.Info`
-  /// objects get re-used.
-  private var recyclableNodeInfos: ContiguousArray<Syntax.Info?> =  ContiguousArray(repeating: nil, count: 64)
-  
-  /// A bit is set to 1 if the corresponding index in `recyclableNodeInfos` is occupied and ready to be reused.
-  ///
-  /// The last bit in this UInt64 corresponds to index 0 in `recyclableNodeInfos`.
-  private var recyclableNodeInfosUsageBitmap: UInt64 = 0
+  /// 'Syntax' object factory recycling 'Syntax.Info' instances.
+  private let nodeFactory: SyntaxNodeFactory = SyntaxNodeFactory()
   
   public init(viewMode: SyntaxTreeViewMode) {
     self.viewMode = viewMode
@@ -5267,60 +5252,11 @@ open class SyntaxVisitor {
   #endif
   
   /// - Note: `node` is `inout` to avoid reference counting. See comment in `visitImpl`.
-  private func visitChildren(_ syntaxNode: inout Syntax) {
-    for childRaw in NonNilRawSyntaxChildren(syntaxNode, viewMode: viewMode) {
-      // syntaxNode gets retained here. That seems unnecessary but I don't know how to remove it.
-      var childNode: Syntax
-      if let recycledInfoIndex = recyclableNodeInfosUsageBitmap.indexOfRightmostOne {
-        var recycledInfo: Syntax.Info? = nil
-        // Use `swap` to extract the recyclable syntax node without incurring ref-counting.
-        swap(&recycledInfo, &recyclableNodeInfos[recycledInfoIndex])
-        assert(recycledInfo != nil, "Slot indicated by the bitmap did not contain a value")
-        recyclableNodeInfosUsageBitmap.setBitToZero(at: recycledInfoIndex)
-        // syntaxNode.info gets retained here. This is necessary because we build up the parent tree.
-        recycledInfo!.info = .nonRoot(.init(parent: syntaxNode, absoluteInfo: childRaw.info))
-        childNode = Syntax(childRaw.raw, info: recycledInfo!)
-      } else {
-        childNode = Syntax(childRaw, parent: syntaxNode)
-      }
+  private func visitChildren(_ node: inout Syntax) {
+    for case let (child?, info) in RawSyntaxChildren(node) where viewMode.shouldTraverse(node: child) {
+      var childNode = nodeFactory.create(parent: node, raw: child, absoluteInfo: info)
       visit(&childNode)
-      if isKnownUniquelyReferenced(&childNode.info) {
-        // The node didn't get stored by the subclass's visit method. We can re-use the memory of its `Syntax.Info`
-        // for future syntax nodes.
-        childNode.info.info = nil
-        if let emptySlot = recyclableNodeInfosUsageBitmap.indexOfRightmostZero {
-          // Use `swap` to store the recyclable syntax node without incurring ref-counting.
-          swap(&recyclableNodeInfos[emptySlot], &childNode.info)
-          assert(childNode.info == nil, "Slot should not have contained a value")
-          recyclableNodeInfosUsageBitmap.setBitToOne(at: emptySlot)
-        }
-      }
+      nodeFactory.dispose(&childNode)
     }
-  }
-}
-
-fileprivate extension UInt64 {
-  var indexOfRightmostZero: Int? {
-    return (~self).indexOfRightmostOne
-  }
-  
-
-  var indexOfRightmostOne: Int? {
-    let trailingZeroCount = self.trailingZeroBitCount
-    if trailingZeroCount == Self.bitWidth {
-      // All indicies are 0
-      return nil
-    }
-    return trailingZeroCount
-  }
-  
-
-  mutating func setBitToZero(at index: Int) {
-    self &= ~(1 << index)
-  }
-  
-
-  mutating func setBitToOne(at index: Int) {
-    self |= 1 << index
   }
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -46,7 +46,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
       self = .getter(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(AccessorDeclListSyntax.self) {
         self = .accessors(node)
         return
@@ -109,7 +109,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .accessorBlock else {
       return nil
     }
@@ -268,7 +268,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
 public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .accessorDecl else {
       return nil
     }
@@ -532,7 +532,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
 public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .accessorEffectSpecifiers else {
       return nil
     }
@@ -658,7 +658,7 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
 public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .accessorParameters else {
       return nil
     }
@@ -812,7 +812,7 @@ public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .actorDecl else {
       return nil
     }
@@ -1159,7 +1159,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
 public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .arrayElement else {
       return nil
     }
@@ -1278,7 +1278,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
 public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .arrayExpr else {
       return nil
     }
@@ -1451,7 +1451,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
 public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .arrayType else {
       return nil
     }
@@ -1606,7 +1606,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
 public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .arrowExpr else {
       return nil
     }
@@ -1739,7 +1739,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
 public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .asExpr else {
       return nil
     }
@@ -1911,7 +1911,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
 public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .assignmentExpr else {
       return nil
     }
@@ -2020,7 +2020,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
 public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .associatedTypeDecl else {
       return nil
     }
@@ -2494,7 +2494,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
       self = .documentationArguments(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(LabeledExprListSyntax.self) {
         self = .argumentList(node)
         return
@@ -3046,7 +3046,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .attribute else {
       return nil
     }
@@ -3263,7 +3263,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .attributedType else {
       return nil
     }
@@ -3494,7 +3494,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
       self = .availabilityLabeledArgument(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
@@ -3583,7 +3583,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .availabilityArgument else {
       return nil
     }
@@ -3710,7 +3710,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
 public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .availabilityCondition else {
       return nil
     }
@@ -3939,7 +3939,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable,
       self = .version(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(SimpleStringLiteralExprSyntax.self) {
         self = .string(node)
         return
@@ -4002,7 +4002,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable,
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .availabilityLabeledArgument else {
       return nil
     }
@@ -4160,7 +4160,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable,
 public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .awaitExpr else {
       return nil
     }
@@ -4283,7 +4283,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
 public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .backDeployedAttributeArguments else {
       return nil
     }
@@ -4468,7 +4468,7 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
 public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .binaryOperatorExpr else {
       return nil
     }
@@ -4545,7 +4545,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
 public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .booleanLiteralExpr else {
       return nil
     }
@@ -4625,7 +4625,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
 public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .borrowExpr else {
       return nil
     }
@@ -4741,7 +4741,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyn
 public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .breakStmt else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -238,17 +238,15 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndAccessors, 
-          \Self.accessors, 
-          \Self.unexpectedBetweenAccessorsAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndAccessors, 
+        \Self.accessors, 
+        \Self.unexpectedBetweenAccessorsAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - AccessorDeclSyntax
@@ -500,23 +498,21 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifier, 
-          \Self.modifier, 
-          \Self.unexpectedBetweenModifierAndAccessorSpecifier, 
-          \Self.accessorSpecifier, 
-          \Self.unexpectedBetweenAccessorSpecifierAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifier, 
+        \Self.modifier, 
+        \Self.unexpectedBetweenModifierAndAccessorSpecifier, 
+        \Self.accessorSpecifier, 
+        \Self.unexpectedBetweenAccessorSpecifierAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - AccessorEffectSpecifiersSyntax
@@ -633,15 +629,13 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsyncSpecifier, 
-          \Self.asyncSpecifier, 
-          \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedAfterThrowsClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsyncSpecifier, 
+        \Self.asyncSpecifier, 
+        \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedAfterThrowsClause
+      ])
 }
 
 // MARK: - AccessorParametersSyntax
@@ -784,17 +778,15 @@ public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ActorDeclSyntax
@@ -1121,27 +1113,25 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndActorKeyword, 
-          \Self.actorKeyword, 
-          \Self.unexpectedBetweenActorKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndActorKeyword, 
+        \Self.actorKeyword, 
+        \Self.unexpectedBetweenActorKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - ArrayElementSyntax
@@ -1255,15 +1245,13 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ArrayExprSyntax
@@ -1428,17 +1416,15 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - ArrayTypeSyntax
@@ -1574,17 +1560,15 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndElement, 
-          \Self.element, 
-          \Self.unexpectedBetweenElementAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndElement, 
+        \Self.element, 
+        \Self.unexpectedBetweenElementAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - ArrowExprSyntax
@@ -1702,15 +1686,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndArrow, 
-          \Self.arrow, 
-          \Self.unexpectedAfterArrow
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndArrow, 
+        \Self.arrow, 
+        \Self.unexpectedAfterArrow
+      ])
 }
 
 // MARK: - AsExprSyntax
@@ -1888,19 +1870,17 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndAsKeyword, 
-          \Self.asKeyword, 
-          \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
-          \Self.questionOrExclamationMark, 
-          \Self.unexpectedBetweenQuestionOrExclamationMarkAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndAsKeyword, 
+        \Self.asKeyword, 
+        \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
+        \Self.questionOrExclamationMark, 
+        \Self.unexpectedBetweenQuestionOrExclamationMarkAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - AssignmentExprSyntax
@@ -1975,9 +1955,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeEqual, \Self.equal, \Self.unexpectedAfterEqual])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeEqual, \Self.equal, \Self.unexpectedAfterEqual])
 }
 
 // MARK: - AssociatedTypeDeclSyntax
@@ -2309,25 +2287,23 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndAssociatedtypeKeyword, 
-          \Self.associatedtypeKeyword, 
-          \Self.unexpectedBetweenAssociatedtypeKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndAssociatedtypeKeyword, 
+        \Self.associatedtypeKeyword, 
+        \Self.unexpectedBetweenAssociatedtypeKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - AttributeSyntax
@@ -3236,21 +3212,19 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAtSign, 
-          \Self.atSign, 
-          \Self.unexpectedBetweenAtSignAndAttributeName, 
-          \Self.attributeName, 
-          \Self.unexpectedBetweenAttributeNameAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAtSign, 
+        \Self.atSign, 
+        \Self.unexpectedBetweenAtSignAndAttributeName, 
+        \Self.attributeName, 
+        \Self.unexpectedBetweenAttributeNameAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - AttributedTypeSyntax
@@ -3440,17 +3414,15 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSpecifiers, 
-          \Self.specifiers, 
-          \Self.unexpectedBetweenSpecifiersAndAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndBaseType, 
-          \Self.baseType, 
-          \Self.unexpectedAfterBaseType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSpecifiers, 
+        \Self.specifiers, 
+        \Self.unexpectedBetweenSpecifiersAndAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndBaseType, 
+        \Self.baseType, 
+        \Self.unexpectedAfterBaseType
+      ])
 }
 
 // MARK: - AvailabilityArgumentSyntax
@@ -3684,15 +3656,13 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArgument, 
-          \Self.argument, 
-          \Self.unexpectedBetweenArgumentAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArgument, 
+        \Self.argument, 
+        \Self.unexpectedBetweenArgumentAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - AvailabilityConditionSyntax
@@ -3889,19 +3859,17 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAvailabilityKeyword, 
-          \Self.availabilityKeyword, 
-          \Self.unexpectedBetweenAvailabilityKeywordAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndAvailabilityArguments, 
-          \Self.availabilityArguments, 
-          \Self.unexpectedBetweenAvailabilityArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAvailabilityKeyword, 
+        \Self.availabilityKeyword, 
+        \Self.unexpectedBetweenAvailabilityKeywordAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndAvailabilityArguments, 
+        \Self.availabilityArguments, 
+        \Self.unexpectedBetweenAvailabilityArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - AvailabilityLabeledArgumentSyntax
@@ -4138,17 +4106,15 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable,
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - AwaitExprSyntax
@@ -4256,15 +4222,13 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAwaitKeyword, 
-          \Self.awaitKeyword, 
-          \Self.unexpectedBetweenAwaitKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAwaitKeyword, 
+        \Self.awaitKeyword, 
+        \Self.unexpectedBetweenAwaitKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - BackDeployedAttributeArgumentsSyntax
@@ -4441,17 +4405,15 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBeforeLabel, 
-          \Self.beforeLabel, 
-          \Self.unexpectedBetweenBeforeLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPlatforms, 
-          \Self.platforms, 
-          \Self.unexpectedAfterPlatforms
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBeforeLabel, 
+        \Self.beforeLabel, 
+        \Self.unexpectedBetweenBeforeLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPlatforms, 
+        \Self.platforms, 
+        \Self.unexpectedAfterPlatforms
+      ])
 }
 
 // MARK: - BinaryOperatorExprSyntax
@@ -4532,9 +4494,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeOperator, \Self.operator, \Self.unexpectedAfterOperator])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeOperator, \Self.operator, \Self.unexpectedAfterOperator])
 }
 
 // MARK: - BooleanLiteralExprSyntax
@@ -4611,9 +4571,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
 }
 
 // MARK: - BorrowExprSyntax
@@ -4721,15 +4679,13 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBorrowKeyword, 
-          \Self.borrowKeyword, 
-          \Self.unexpectedBetweenBorrowKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBorrowKeyword, 
+        \Self.borrowKeyword, 
+        \Self.unexpectedBetweenBorrowKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - BreakStmtSyntax
@@ -4840,13 +4796,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBreakKeyword, 
-          \Self.breakKeyword, 
-          \Self.unexpectedBetweenBreakKeywordAndLabel, 
-          \Self.label, 
-          \Self.unexpectedAfterLabel
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBreakKeyword, 
+        \Self.breakKeyword, 
+        \Self.unexpectedBetweenBreakKeywordAndLabel, 
+        \Self.label, 
+        \Self.unexpectedAfterLabel
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
@@ -201,21 +201,19 @@ public struct _CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCanImportKeyword, 
-          \Self.canImportKeyword, 
-          \Self.unexpectedBetweenCanImportKeywordAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndImportPath, 
-          \Self.importPath, 
-          \Self.unexpectedBetweenImportPathAndVersionInfo, 
-          \Self.versionInfo, 
-          \Self.unexpectedBetweenVersionInfoAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCanImportKeyword, 
+        \Self.canImportKeyword, 
+        \Self.unexpectedBetweenCanImportKeywordAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndImportPath, 
+        \Self.importPath, 
+        \Self.unexpectedBetweenImportPathAndVersionInfo, 
+        \Self.versionInfo, 
+        \Self.unexpectedBetweenVersionInfoAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - _CanImportVersionInfoSyntax
@@ -385,19 +383,17 @@ public struct _CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndVersion, 
-          \Self.version, 
-          \Self.unexpectedAfterVersion
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndVersion, 
+        \Self.version, 
+        \Self.unexpectedAfterVersion
+      ])
 }
 
 // MARK: - CatchClauseSyntax
@@ -561,17 +557,15 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCatchKeyword, 
-          \Self.catchKeyword, 
-          \Self.unexpectedBetweenCatchKeywordAndCatchItems, 
-          \Self.catchItems, 
-          \Self.unexpectedBetweenCatchItemsAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCatchKeyword, 
+        \Self.catchKeyword, 
+        \Self.unexpectedBetweenCatchKeywordAndCatchItems, 
+        \Self.catchItems, 
+        \Self.unexpectedBetweenCatchItemsAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - CatchItemSyntax
@@ -708,17 +702,15 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndWhereClause, 
-          \Self.whereClause, 
-          \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndWhereClause, 
+        \Self.whereClause, 
+        \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClassDeclSyntax
@@ -1075,27 +1067,25 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndClassKeyword, 
-          \Self.classKeyword, 
-          \Self.unexpectedBetweenClassKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndClassKeyword, 
+        \Self.classKeyword, 
+        \Self.unexpectedBetweenClassKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - ClassRestrictionTypeSyntax
@@ -1170,9 +1160,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeClassKeyword, \Self.classKeyword, \Self.unexpectedAfterClassKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeClassKeyword, \Self.classKeyword, \Self.unexpectedAfterClassKeyword])
 }
 
 // MARK: - ClosureCaptureClauseSyntax
@@ -1339,17 +1327,15 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndItems, 
-          \Self.items, 
-          \Self.unexpectedBetweenItemsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndItems, 
+        \Self.items, 
+        \Self.unexpectedBetweenItemsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - ClosureCaptureSpecifierSyntax
@@ -1524,19 +1510,17 @@ public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSpecifier, 
-          \Self.specifier, 
-          \Self.unexpectedBetweenSpecifierAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndDetail, 
-          \Self.detail, 
-          \Self.unexpectedBetweenDetailAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSpecifier, 
+        \Self.specifier, 
+        \Self.unexpectedBetweenSpecifierAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndDetail, 
+        \Self.detail, 
+        \Self.unexpectedBetweenDetailAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ClosureCaptureSyntax
@@ -1729,21 +1713,19 @@ public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSpecifier, 
-          \Self.specifier, 
-          \Self.unexpectedBetweenSpecifierAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSpecifier, 
+        \Self.specifier, 
+        \Self.unexpectedBetweenSpecifierAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClosureExprSyntax
@@ -1939,19 +1921,17 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedBetweenStatementsAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedBetweenStatementsAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - ClosureParameterClauseSyntax
@@ -2126,17 +2106,15 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ClosureParameterSyntax
@@ -2485,27 +2463,25 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndEllipsis, 
-          \Self.ellipsis, 
-          \Self.unexpectedBetweenEllipsisAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndEllipsis, 
+        \Self.ellipsis, 
+        \Self.unexpectedBetweenEllipsisAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClosureShorthandParameterSyntax
@@ -2622,15 +2598,13 @@ public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ClosureSignatureSyntax
@@ -2951,23 +2925,21 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndCapture, 
-          \Self.capture, 
-          \Self.unexpectedBetweenCaptureAndParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedBetweenReturnClauseAndInKeyword, 
-          \Self.inKeyword, 
-          \Self.unexpectedAfterInKeyword
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndCapture, 
+        \Self.capture, 
+        \Self.unexpectedBetweenCaptureAndParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedBetweenReturnClauseAndInKeyword, 
+        \Self.inKeyword, 
+        \Self.unexpectedAfterInKeyword
+      ])
 }
 
 // MARK: - CodeBlockItemSyntax
@@ -3201,15 +3173,13 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeItem, 
-          \Self.item, 
-          \Self.unexpectedBetweenItemAndSemicolon, 
-          \Self.semicolon, 
-          \Self.unexpectedAfterSemicolon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeItem, 
+        \Self.item, 
+        \Self.unexpectedBetweenItemAndSemicolon, 
+        \Self.semicolon, 
+        \Self.unexpectedAfterSemicolon
+      ])
 }
 
 // MARK: - CodeBlockSyntax
@@ -3394,17 +3364,15 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedBetweenStatementsAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedBetweenStatementsAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - CompositionTypeElementSyntax
@@ -3513,15 +3481,13 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndAmpersand, 
-          \Self.ampersand, 
-          \Self.unexpectedAfterAmpersand
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndAmpersand, 
+        \Self.ampersand, 
+        \Self.unexpectedAfterAmpersand
+      ])
 }
 
 // MARK: - CompositionTypeSyntax
@@ -3620,9 +3586,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
 }
 
 // MARK: - ConditionElementSyntax
@@ -3887,15 +3851,13 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCondition, 
-          \Self.condition, 
-          \Self.unexpectedBetweenConditionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCondition, 
+        \Self.condition, 
+        \Self.unexpectedBetweenConditionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ConformanceRequirementSyntax
@@ -4032,17 +3994,15 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftType, 
-          \Self.leftType, 
-          \Self.unexpectedBetweenLeftTypeAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndRightType, 
-          \Self.rightType, 
-          \Self.unexpectedAfterRightType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftType, 
+        \Self.leftType, 
+        \Self.unexpectedBetweenLeftTypeAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndRightType, 
+        \Self.rightType, 
+        \Self.unexpectedAfterRightType
+      ])
 }
 
 // MARK: - ConsumeExprSyntax
@@ -4152,15 +4112,13 @@ public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeConsumeKeyword, 
-          \Self.consumeKeyword, 
-          \Self.unexpectedBetweenConsumeKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeConsumeKeyword, 
+        \Self.consumeKeyword, 
+        \Self.unexpectedBetweenConsumeKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - ContinueStmtSyntax
@@ -4271,15 +4229,13 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeContinueKeyword, 
-          \Self.continueKeyword, 
-          \Self.unexpectedBetweenContinueKeywordAndLabel, 
-          \Self.label, 
-          \Self.unexpectedAfterLabel
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeContinueKeyword, 
+        \Self.continueKeyword, 
+        \Self.unexpectedBetweenContinueKeywordAndLabel, 
+        \Self.label, 
+        \Self.unexpectedAfterLabel
+      ])
 }
 
 // MARK: - ConventionAttributeArgumentsSyntax
@@ -4480,21 +4436,19 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeConventionLabel, 
-          \Self.conventionLabel, 
-          \Self.unexpectedBetweenConventionLabelAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndCTypeLabel, 
-          \Self.cTypeLabel, 
-          \Self.unexpectedBetweenCTypeLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndCTypeString, 
-          \Self.cTypeString, 
-          \Self.unexpectedAfterCTypeString
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeConventionLabel, 
+        \Self.conventionLabel, 
+        \Self.unexpectedBetweenConventionLabelAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndCTypeLabel, 
+        \Self.cTypeLabel, 
+        \Self.unexpectedBetweenCTypeLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndCTypeString, 
+        \Self.cTypeString, 
+        \Self.unexpectedAfterCTypeString
+      ])
 }
 
 // MARK: - ConventionWitnessMethodAttributeArgumentsSyntax
@@ -4648,17 +4602,15 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWitnessMethodLabel, 
-          \Self.witnessMethodLabel, 
-          \Self.unexpectedBetweenWitnessMethodLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndProtocolName, 
-          \Self.protocolName, 
-          \Self.unexpectedAfterProtocolName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWitnessMethodLabel, 
+        \Self.witnessMethodLabel, 
+        \Self.unexpectedBetweenWitnessMethodLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndProtocolName, 
+        \Self.protocolName, 
+        \Self.unexpectedAfterProtocolName
+      ])
 }
 
 // MARK: - CopyExprSyntax
@@ -4766,13 +4718,11 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCopyKeyword, 
-          \Self.copyKeyword, 
-          \Self.unexpectedBetweenCopyKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCopyKeyword, 
+        \Self.copyKeyword, 
+        \Self.unexpectedBetweenCopyKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
@@ -24,7 +24,7 @@
 public struct _CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == ._canImportExpr else {
       return nil
     }
@@ -233,7 +233,7 @@ public struct _CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
 public struct _CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == ._canImportVersionInfo else {
       return nil
     }
@@ -414,7 +414,7 @@ public struct _CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable, _
 public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .catchClause else {
       return nil
     }
@@ -588,7 +588,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
 public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .catchItem else {
       return nil
     }
@@ -760,7 +760,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .classDecl else {
       return nil
     }
@@ -1106,7 +1106,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
 public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .classRestrictionType else {
       return nil
     }
@@ -1189,7 +1189,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _L
 public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureClause else {
       return nil
     }
@@ -1367,7 +1367,7 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
 public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureSpecifier else {
       return nil
     }
@@ -1555,7 +1555,7 @@ public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Le
 public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureCapture else {
       return nil
     }
@@ -1765,7 +1765,7 @@ public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
 public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureExpr else {
       return nil
     }
@@ -1968,7 +1968,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureParameterClause else {
       return nil
     }
@@ -2158,7 +2158,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
 public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureParameter else {
       return nil
     }
@@ -2521,7 +2521,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
 public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureShorthandParameter else {
       return nil
     }
@@ -2669,7 +2669,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
       self = .parameterClause(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(ClosureShorthandParameterListSyntax.self) {
         self = .simpleInput(node)
         return
@@ -2732,7 +2732,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .closureSignature else {
       return nil
     }
@@ -3011,7 +3011,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
       self = .expr(ExprSyntax(node))
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(DeclSyntax.self) {
         self = .decl(node)
         return
@@ -3100,7 +3100,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .codeBlockItem else {
       return nil
     }
@@ -3238,7 +3238,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
 public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .codeBlock else {
       return nil
     }
@@ -3420,7 +3420,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .compositionTypeElement else {
       return nil
     }
@@ -3532,7 +3532,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
 public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .compositionType else {
       return nil
     }
@@ -3671,7 +3671,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
       self = .optionalBinding(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(ExprSyntax.self) {
         self = .expression(node)
         return
@@ -3791,7 +3791,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .conditionElement else {
       return nil
     }
@@ -3912,7 +3912,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
 public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .conformanceRequirement else {
       return nil
     }
@@ -4054,7 +4054,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
 public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .consumeExpr else {
       return nil
     }
@@ -4172,7 +4172,7 @@ public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .continueStmt else {
       return nil
     }
@@ -4300,7 +4300,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtS
 public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .conventionAttributeArguments else {
       return nil
     }
@@ -4513,7 +4513,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .conventionWitnessMethodAttributeArguments else {
       return nil
     }
@@ -4670,7 +4670,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
 public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .copyExpr else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -152,17 +152,15 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndDetail, 
-          \Self.detail, 
-          \Self.unexpectedBetweenDetailAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndDetail, 
+        \Self.detail, 
+        \Self.unexpectedBetweenDetailAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - DeclModifierSyntax
@@ -312,15 +310,13 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndDetail, 
-          \Self.detail, 
-          \Self.unexpectedAfterDetail
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndDetail, 
+        \Self.detail, 
+        \Self.unexpectedAfterDetail
+      ])
 }
 
 // MARK: - DeclNameArgumentSyntax
@@ -432,15 +428,13 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - DeclNameArgumentsSyntax
@@ -607,17 +601,15 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - DeclReferenceExprSyntax
@@ -742,15 +734,13 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBaseName, 
-          \Self.baseName, 
-          \Self.unexpectedBetweenBaseNameAndArgumentNames, 
-          \Self.argumentNames, 
-          \Self.unexpectedAfterArgumentNames
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBaseName, 
+        \Self.baseName, 
+        \Self.unexpectedBetweenBaseNameAndArgumentNames, 
+        \Self.argumentNames, 
+        \Self.unexpectedAfterArgumentNames
+      ])
 }
 
 // MARK: - DeferStmtSyntax
@@ -858,15 +848,13 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDeferKeyword, 
-          \Self.deferKeyword, 
-          \Self.unexpectedBetweenDeferKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDeferKeyword, 
+        \Self.deferKeyword, 
+        \Self.unexpectedBetweenDeferKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - DeinitializerDeclSyntax
@@ -1121,21 +1109,19 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndDeinitKeyword, 
-          \Self.deinitKeyword, 
-          \Self.unexpectedBetweenDeinitKeywordAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndDeinitKeyword, 
+        \Self.deinitKeyword, 
+        \Self.unexpectedBetweenDeinitKeywordAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - DeinitializerEffectSpecifiersSyntax
@@ -1217,9 +1203,7 @@ public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashabl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeAsyncSpecifier, \Self.asyncSpecifier, \Self.unexpectedAfterAsyncSpecifier])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeAsyncSpecifier, \Self.asyncSpecifier, \Self.unexpectedAfterAsyncSpecifier])
 }
 
 // MARK: - DerivativeAttributeArgumentsSyntax
@@ -1486,25 +1470,23 @@ public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOfLabel, 
-          \Self.ofLabel, 
-          \Self.unexpectedBetweenOfLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndOriginalDeclName, 
-          \Self.originalDeclName, 
-          \Self.unexpectedBetweenOriginalDeclNameAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndAccessorSpecifier, 
-          \Self.accessorSpecifier, 
-          \Self.unexpectedBetweenAccessorSpecifierAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedAfterArguments
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOfLabel, 
+        \Self.ofLabel, 
+        \Self.unexpectedBetweenOfLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndOriginalDeclName, 
+        \Self.originalDeclName, 
+        \Self.unexpectedBetweenOriginalDeclNameAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndAccessorSpecifier, 
+        \Self.accessorSpecifier, 
+        \Self.unexpectedBetweenAccessorSpecifierAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedAfterArguments
+      ])
 }
 
 // MARK: - DesignatedTypeSyntax
@@ -1616,15 +1598,13 @@ public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeadingComma, 
-          \Self.leadingComma, 
-          \Self.unexpectedBetweenLeadingCommaAndName, 
-          \Self.name, 
-          \Self.unexpectedAfterName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeadingComma, 
+        \Self.leadingComma, 
+        \Self.unexpectedBetweenLeadingCommaAndName, 
+        \Self.name, 
+        \Self.unexpectedAfterName
+      ])
 }
 
 // MARK: - DictionaryElementSyntax
@@ -1791,19 +1771,17 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeKey, 
-          \Self.key, 
-          \Self.unexpectedBetweenKeyAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeKey, 
+        \Self.key, 
+        \Self.unexpectedBetweenKeyAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - DictionaryExprSyntax
@@ -2023,17 +2001,15 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndContent, 
-          \Self.content, 
-          \Self.unexpectedBetweenContentAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndContent, 
+        \Self.content, 
+        \Self.unexpectedBetweenContentAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - DictionaryTypeSyntax
@@ -2222,21 +2198,19 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndKey, 
-          \Self.key, 
-          \Self.unexpectedBetweenKeyAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndKey, 
+        \Self.key, 
+        \Self.unexpectedBetweenKeyAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - DifferentiabilityArgumentSyntax
@@ -2357,15 +2331,13 @@ public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArgument, 
-          \Self.argument, 
-          \Self.unexpectedBetweenArgumentAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArgument, 
+        \Self.argument, 
+        \Self.unexpectedBetweenArgumentAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - DifferentiabilityArgumentsSyntax
@@ -2536,17 +2508,15 @@ public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable, 
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - DifferentiabilityWithRespectToArgumentSyntax
@@ -2777,17 +2747,15 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWrtLabel, 
-          \Self.wrtLabel, 
-          \Self.unexpectedBetweenWrtLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedAfterArguments
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWrtLabel, 
+        \Self.wrtLabel, 
+        \Self.unexpectedBetweenWrtLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedAfterArguments
+      ])
 }
 
 // MARK: - DifferentiableAttributeArgumentsSyntax
@@ -2998,21 +2966,19 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeKindSpecifier, 
-          \Self.kindSpecifier, 
-          \Self.unexpectedBetweenKindSpecifierAndKindSpecifierComma, 
-          \Self.kindSpecifierComma, 
-          \Self.unexpectedBetweenKindSpecifierCommaAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndArgumentsComma, 
-          \Self.argumentsComma, 
-          \Self.unexpectedBetweenArgumentsCommaAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeKindSpecifier, 
+        \Self.kindSpecifier, 
+        \Self.unexpectedBetweenKindSpecifierAndKindSpecifierComma, 
+        \Self.kindSpecifierComma, 
+        \Self.unexpectedBetweenKindSpecifierCommaAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndArgumentsComma, 
+        \Self.argumentsComma, 
+        \Self.unexpectedBetweenArgumentsCommaAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - DiscardAssignmentExprSyntax
@@ -3100,9 +3066,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
 }
 
 // MARK: - DiscardStmtSyntax
@@ -3210,15 +3174,13 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDiscardKeyword, 
-          \Self.discardKeyword, 
-          \Self.unexpectedBetweenDiscardKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDiscardKeyword, 
+        \Self.discardKeyword, 
+        \Self.unexpectedBetweenDiscardKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - DoExprSyntax
@@ -3405,17 +3367,15 @@ public struct DoExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDoKeyword, 
-          \Self.doKeyword, 
-          \Self.unexpectedBetweenDoKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndCatchClauses, 
-          \Self.catchClauses, 
-          \Self.unexpectedAfterCatchClauses
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDoKeyword, 
+        \Self.doKeyword, 
+        \Self.unexpectedBetweenDoKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndCatchClauses, 
+        \Self.catchClauses, 
+        \Self.unexpectedAfterCatchClauses
+      ])
 }
 
 // MARK: - DoStmtSyntax
@@ -3602,19 +3562,17 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDoKeyword, 
-          \Self.doKeyword, 
-          \Self.unexpectedBetweenDoKeywordAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedBetweenThrowsClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndCatchClauses, 
-          \Self.catchClauses, 
-          \Self.unexpectedAfterCatchClauses
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDoKeyword, 
+        \Self.doKeyword, 
+        \Self.unexpectedBetweenDoKeywordAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedBetweenThrowsClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndCatchClauses, 
+        \Self.catchClauses, 
+        \Self.unexpectedAfterCatchClauses
+      ])
 }
 
 // MARK: - DocumentationAttributeArgumentSyntax
@@ -3869,19 +3827,17 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - DynamicReplacementAttributeArgumentsSyntax
@@ -4023,15 +3979,13 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeForLabel, 
-          \Self.forLabel, 
-          \Self.unexpectedBetweenForLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedAfterDeclName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeForLabel, 
+        \Self.forLabel, 
+        \Self.unexpectedBetweenForLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedAfterDeclName
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -26,7 +26,7 @@
 public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .declModifierDetail else {
       return nil
     }
@@ -179,7 +179,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .declModifier else {
       return nil
     }
@@ -336,7 +336,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
 public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .declNameArgument else {
       return nil
     }
@@ -457,7 +457,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .declNameArguments else {
       return nil
     }
@@ -637,7 +637,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .declReferenceExpr else {
       return nil
     }
@@ -762,7 +762,7 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .deferStmt else {
       return nil
     }
@@ -890,7 +890,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .deinitializerDecl else {
       return nil
     }
@@ -1150,7 +1150,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Leaf
 public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .deinitializerEffectSpecifiers else {
       return nil
     }
@@ -1242,7 +1242,7 @@ public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashabl
 public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .derivativeAttributeArguments else {
       return nil
     }
@@ -1520,7 +1520,7 @@ public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .designatedType else {
       return nil
     }
@@ -1644,7 +1644,7 @@ public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
 public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryElement else {
       return nil
     }
@@ -1837,7 +1837,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
       self = .elements(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .colon(node)
         return
@@ -1900,7 +1900,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryExpr else {
       return nil
     }
@@ -2048,7 +2048,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
 public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryType else {
       return nil
     }
@@ -2255,7 +2255,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
 public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityArgument else {
       return nil
     }
@@ -2384,7 +2384,7 @@ public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
 public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityArguments else {
       return nil
     }
@@ -2585,7 +2585,7 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
       self = .argumentList(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(DifferentiabilityArgumentSyntax.self) {
         self = .argument(node)
         return
@@ -2648,7 +2648,7 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityWithRespectToArgument else {
       return nil
     }
@@ -2808,7 +2808,7 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
 public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .differentiableAttributeArguments else {
       return nil
     }
@@ -3036,7 +3036,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
 public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .discardAssignmentExpr else {
       return nil
     }
@@ -3114,7 +3114,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
 public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .discardStmt else {
       return nil
     }
@@ -3258,7 +3258,7 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
 public struct DoExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .doExpr else {
       return nil
     }
@@ -3429,7 +3429,7 @@ public struct DoExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .doStmt else {
       return nil
     }
@@ -3651,7 +3651,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       self = .string(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
@@ -3714,7 +3714,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .documentationAttributeArgument else {
       return nil
     }
@@ -3900,7 +3900,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .dynamicReplacementAttributeArguments else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -207,17 +207,15 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPlaceholder, 
-          \Self.placeholder, 
-          \Self.unexpectedAfterPlaceholder
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPlaceholder, 
+        \Self.placeholder, 
+        \Self.unexpectedAfterPlaceholder
+      ])
 }
 
 // MARK: - EditorPlaceholderExprSyntax
@@ -294,9 +292,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - EnumCaseDeclSyntax
@@ -546,19 +542,17 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndElements, 
-          \Self.elements, 
-          \Self.unexpectedAfterElements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndElements, 
+        \Self.elements, 
+        \Self.unexpectedAfterElements
+      ])
 }
 
 // MARK: - EnumCaseElementSyntax
@@ -735,19 +729,17 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndRawValue, 
-          \Self.rawValue, 
-          \Self.unexpectedBetweenRawValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndRawValue, 
+        \Self.rawValue, 
+        \Self.unexpectedBetweenRawValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - EnumCaseParameterClauseSyntax
@@ -922,17 +914,15 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - EnumCaseParameterSyntax
@@ -1219,25 +1209,23 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndDefaultValue, 
-          \Self.defaultValue, 
-          \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndDefaultValue, 
+        \Self.defaultValue, 
+        \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - EnumDeclSyntax
@@ -1572,27 +1560,25 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndEnumKeyword, 
-          \Self.enumKeyword, 
-          \Self.unexpectedBetweenEnumKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndEnumKeyword, 
+        \Self.enumKeyword, 
+        \Self.unexpectedBetweenEnumKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - ExposeAttributeArgumentsSyntax
@@ -1731,17 +1717,15 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLanguage, 
-          \Self.language, 
-          \Self.unexpectedBetweenLanguageAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndCxxName, 
-          \Self.cxxName, 
-          \Self.unexpectedAfterCxxName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLanguage, 
+        \Self.language, 
+        \Self.unexpectedBetweenLanguageAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndCxxName, 
+        \Self.cxxName, 
+        \Self.unexpectedAfterCxxName
+      ])
 }
 
 // MARK: - ExpressionPatternSyntax
@@ -1827,9 +1811,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
 }
 
 // MARK: - ExpressionSegmentSyntax
@@ -2056,21 +2038,19 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBackslash, 
-          \Self.backslash, 
-          \Self.unexpectedBetweenBackslashAndPounds, 
-          \Self.pounds, 
-          \Self.unexpectedBetweenPoundsAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndExpressions, 
-          \Self.expressions, 
-          \Self.unexpectedBetweenExpressionsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBackslash, 
+        \Self.backslash, 
+        \Self.unexpectedBetweenBackslashAndPounds, 
+        \Self.pounds, 
+        \Self.unexpectedBetweenPoundsAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndExpressions, 
+        \Self.expressions, 
+        \Self.unexpectedBetweenExpressionsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - ExpressionStmtSyntax
@@ -2142,9 +2122,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStm
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeExpression, \Self.expression, \Self.unexpectedAfterExpression])
 }
 
 // MARK: - ExtensionDeclSyntax
@@ -2437,25 +2415,23 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndExtensionKeyword, 
-          \Self.extensionKeyword, 
-          \Self.unexpectedBetweenExtensionKeywordAndExtendedType, 
-          \Self.extendedType, 
-          \Self.unexpectedBetweenExtendedTypeAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndExtensionKeyword, 
+        \Self.extensionKeyword, 
+        \Self.unexpectedBetweenExtensionKeywordAndExtendedType, 
+        \Self.extendedType, 
+        \Self.unexpectedBetweenExtendedTypeAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - FallThroughStmtSyntax
@@ -2530,9 +2506,7 @@ public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafSt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeFallthroughKeyword, \Self.fallthroughKeyword, \Self.unexpectedAfterFallthroughKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeFallthroughKeyword, \Self.fallthroughKeyword, \Self.unexpectedAfterFallthroughKeyword])
 }
 
 // MARK: - FloatLiteralExprSyntax
@@ -2607,9 +2581,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
 }
 
 // MARK: - ForStmtSyntax
@@ -2929,31 +2901,29 @@ public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeForKeyword, 
-          \Self.forKeyword, 
-          \Self.unexpectedBetweenForKeywordAndTryKeyword, 
-          \Self.tryKeyword, 
-          \Self.unexpectedBetweenTryKeywordAndAwaitKeyword, 
-          \Self.awaitKeyword, 
-          \Self.unexpectedBetweenAwaitKeywordAndCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInKeyword, 
-          \Self.inKeyword, 
-          \Self.unexpectedBetweenInKeywordAndSequence, 
-          \Self.sequence, 
-          \Self.unexpectedBetweenSequenceAndWhereClause, 
-          \Self.whereClause, 
-          \Self.unexpectedBetweenWhereClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeForKeyword, 
+        \Self.forKeyword, 
+        \Self.unexpectedBetweenForKeywordAndTryKeyword, 
+        \Self.tryKeyword, 
+        \Self.unexpectedBetweenTryKeywordAndAwaitKeyword, 
+        \Self.awaitKeyword, 
+        \Self.unexpectedBetweenAwaitKeywordAndCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInKeyword, 
+        \Self.inKeyword, 
+        \Self.unexpectedBetweenInKeywordAndSequence, 
+        \Self.sequence, 
+        \Self.unexpectedBetweenSequenceAndWhereClause, 
+        \Self.whereClause, 
+        \Self.unexpectedBetweenWhereClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - ForceUnwrapExprSyntax
@@ -3061,15 +3031,13 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndExclamationMark, 
-          \Self.exclamationMark, 
-          \Self.unexpectedAfterExclamationMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndExclamationMark, 
+        \Self.exclamationMark, 
+        \Self.unexpectedAfterExclamationMark
+      ])
 }
 
 // MARK: - FunctionCallExprSyntax
@@ -3334,23 +3302,21 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCalledExpression, 
-          \Self.calledExpression, 
-          \Self.unexpectedBetweenCalledExpressionAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCalledExpression, 
+        \Self.calledExpression, 
+        \Self.unexpectedBetweenCalledExpressionAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - FunctionDeclSyntax
@@ -3678,27 +3644,25 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFuncKeyword, 
-          \Self.funcKeyword, 
-          \Self.unexpectedBetweenFuncKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFuncKeyword, 
+        \Self.funcKeyword, 
+        \Self.unexpectedBetweenFuncKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - FunctionEffectSpecifiersSyntax
@@ -3817,15 +3781,13 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsyncSpecifier, 
-          \Self.asyncSpecifier, 
-          \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedAfterThrowsClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsyncSpecifier, 
+        \Self.asyncSpecifier, 
+        \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedAfterThrowsClause
+      ])
 }
 
 // MARK: - FunctionParameterClauseSyntax
@@ -3993,17 +3955,15 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - FunctionParameterSyntax
@@ -4360,29 +4320,27 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndEllipsis, 
-          \Self.ellipsis, 
-          \Self.unexpectedBetweenEllipsisAndDefaultValue, 
-          \Self.defaultValue, 
-          \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndEllipsis, 
+        \Self.ellipsis, 
+        \Self.unexpectedBetweenEllipsisAndDefaultValue, 
+        \Self.defaultValue, 
+        \Self.unexpectedBetweenDefaultValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - FunctionSignatureSyntax
@@ -4518,17 +4476,15 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedAfterReturnClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedAfterReturnClause
+      ])
 }
 
 // MARK: - FunctionTypeSyntax
@@ -4741,19 +4697,17 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndEffectSpecifiers, 
-          \Self.effectSpecifiers, 
-          \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedAfterReturnClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndEffectSpecifiers, 
+        \Self.effectSpecifiers, 
+        \Self.unexpectedBetweenEffectSpecifiersAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedAfterReturnClause
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -26,7 +26,7 @@
 public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .editorPlaceholderDecl else {
       return nil
     }
@@ -230,7 +230,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _
 public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .editorPlaceholderExpr else {
       return nil
     }
@@ -312,7 +312,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseDecl else {
       return nil
     }
@@ -578,7 +578,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseElement else {
       return nil
     }
@@ -764,7 +764,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
 public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameterClause else {
       return nil
     }
@@ -953,7 +953,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
 public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameter else {
       return nil
     }
@@ -1257,7 +1257,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .enumDecl else {
       return nil
     }
@@ -1611,7 +1611,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynta
 public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .exposeAttributeArguments else {
       return nil
     }
@@ -1766,7 +1766,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _L
 public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .expressionPattern else {
       return nil
     }
@@ -1852,7 +1852,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
 public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .expressionSegment else {
       return nil
     }
@@ -2081,7 +2081,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .expressionStmt else {
       return nil
     }
@@ -2161,7 +2161,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStm
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .extensionDecl else {
       return nil
     }
@@ -2466,7 +2466,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
 public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .fallThroughStmt else {
       return nil
     }
@@ -2543,7 +2543,7 @@ public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafSt
 public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .floatLiteralExpr else {
       return nil
     }
@@ -2629,7 +2629,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
 public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .forStmt else {
       return nil
     }
@@ -2965,7 +2965,7 @@ public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntax
 public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .forceUnwrapExpr else {
       return nil
     }
@@ -3085,7 +3085,7 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionCallExpr else {
       return nil
     }
@@ -3368,7 +3368,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionDecl else {
       return nil
     }
@@ -3714,7 +3714,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
 public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionEffectSpecifiers else {
       return nil
     }
@@ -3843,7 +3843,7 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
 public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionParameterClause else {
       return nil
     }
@@ -4026,7 +4026,7 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
 public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionParameter else {
       return nil
     }
@@ -4401,7 +4401,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionSignature else {
       return nil
     }
@@ -4543,7 +4543,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionType else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -181,17 +181,15 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftAngle, 
-          \Self.leftAngle, 
-          \Self.unexpectedBetweenLeftAngleAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightAngle, 
-          \Self.rightAngle, 
-          \Self.unexpectedAfterRightAngle
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftAngle, 
+        \Self.leftAngle, 
+        \Self.unexpectedBetweenLeftAngleAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightAngle, 
+        \Self.rightAngle, 
+        \Self.unexpectedAfterRightAngle
+      ])
 }
 
 // MARK: - GenericArgumentSyntax
@@ -303,15 +301,13 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArgument, 
-          \Self.argument, 
-          \Self.unexpectedBetweenArgumentAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArgument, 
+        \Self.argument, 
+        \Self.unexpectedBetweenArgumentAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - GenericParameterClauseSyntax
@@ -524,19 +520,17 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftAngle, 
-          \Self.leftAngle, 
-          \Self.unexpectedBetweenLeftAngleAndParameters, 
-          \Self.parameters, 
-          \Self.unexpectedBetweenParametersAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndRightAngle, 
-          \Self.rightAngle, 
-          \Self.unexpectedAfterRightAngle
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftAngle, 
+        \Self.leftAngle, 
+        \Self.unexpectedBetweenLeftAngleAndParameters, 
+        \Self.parameters, 
+        \Self.unexpectedBetweenParametersAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndRightAngle, 
+        \Self.rightAngle, 
+        \Self.unexpectedAfterRightAngle
+      ])
 }
 
 // MARK: - GenericParameterSyntax
@@ -784,23 +778,21 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndEachKeyword, 
-          \Self.eachKeyword, 
-          \Self.unexpectedBetweenEachKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndInheritedType, 
-          \Self.inheritedType, 
-          \Self.unexpectedBetweenInheritedTypeAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndEachKeyword, 
+        \Self.eachKeyword, 
+        \Self.unexpectedBetweenEachKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndInheritedType, 
+        \Self.inheritedType, 
+        \Self.unexpectedBetweenInheritedTypeAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - GenericRequirementSyntax
@@ -1027,15 +1019,13 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRequirement, 
-          \Self.requirement, 
-          \Self.unexpectedBetweenRequirementAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRequirement, 
+        \Self.requirement, 
+        \Self.unexpectedBetweenRequirementAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - GenericSpecializationExprSyntax
@@ -1140,15 +1130,13 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - GenericWhereClauseSyntax
@@ -1308,15 +1296,13 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWhereKeyword, 
-          \Self.whereKeyword, 
-          \Self.unexpectedBetweenWhereKeywordAndRequirements, 
-          \Self.requirements, 
-          \Self.unexpectedAfterRequirements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWhereKeyword, 
+        \Self.whereKeyword, 
+        \Self.unexpectedBetweenWhereKeywordAndRequirements, 
+        \Self.requirements, 
+        \Self.unexpectedAfterRequirements
+      ])
 }
 
 // MARK: - GuardStmtSyntax
@@ -1504,19 +1490,17 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeGuardKeyword, 
-          \Self.guardKeyword, 
-          \Self.unexpectedBetweenGuardKeywordAndConditions, 
-          \Self.conditions, 
-          \Self.unexpectedBetweenConditionsAndElseKeyword, 
-          \Self.elseKeyword, 
-          \Self.unexpectedBetweenElseKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeGuardKeyword, 
+        \Self.guardKeyword, 
+        \Self.unexpectedBetweenGuardKeywordAndConditions, 
+        \Self.conditions, 
+        \Self.unexpectedBetweenConditionsAndElseKeyword, 
+        \Self.elseKeyword, 
+        \Self.unexpectedBetweenElseKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - IdentifierPatternSyntax
@@ -1607,9 +1591,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeIdentifier, \Self.identifier, \Self.unexpectedAfterIdentifier])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeIdentifier, \Self.identifier, \Self.unexpectedAfterIdentifier])
 }
 
 // MARK: - IdentifierTypeSyntax
@@ -1721,15 +1703,13 @@ public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - IfConfigClauseSyntax
@@ -2056,17 +2036,15 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePoundKeyword, 
-          \Self.poundKeyword, 
-          \Self.unexpectedBetweenPoundKeywordAndCondition, 
-          \Self.condition, 
-          \Self.unexpectedBetweenConditionAndElements, 
-          \Self.elements, 
-          \Self.unexpectedAfterElements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePoundKeyword, 
+        \Self.poundKeyword, 
+        \Self.unexpectedBetweenPoundKeywordAndCondition, 
+        \Self.condition, 
+        \Self.unexpectedBetweenConditionAndElements, 
+        \Self.elements, 
+        \Self.unexpectedAfterElements
+      ])
 }
 
 // MARK: - IfConfigDeclSyntax
@@ -2207,15 +2185,13 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeClauses, 
-          \Self.clauses, 
-          \Self.unexpectedBetweenClausesAndPoundEndif, 
-          \Self.poundEndif, 
-          \Self.unexpectedAfterPoundEndif
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeClauses, 
+        \Self.clauses, 
+        \Self.unexpectedBetweenClausesAndPoundEndif, 
+        \Self.poundEndif, 
+        \Self.unexpectedAfterPoundEndif
+      ])
 }
 
 // MARK: - IfExprSyntax
@@ -2514,21 +2490,19 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeIfKeyword, 
-          \Self.ifKeyword, 
-          \Self.unexpectedBetweenIfKeywordAndConditions, 
-          \Self.conditions, 
-          \Self.unexpectedBetweenConditionsAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndElseKeyword, 
-          \Self.elseKeyword, 
-          \Self.unexpectedBetweenElseKeywordAndElseBody, 
-          \Self.elseBody, 
-          \Self.unexpectedAfterElseBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeIfKeyword, 
+        \Self.ifKeyword, 
+        \Self.unexpectedBetweenIfKeywordAndConditions, 
+        \Self.conditions, 
+        \Self.unexpectedBetweenConditionsAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndElseKeyword, 
+        \Self.elseKeyword, 
+        \Self.unexpectedBetweenElseKeywordAndElseBody, 
+        \Self.elseBody, 
+        \Self.unexpectedAfterElseBody
+      ])
 }
 
 // MARK: - ImplementsAttributeArgumentsSyntax
@@ -2674,17 +2648,15 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedAfterDeclName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedAfterDeclName
+      ])
 }
 
 // MARK: - ImplicitlyUnwrappedOptionalTypeSyntax
@@ -2792,15 +2764,13 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWrappedType, 
-          \Self.wrappedType, 
-          \Self.unexpectedBetweenWrappedTypeAndExclamationMark, 
-          \Self.exclamationMark, 
-          \Self.unexpectedAfterExclamationMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWrappedType, 
+        \Self.wrappedType, 
+        \Self.unexpectedBetweenWrappedTypeAndExclamationMark, 
+        \Self.exclamationMark, 
+        \Self.unexpectedAfterExclamationMark
+      ])
 }
 
 // MARK: - ImportDeclSyntax
@@ -3098,21 +3068,19 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndImportKeyword, 
-          \Self.importKeyword, 
-          \Self.unexpectedBetweenImportKeywordAndImportKindSpecifier, 
-          \Self.importKindSpecifier, 
-          \Self.unexpectedBetweenImportKindSpecifierAndPath, 
-          \Self.path, 
-          \Self.unexpectedAfterPath
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndImportKeyword, 
+        \Self.importKeyword, 
+        \Self.unexpectedBetweenImportKeywordAndImportKindSpecifier, 
+        \Self.importKindSpecifier, 
+        \Self.unexpectedBetweenImportKindSpecifierAndPath, 
+        \Self.path, 
+        \Self.unexpectedAfterPath
+      ])
 }
 
 // MARK: - ImportPathComponentSyntax
@@ -3231,15 +3199,13 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingPeriod, 
-          \Self.trailingPeriod, 
-          \Self.unexpectedAfterTrailingPeriod
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingPeriod, 
+        \Self.trailingPeriod, 
+        \Self.unexpectedAfterTrailingPeriod
+      ])
 }
 
 // MARK: - InOutExprSyntax
@@ -3349,15 +3315,13 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAmpersand, 
-          \Self.ampersand, 
-          \Self.unexpectedBetweenAmpersandAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAmpersand, 
+        \Self.ampersand, 
+        \Self.unexpectedBetweenAmpersandAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - InfixOperatorExprSyntax
@@ -3493,17 +3457,15 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftOperand, 
-          \Self.leftOperand, 
-          \Self.unexpectedBetweenLeftOperandAndOperator, 
-          \Self.operator, 
-          \Self.unexpectedBetweenOperatorAndRightOperand, 
-          \Self.rightOperand, 
-          \Self.unexpectedAfterRightOperand
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftOperand, 
+        \Self.leftOperand, 
+        \Self.unexpectedBetweenLeftOperandAndOperator, 
+        \Self.operator, 
+        \Self.unexpectedBetweenOperatorAndRightOperand, 
+        \Self.rightOperand, 
+        \Self.unexpectedAfterRightOperand
+      ])
 }
 
 // MARK: - InheritanceClauseSyntax
@@ -3648,15 +3610,13 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndInheritedTypes, 
-          \Self.inheritedTypes, 
-          \Self.unexpectedAfterInheritedTypes
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndInheritedTypes, 
+        \Self.inheritedTypes, 
+        \Self.unexpectedAfterInheritedTypes
+      ])
 }
 
 // MARK: - InheritedTypeSyntax
@@ -3768,15 +3728,13 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - InitializerClauseSyntax
@@ -3894,15 +3852,13 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - InitializerDeclSyntax
@@ -4248,27 +4204,25 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDe
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndInitKeyword, 
-          \Self.initKeyword, 
-          \Self.unexpectedBetweenInitKeywordAndOptionalMark, 
-          \Self.optionalMark, 
-          \Self.unexpectedBetweenOptionalMarkAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndInitKeyword, 
+        \Self.initKeyword, 
+        \Self.unexpectedBetweenInitKeywordAndOptionalMark, 
+        \Self.optionalMark, 
+        \Self.unexpectedBetweenOptionalMarkAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - IntegerLiteralExprSyntax
@@ -4343,9 +4297,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeLiteral, \Self.literal, \Self.unexpectedAfterLiteral])
 }
 
 // MARK: - IsExprSyntax
@@ -4496,17 +4448,15 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndIsKeyword, 
-          \Self.isKeyword, 
-          \Self.unexpectedBetweenIsKeywordAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndIsKeyword, 
+        \Self.isKeyword, 
+        \Self.unexpectedBetweenIsKeywordAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - IsTypePatternSyntax
@@ -4614,13 +4564,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafP
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeIsKeyword, 
-          \Self.isKeyword, 
-          \Self.unexpectedBetweenIsKeywordAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeIsKeyword, 
+        \Self.isKeyword, 
+        \Self.unexpectedBetweenIsKeywordAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -31,7 +31,7 @@
 public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .genericArgumentClause else {
       return nil
     }
@@ -207,7 +207,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .genericArgument else {
       return nil
     }
@@ -340,7 +340,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
 public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .genericParameterClause else {
       return nil
     }
@@ -556,7 +556,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
 public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .genericParameter else {
       return nil
     }
@@ -842,7 +842,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
       self = .layoutRequirement(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(SameTypeRequirementSyntax.self) {
         self = .sameTypeRequirement(node)
         return
@@ -931,7 +931,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .genericRequirement else {
       return nil
     }
@@ -1047,7 +1047,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .genericSpecializationExpr else {
       return nil
     }
@@ -1180,7 +1180,7 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
 public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .genericWhereClause else {
       return nil
     }
@@ -1330,7 +1330,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .guardStmt else {
       return nil
     }
@@ -1538,7 +1538,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .identifierPattern else {
       return nil
     }
@@ -1621,7 +1621,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
 public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .identifierType else {
       return nil
     }
@@ -1786,7 +1786,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
       self = .attributes(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(CodeBlockItemListSyntax.self) {
         self = .statements(node)
         return
@@ -1933,7 +1933,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigClause else {
       return nil
     }
@@ -2084,7 +2084,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
 public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigDecl else {
       return nil
     }
@@ -2253,7 +2253,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
       self = .codeBlock(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(IfExprSyntax.self) {
         self = .ifExpr(node)
         return
@@ -2316,7 +2316,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .ifExpr else {
       return nil
     }
@@ -2547,7 +2547,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .implementsAttributeArguments else {
       return nil
     }
@@ -2696,7 +2696,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .implicitlyUnwrappedOptionalType else {
       return nil
     }
@@ -2823,7 +2823,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .importDecl else {
       return nil
     }
@@ -3128,7 +3128,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
 public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .importPathComponent else {
       return nil
     }
@@ -3253,7 +3253,7 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .inOutExpr else {
       return nil
     }
@@ -3376,7 +3376,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
 public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .infixOperatorExpr else {
       return nil
     }
@@ -3525,7 +3525,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .inheritanceClause else {
       return nil
     }
@@ -3672,7 +3672,7 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .inheritedType else {
       return nil
     }
@@ -3798,7 +3798,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .initializerClause else {
       return nil
     }
@@ -3931,7 +3931,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .initializerDecl else {
       return nil
     }
@@ -4279,7 +4279,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDe
 public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .integerLiteralExpr else {
       return nil
     }
@@ -4369,7 +4369,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .isExpr else {
       return nil
     }
@@ -4518,7 +4518,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
 public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .isTypePattern else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -53,7 +53,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
       self = .optional(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(KeyPathPropertyComponentSyntax.self) {
         self = .property(node)
         return
@@ -142,7 +142,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .keyPathComponent else {
       return nil
     }
@@ -267,7 +267,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
 public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .keyPathExpr else {
       return nil
     }
@@ -441,7 +441,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .keyPathOptionalComponent else {
       return nil
     }
@@ -527,7 +527,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
 public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .keyPathPropertyComponent else {
       return nil
     }
@@ -647,7 +647,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
 public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .keyPathSubscriptComponent else {
       return nil
     }
@@ -831,7 +831,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable, _
 public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .labeledExpr else {
       return nil
     }
@@ -1015,7 +1015,7 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
 public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .labeledSpecializeArgument else {
       return nil
     }
@@ -1207,7 +1207,7 @@ public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
 public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .labeledStmt else {
       return nil
     }
@@ -1362,7 +1362,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
 public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .layoutRequirement else {
       return nil
     }
@@ -1671,7 +1671,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .lifetimeSpecifierArgument else {
       return nil
     }
@@ -1813,7 +1813,7 @@ public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
 public struct LifetimeTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .lifetimeTypeSpecifier else {
       return nil
     }
@@ -2055,7 +2055,7 @@ public struct LifetimeTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
 public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .macroDecl else {
       return nil
     }
@@ -2398,7 +2398,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
 public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .macroExpansionDecl else {
       return nil
     }
@@ -2850,7 +2850,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
 public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .macroExpansionExpr else {
       return nil
     }
@@ -3194,7 +3194,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
 public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .matchingPatternCondition else {
       return nil
     }
@@ -3365,7 +3365,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .memberAccessExpr else {
       return nil
     }
@@ -3517,7 +3517,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
 public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .memberBlockItem else {
       return nil
     }
@@ -3648,7 +3648,7 @@ public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
 public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .memberBlock else {
       return nil
     }
@@ -3822,7 +3822,7 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
 public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .memberType else {
       return nil
     }
@@ -3996,7 +3996,7 @@ public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyn
 public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .metatypeType else {
       return nil
     }
@@ -4146,7 +4146,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .missingDecl else {
       return nil
     }
@@ -4352,7 +4352,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSy
 public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .missingExpr else {
       return nil
     }
@@ -4436,7 +4436,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .missingPattern else {
       return nil
     }
@@ -4520,7 +4520,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Leaf
 public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .missingStmt else {
       return nil
     }
@@ -4604,7 +4604,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
 public struct MissingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .missing else {
       return nil
     }
@@ -4688,7 +4688,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProt
 public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .missingType else {
       return nil
     }
@@ -4776,7 +4776,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSy
 public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .multipleTrailingClosureElement else {
       return nil
     }
@@ -4923,7 +4923,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
 public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .namedOpaqueReturnType else {
       return nil
     }
@@ -5037,7 +5037,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _
 public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .nilLiteralExpr else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -238,15 +238,13 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndComponent, 
-          \Self.component, 
-          \Self.unexpectedAfterComponent
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndComponent, 
+        \Self.component, 
+        \Self.unexpectedAfterComponent
+      ])
 }
 
 // MARK: - KeyPathExprSyntax
@@ -414,17 +412,15 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBackslash, 
-          \Self.backslash, 
-          \Self.unexpectedBetweenBackslashAndRoot, 
-          \Self.root, 
-          \Self.unexpectedBetweenRootAndComponents, 
-          \Self.components, 
-          \Self.unexpectedAfterComponents
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBackslash, 
+        \Self.backslash, 
+        \Self.unexpectedBetweenBackslashAndRoot, 
+        \Self.root, 
+        \Self.unexpectedBetweenRootAndComponents, 
+        \Self.components, 
+        \Self.unexpectedAfterComponents
+      ])
 }
 
 // MARK: - KeyPathOptionalComponentSyntax
@@ -507,9 +503,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeQuestionOrExclamationMark, \Self.questionOrExclamationMark, \Self.unexpectedAfterQuestionOrExclamationMark])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeQuestionOrExclamationMark, \Self.questionOrExclamationMark, \Self.unexpectedAfterQuestionOrExclamationMark])
 }
 
 // MARK: - KeyPathPropertyComponentSyntax
@@ -620,15 +614,13 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDeclName, 
-          \Self.declName, 
-          \Self.unexpectedBetweenDeclNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDeclName, 
+        \Self.declName, 
+        \Self.unexpectedBetweenDeclNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - KeyPathSubscriptComponentSyntax
@@ -797,17 +789,15 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedAfterRightSquare
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedAfterRightSquare
+      ])
 }
 
 // MARK: - LabeledExprSyntax
@@ -983,19 +973,17 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - LabeledSpecializeArgumentSyntax
@@ -1182,19 +1170,17 @@ public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedBetweenValueAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedBetweenValueAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - LabeledStmtSyntax
@@ -1330,17 +1316,15 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndStatement, 
-          \Self.statement, 
-          \Self.unexpectedAfterStatement
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndStatement, 
+        \Self.statement, 
+        \Self.unexpectedAfterStatement
+      ])
 }
 
 // MARK: - LayoutRequirementSyntax
@@ -1629,27 +1613,25 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndLayoutSpecifier, 
-          \Self.layoutSpecifier, 
-          \Self.unexpectedBetweenLayoutSpecifierAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndSize, 
-          \Self.size, 
-          \Self.unexpectedBetweenSizeAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndAlignment, 
-          \Self.alignment, 
-          \Self.unexpectedBetweenAlignmentAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndLayoutSpecifier, 
+        \Self.layoutSpecifier, 
+        \Self.unexpectedBetweenLayoutSpecifierAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndSize, 
+        \Self.size, 
+        \Self.unexpectedBetweenSizeAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndAlignment, 
+        \Self.alignment, 
+        \Self.unexpectedBetweenAlignmentAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - LifetimeSpecifierArgumentSyntax
@@ -1779,15 +1761,13 @@ public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeParameter, 
-          \Self.parameter, 
-          \Self.unexpectedBetweenParameterAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeParameter, 
+        \Self.parameter, 
+        \Self.unexpectedBetweenParameterAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - LifetimeTypeSpecifierSyntax
@@ -2023,21 +2003,19 @@ public struct LifetimeTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDependsOnKeyword, 
-          \Self.dependsOnKeyword, 
-          \Self.unexpectedBetweenDependsOnKeywordAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndScopedKeyword, 
-          \Self.scopedKeyword, 
-          \Self.unexpectedBetweenScopedKeywordAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDependsOnKeyword, 
+        \Self.dependsOnKeyword, 
+        \Self.unexpectedBetweenDependsOnKeywordAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndScopedKeyword, 
+        \Self.scopedKeyword, 
+        \Self.unexpectedBetweenScopedKeywordAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - MacroDeclSyntax
@@ -2356,27 +2334,25 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndMacroKeyword, 
-          \Self.macroKeyword, 
-          \Self.unexpectedBetweenMacroKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
-          \Self.signature, 
-          \Self.unexpectedBetweenSignatureAndDefinition, 
-          \Self.definition, 
-          \Self.unexpectedBetweenDefinitionAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndMacroKeyword, 
+        \Self.macroKeyword, 
+        \Self.unexpectedBetweenMacroKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndSignature, 
+        \Self.signature, 
+        \Self.unexpectedBetweenSignatureAndDefinition, 
+        \Self.definition, 
+        \Self.unexpectedBetweenDefinitionAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - MacroExpansionDeclSyntax
@@ -2806,31 +2782,29 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPound, 
-          \Self.pound, 
-          \Self.unexpectedBetweenPoundAndMacroName, 
-          \Self.macroName, 
-          \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPound, 
+        \Self.pound, 
+        \Self.unexpectedBetweenPoundAndMacroName, 
+        \Self.macroName, 
+        \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - MacroExpansionExprSyntax
@@ -3156,27 +3130,25 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePound, 
-          \Self.pound, 
-          \Self.unexpectedBetweenPoundAndMacroName, 
-          \Self.macroName, 
-          \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedBetweenRightParenAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePound, 
+        \Self.pound, 
+        \Self.unexpectedBetweenPoundAndMacroName, 
+        \Self.macroName, 
+        \Self.unexpectedBetweenMacroNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedBetweenGenericArgumentClauseAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedBetweenRightParenAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - MatchingPatternConditionSyntax
@@ -3338,19 +3310,17 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedAfterInitializer
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedAfterInitializer
+      ])
 }
 
 // MARK: - MemberAccessExprSyntax
@@ -3489,17 +3459,15 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBase, 
-          \Self.base, 
-          \Self.unexpectedBetweenBaseAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedAfterDeclName
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBase, 
+        \Self.base, 
+        \Self.unexpectedBetweenBaseAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedAfterDeclName
+      ])
 }
 
 // MARK: - MemberBlockItemSyntax
@@ -3618,15 +3586,13 @@ public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDecl, 
-          \Self.decl, 
-          \Self.unexpectedBetweenDeclAndSemicolon, 
-          \Self.semicolon, 
-          \Self.unexpectedAfterSemicolon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDecl, 
+        \Self.decl, 
+        \Self.unexpectedBetweenDeclAndSemicolon, 
+        \Self.semicolon, 
+        \Self.unexpectedAfterSemicolon
+      ])
 }
 
 // MARK: - MemberBlockSyntax
@@ -3798,17 +3764,15 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndMembers, 
-          \Self.members, 
-          \Self.unexpectedBetweenMembersAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndMembers, 
+        \Self.members, 
+        \Self.unexpectedBetweenMembersAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - MemberTypeSyntax
@@ -3971,19 +3935,17 @@ public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBaseType, 
-          \Self.baseType, 
-          \Self.unexpectedBetweenBaseTypeAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericArgumentClause, 
-          \Self.genericArgumentClause, 
-          \Self.unexpectedAfterGenericArgumentClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBaseType, 
+        \Self.baseType, 
+        \Self.unexpectedBetweenBaseTypeAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericArgumentClause, 
+        \Self.genericArgumentClause, 
+        \Self.unexpectedAfterGenericArgumentClause
+      ])
 }
 
 // MARK: - MetatypeTypeSyntax
@@ -4121,17 +4083,15 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBaseType, 
-          \Self.baseType, 
-          \Self.unexpectedBetweenBaseTypeAndPeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndMetatypeSpecifier, 
-          \Self.metatypeSpecifier, 
-          \Self.unexpectedAfterMetatypeSpecifier
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBaseType, 
+        \Self.baseType, 
+        \Self.unexpectedBetweenBaseTypeAndPeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndMetatypeSpecifier, 
+        \Self.metatypeSpecifier, 
+        \Self.unexpectedAfterMetatypeSpecifier
+      ])
 }
 
 // MARK: - MissingDeclSyntax
@@ -4329,17 +4289,15 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPlaceholder, 
-          \Self.placeholder, 
-          \Self.unexpectedAfterPlaceholder
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPlaceholder, 
+        \Self.placeholder, 
+        \Self.unexpectedAfterPlaceholder
+      ])
 }
 
 // MARK: - MissingExprSyntax
@@ -4421,9 +4379,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingPatternSyntax
@@ -4505,9 +4461,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingStmtSyntax
@@ -4589,9 +4543,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingSyntax
@@ -4673,9 +4625,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MissingTypeSyntax
@@ -4757,9 +4707,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePlaceholder, \Self.placeholder, \Self.unexpectedAfterPlaceholder])
 }
 
 // MARK: - MultipleTrailingClosureElementSyntax
@@ -4901,17 +4849,15 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndClosure, 
-          \Self.closure, 
-          \Self.unexpectedAfterClosure
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndClosure, 
+        \Self.closure, 
+        \Self.unexpectedAfterClosure
+      ])
 }
 
 // MARK: - NamedOpaqueReturnTypeSyntax
@@ -5018,15 +4964,13 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - NilLiteralExprSyntax
@@ -5101,7 +5045,5 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeNilKeyword, \Self.nilKeyword, \Self.unexpectedAfterNilKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeNilKeyword, \Self.nilKeyword, \Self.unexpectedAfterNilKeyword])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
@@ -128,15 +128,13 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - OpaqueReturnTypeOfAttributeArgumentsSyntax
@@ -283,17 +281,15 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeMangledName, 
-          \Self.mangledName, 
-          \Self.unexpectedBetweenMangledNameAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndOrdinal, 
-          \Self.ordinal, 
-          \Self.unexpectedAfterOrdinal
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeMangledName, 
+        \Self.mangledName, 
+        \Self.unexpectedBetweenMangledNameAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndOrdinal, 
+        \Self.ordinal, 
+        \Self.unexpectedAfterOrdinal
+      ])
 }
 
 // MARK: - OperatorDeclSyntax
@@ -470,19 +466,17 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeFixitySpecifier, 
-          \Self.fixitySpecifier, 
-          \Self.unexpectedBetweenFixitySpecifierAndOperatorKeyword, 
-          \Self.operatorKeyword, 
-          \Self.unexpectedBetweenOperatorKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndOperatorPrecedenceAndTypes, 
-          \Self.operatorPrecedenceAndTypes, 
-          \Self.unexpectedAfterOperatorPrecedenceAndTypes
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeFixitySpecifier, 
+        \Self.fixitySpecifier, 
+        \Self.unexpectedBetweenFixitySpecifierAndOperatorKeyword, 
+        \Self.operatorKeyword, 
+        \Self.unexpectedBetweenOperatorKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndOperatorPrecedenceAndTypes, 
+        \Self.operatorPrecedenceAndTypes, 
+        \Self.unexpectedAfterOperatorPrecedenceAndTypes
+      ])
 }
 
 // MARK: - OperatorPrecedenceAndTypesSyntax
@@ -656,17 +650,15 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable, 
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPrecedenceGroup, 
-          \Self.precedenceGroup, 
-          \Self.unexpectedBetweenPrecedenceGroupAndDesignatedTypes, 
-          \Self.designatedTypes, 
-          \Self.unexpectedAfterDesignatedTypes
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPrecedenceGroup, 
+        \Self.precedenceGroup, 
+        \Self.unexpectedBetweenPrecedenceGroupAndDesignatedTypes, 
+        \Self.designatedTypes, 
+        \Self.unexpectedAfterDesignatedTypes
+      ])
 }
 
 // MARK: - OptionalBindingConditionSyntax
@@ -834,19 +826,17 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBindingSpecifier, 
-          \Self.bindingSpecifier, 
-          \Self.unexpectedBetweenBindingSpecifierAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedAfterInitializer
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBindingSpecifier, 
+        \Self.bindingSpecifier, 
+        \Self.unexpectedBetweenBindingSpecifierAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedAfterInitializer
+      ])
 }
 
 // MARK: - OptionalChainingExprSyntax
@@ -954,15 +944,13 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedAfterQuestionMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedAfterQuestionMark
+      ])
 }
 
 // MARK: - OptionalTypeSyntax
@@ -1070,15 +1058,13 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWrappedType, 
-          \Self.wrappedType, 
-          \Self.unexpectedBetweenWrappedTypeAndQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedAfterQuestionMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWrappedType, 
+        \Self.wrappedType, 
+        \Self.unexpectedBetweenWrappedTypeAndQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedAfterQuestionMark
+      ])
 }
 
 // MARK: - OriginallyDefinedInAttributeArgumentsSyntax
@@ -1300,21 +1286,19 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeModuleLabel, 
-          \Self.moduleLabel, 
-          \Self.unexpectedBetweenModuleLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndModuleName, 
-          \Self.moduleName, 
-          \Self.unexpectedBetweenModuleNameAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndPlatforms, 
-          \Self.platforms, 
-          \Self.unexpectedAfterPlatforms
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeModuleLabel, 
+        \Self.moduleLabel, 
+        \Self.unexpectedBetweenModuleLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndModuleName, 
+        \Self.moduleName, 
+        \Self.unexpectedBetweenModuleNameAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndPlatforms, 
+        \Self.platforms, 
+        \Self.unexpectedAfterPlatforms
+      ])
 }
 
 // MARK: - PackElementExprSyntax
@@ -1424,15 +1408,13 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEachKeyword, 
-          \Self.eachKeyword, 
-          \Self.unexpectedBetweenEachKeywordAndPack, 
-          \Self.pack, 
-          \Self.unexpectedAfterPack
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEachKeyword, 
+        \Self.eachKeyword, 
+        \Self.unexpectedBetweenEachKeywordAndPack, 
+        \Self.pack, 
+        \Self.unexpectedAfterPack
+      ])
 }
 
 // MARK: - PackElementTypeSyntax
@@ -1540,15 +1522,13 @@ public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEachKeyword, 
-          \Self.eachKeyword, 
-          \Self.unexpectedBetweenEachKeywordAndPack, 
-          \Self.pack, 
-          \Self.unexpectedAfterPack
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEachKeyword, 
+        \Self.eachKeyword, 
+        \Self.unexpectedBetweenEachKeywordAndPack, 
+        \Self.pack, 
+        \Self.unexpectedAfterPack
+      ])
 }
 
 // MARK: - PackExpansionExprSyntax
@@ -1658,15 +1638,13 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRepeatKeyword, 
-          \Self.repeatKeyword, 
-          \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
-          \Self.repetitionPattern, 
-          \Self.unexpectedAfterRepetitionPattern
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRepeatKeyword, 
+        \Self.repeatKeyword, 
+        \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
+        \Self.repetitionPattern, 
+        \Self.unexpectedAfterRepetitionPattern
+      ])
 }
 
 // MARK: - PackExpansionTypeSyntax
@@ -1774,15 +1752,13 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRepeatKeyword, 
-          \Self.repeatKeyword, 
-          \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
-          \Self.repetitionPattern, 
-          \Self.unexpectedAfterRepetitionPattern
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRepeatKeyword, 
+        \Self.repeatKeyword, 
+        \Self.unexpectedBetweenRepeatKeywordAndRepetitionPattern, 
+        \Self.repetitionPattern, 
+        \Self.unexpectedAfterRepetitionPattern
+      ])
 }
 
 // MARK: - PatternBindingSyntax
@@ -1991,21 +1967,19 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedBetweenInitializerAndAccessorBlock, 
-          \Self.accessorBlock, 
-          \Self.unexpectedBetweenAccessorBlockAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTypeAnnotation, 
+        \Self.typeAnnotation, 
+        \Self.unexpectedBetweenTypeAnnotationAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedBetweenInitializerAndAccessorBlock, 
+        \Self.accessorBlock, 
+        \Self.unexpectedBetweenAccessorBlockAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - PatternExprSyntax
@@ -2077,9 +2051,7 @@ public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforePattern, \Self.pattern, \Self.unexpectedAfterPattern])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforePattern, \Self.pattern, \Self.unexpectedAfterPattern])
 }
 
 // MARK: - PlatformVersionItemSyntax
@@ -2198,15 +2170,13 @@ public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePlatformVersion, 
-          \Self.platformVersion, 
-          \Self.unexpectedBetweenPlatformVersionAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePlatformVersion, 
+        \Self.platformVersion, 
+        \Self.unexpectedBetweenPlatformVersionAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - PlatformVersionSyntax
@@ -2330,15 +2300,13 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePlatform, 
-          \Self.platform, 
-          \Self.unexpectedBetweenPlatformAndVersion, 
-          \Self.version, 
-          \Self.unexpectedAfterVersion
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePlatform, 
+        \Self.platform, 
+        \Self.unexpectedBetweenPlatformAndVersion, 
+        \Self.version, 
+        \Self.unexpectedAfterVersion
+      ])
 }
 
 // MARK: - PostfixIfConfigExprSyntax
@@ -2443,15 +2411,13 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBase, 
-          \Self.base, 
-          \Self.unexpectedBetweenBaseAndConfig, 
-          \Self.config, 
-          \Self.unexpectedAfterConfig
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBase, 
+        \Self.base, 
+        \Self.unexpectedBetweenBaseAndConfig, 
+        \Self.config, 
+        \Self.unexpectedAfterConfig
+      ])
 }
 
 // MARK: - PostfixOperatorExprSyntax
@@ -2559,15 +2525,13 @@ public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndOperator, 
-          \Self.operator, 
-          \Self.unexpectedAfterOperator
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndOperator, 
+        \Self.operator, 
+        \Self.unexpectedAfterOperator
+      ])
 }
 
 // MARK: - PoundSourceLocationArgumentsSyntax
@@ -2819,25 +2783,23 @@ public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeFileLabel, 
-          \Self.fileLabel, 
-          \Self.unexpectedBetweenFileLabelAndFileColon, 
-          \Self.fileColon, 
-          \Self.unexpectedBetweenFileColonAndFileName, 
-          \Self.fileName, 
-          \Self.unexpectedBetweenFileNameAndComma, 
-          \Self.comma, 
-          \Self.unexpectedBetweenCommaAndLineLabel, 
-          \Self.lineLabel, 
-          \Self.unexpectedBetweenLineLabelAndLineColon, 
-          \Self.lineColon, 
-          \Self.unexpectedBetweenLineColonAndLineNumber, 
-          \Self.lineNumber, 
-          \Self.unexpectedAfterLineNumber
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeFileLabel, 
+        \Self.fileLabel, 
+        \Self.unexpectedBetweenFileLabelAndFileColon, 
+        \Self.fileColon, 
+        \Self.unexpectedBetweenFileColonAndFileName, 
+        \Self.fileName, 
+        \Self.unexpectedBetweenFileNameAndComma, 
+        \Self.comma, 
+        \Self.unexpectedBetweenCommaAndLineLabel, 
+        \Self.lineLabel, 
+        \Self.unexpectedBetweenLineLabelAndLineColon, 
+        \Self.lineColon, 
+        \Self.unexpectedBetweenLineColonAndLineNumber, 
+        \Self.lineNumber, 
+        \Self.unexpectedAfterLineNumber
+      ])
 }
 
 // MARK: - PoundSourceLocationSyntax
@@ -3001,19 +2963,17 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePoundSourceLocation, 
-          \Self.poundSourceLocation, 
-          \Self.unexpectedBetweenPoundSourceLocationAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePoundSourceLocation, 
+        \Self.poundSourceLocation, 
+        \Self.unexpectedBetweenPoundSourceLocationAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - PrecedenceGroupAssignmentSyntax
@@ -3163,17 +3123,15 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAssignmentLabel, 
-          \Self.assignmentLabel, 
-          \Self.unexpectedBetweenAssignmentLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAssignmentLabel, 
+        \Self.assignmentLabel, 
+        \Self.unexpectedBetweenAssignmentLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - PrecedenceGroupAssociativitySyntax
@@ -3324,17 +3282,15 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAssociativityLabel, 
-          \Self.associativityLabel, 
-          \Self.unexpectedBetweenAssociativityLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAssociativityLabel, 
+        \Self.associativityLabel, 
+        \Self.unexpectedBetweenAssociativityLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - PrecedenceGroupDeclSyntax
@@ -3668,25 +3624,23 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndPrecedencegroupKeyword, 
-          \Self.precedencegroupKeyword, 
-          \Self.unexpectedBetweenPrecedencegroupKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndGroupAttributes, 
-          \Self.groupAttributes, 
-          \Self.unexpectedBetweenGroupAttributesAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndPrecedencegroupKeyword, 
+        \Self.precedencegroupKeyword, 
+        \Self.unexpectedBetweenPrecedencegroupKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndGroupAttributes, 
+        \Self.groupAttributes, 
+        \Self.unexpectedBetweenGroupAttributesAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }
 
 // MARK: - PrecedenceGroupNameSyntax
@@ -3801,15 +3755,13 @@ public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - PrecedenceGroupRelationSyntax
@@ -3985,17 +3937,15 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable, _Le
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeHigherThanOrLowerThanLabel, 
-          \Self.higherThanOrLowerThanLabel, 
-          \Self.unexpectedBetweenHigherThanOrLowerThanLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPrecedenceGroups, 
-          \Self.precedenceGroups, 
-          \Self.unexpectedAfterPrecedenceGroups
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeHigherThanOrLowerThanLabel, 
+        \Self.higherThanOrLowerThanLabel, 
+        \Self.unexpectedBetweenHigherThanOrLowerThanLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPrecedenceGroups, 
+        \Self.precedenceGroups, 
+        \Self.unexpectedAfterPrecedenceGroups
+      ])
 }
 
 // MARK: - PrefixOperatorExprSyntax
@@ -4115,15 +4065,13 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOperator, 
-          \Self.operator, 
-          \Self.unexpectedBetweenOperatorAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOperator, 
+        \Self.operator, 
+        \Self.unexpectedBetweenOperatorAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - PrimaryAssociatedTypeClauseSyntax
@@ -4290,17 +4238,15 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable,
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftAngle, 
-          \Self.leftAngle, 
-          \Self.unexpectedBetweenLeftAngleAndPrimaryAssociatedTypes, 
-          \Self.primaryAssociatedTypes, 
-          \Self.unexpectedBetweenPrimaryAssociatedTypesAndRightAngle, 
-          \Self.rightAngle, 
-          \Self.unexpectedAfterRightAngle
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftAngle, 
+        \Self.leftAngle, 
+        \Self.unexpectedBetweenLeftAngleAndPrimaryAssociatedTypes, 
+        \Self.primaryAssociatedTypes, 
+        \Self.unexpectedBetweenPrimaryAssociatedTypesAndRightAngle, 
+        \Self.rightAngle, 
+        \Self.unexpectedAfterRightAngle
+      ])
 }
 
 // MARK: - PrimaryAssociatedTypeSyntax
@@ -4415,15 +4361,13 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - ProtocolDeclSyntax
@@ -4766,25 +4710,23 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndProtocolKeyword, 
-          \Self.protocolKeyword, 
-          \Self.unexpectedBetweenProtocolKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndPrimaryAssociatedTypeClause, 
-          \Self.primaryAssociatedTypeClause, 
-          \Self.unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndProtocolKeyword, 
+        \Self.protocolKeyword, 
+        \Self.unexpectedBetweenProtocolKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndPrimaryAssociatedTypeClause, 
+        \Self.primaryAssociatedTypeClause, 
+        \Self.unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
@@ -27,7 +27,7 @@
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .objCSelectorPiece else {
       return nil
     }
@@ -155,7 +155,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .opaqueReturnTypeOfAttributeArguments else {
       return nil
     }
@@ -309,7 +309,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
 public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .operatorDecl else {
       return nil
     }
@@ -501,7 +501,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
 public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .operatorPrecedenceAndTypes else {
       return nil
     }
@@ -684,7 +684,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable, 
 public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .optionalBindingCondition else {
       return nil
     }
@@ -858,7 +858,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
 public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .optionalChainingExpr else {
       return nil
     }
@@ -974,7 +974,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _L
 public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .optionalType else {
       return nil
     }
@@ -1099,7 +1099,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
 public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .originallyDefinedInAttributeArguments else {
       return nil
     }
@@ -1328,7 +1328,7 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
 public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .packElementExpr else {
       return nil
     }
@@ -1444,7 +1444,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
 public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .packElementType else {
       return nil
     }
@@ -1562,7 +1562,7 @@ public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTy
 public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .packExpansionExpr else {
       return nil
     }
@@ -1678,7 +1678,7 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .packExpansionType else {
       return nil
     }
@@ -1803,7 +1803,7 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _Leaf
 public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .patternBinding else {
       return nil
     }
@@ -2016,7 +2016,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
 public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .patternExpr else {
       return nil
     }
@@ -2097,7 +2097,7 @@ public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .platformVersionItem else {
       return nil
     }
@@ -2225,7 +2225,7 @@ public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .platformVersion else {
       return nil
     }
@@ -2350,7 +2350,7 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
 public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .postfixIfConfigExpr else {
       return nil
     }
@@ -2463,7 +2463,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
 public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .postfixOperatorExpr else {
       return nil
     }
@@ -2588,7 +2588,7 @@ public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
 public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .poundSourceLocationArguments else {
       return nil
     }
@@ -2851,7 +2851,7 @@ public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .poundSourceLocation else {
       return nil
     }
@@ -3032,7 +3032,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
 public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAssignment else {
       return nil
     }
@@ -3192,7 +3192,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable, _
 public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAssociativity else {
       return nil
     }
@@ -3353,7 +3353,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupDecl else {
       return nil
     }
@@ -3702,7 +3702,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
 public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupName else {
       return nil
     }
@@ -3828,7 +3828,7 @@ public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupRelation else {
       return nil
     }
@@ -4019,7 +4019,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable, _Le
 public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .prefixOperatorExpr else {
       return nil
     }
@@ -4140,7 +4140,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
 public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedTypeClause else {
       return nil
     }
@@ -4316,7 +4316,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable,
 public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedType else {
       return nil
     }
@@ -4451,7 +4451,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .protocolDecl else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -204,21 +204,19 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOpeningPounds, 
-          \Self.openingPounds, 
-          \Self.unexpectedBetweenOpeningPoundsAndOpeningSlash, 
-          \Self.openingSlash, 
-          \Self.unexpectedBetweenOpeningSlashAndRegex, 
-          \Self.regex, 
-          \Self.unexpectedBetweenRegexAndClosingSlash, 
-          \Self.closingSlash, 
-          \Self.unexpectedBetweenClosingSlashAndClosingPounds, 
-          \Self.closingPounds, 
-          \Self.unexpectedAfterClosingPounds
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOpeningPounds, 
+        \Self.openingPounds, 
+        \Self.unexpectedBetweenOpeningPoundsAndOpeningSlash, 
+        \Self.openingSlash, 
+        \Self.unexpectedBetweenOpeningSlashAndRegex, 
+        \Self.regex, 
+        \Self.unexpectedBetweenRegexAndClosingSlash, 
+        \Self.closingSlash, 
+        \Self.unexpectedBetweenClosingSlashAndClosingPounds, 
+        \Self.closingPounds, 
+        \Self.unexpectedAfterClosingPounds
+      ])
 }
 
 // MARK: - RepeatStmtSyntax
@@ -379,19 +377,17 @@ public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeRepeatKeyword, 
-          \Self.repeatKeyword, 
-          \Self.unexpectedBetweenRepeatKeywordAndBody, 
-          \Self.body, 
-          \Self.unexpectedBetweenBodyAndWhileKeyword, 
-          \Self.whileKeyword, 
-          \Self.unexpectedBetweenWhileKeywordAndCondition, 
-          \Self.condition, 
-          \Self.unexpectedAfterCondition
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeRepeatKeyword, 
+        \Self.repeatKeyword, 
+        \Self.unexpectedBetweenRepeatKeywordAndBody, 
+        \Self.body, 
+        \Self.unexpectedBetweenBodyAndWhileKeyword, 
+        \Self.whileKeyword, 
+        \Self.unexpectedBetweenWhileKeywordAndCondition, 
+        \Self.condition, 
+        \Self.unexpectedAfterCondition
+      ])
 }
 
 // MARK: - ReturnClauseSyntax
@@ -506,15 +502,13 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeArrow, 
-          \Self.arrow, 
-          \Self.unexpectedBetweenArrowAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeArrow, 
+        \Self.arrow, 
+        \Self.unexpectedBetweenArrowAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - ReturnStmtSyntax
@@ -622,15 +616,13 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeReturnKeyword, 
-          \Self.returnKeyword, 
-          \Self.unexpectedBetweenReturnKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeReturnKeyword, 
+        \Self.returnKeyword, 
+        \Self.unexpectedBetweenReturnKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - SameTypeRequirementSyntax
@@ -770,17 +762,15 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftType, 
-          \Self.leftType, 
-          \Self.unexpectedBetweenLeftTypeAndEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndRightType, 
-          \Self.rightType, 
-          \Self.unexpectedAfterRightType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftType, 
+        \Self.leftType, 
+        \Self.unexpectedBetweenLeftTypeAndEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndRightType, 
+        \Self.rightType, 
+        \Self.unexpectedAfterRightType
+      ])
 }
 
 // MARK: - SequenceExprSyntax
@@ -887,9 +877,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeElements, \Self.elements, \Self.unexpectedAfterElements])
 }
 
 // MARK: - SimpleStringLiteralExprSyntax
@@ -1071,17 +1059,15 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable,
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOpeningQuote, 
-          \Self.openingQuote, 
-          \Self.unexpectedBetweenOpeningQuoteAndSegments, 
-          \Self.segments, 
-          \Self.unexpectedBetweenSegmentsAndClosingQuote, 
-          \Self.closingQuote, 
-          \Self.unexpectedAfterClosingQuote
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOpeningQuote, 
+        \Self.openingQuote, 
+        \Self.unexpectedBetweenOpeningQuoteAndSegments, 
+        \Self.segments, 
+        \Self.unexpectedBetweenSegmentsAndClosingQuote, 
+        \Self.closingQuote, 
+        \Self.unexpectedAfterClosingQuote
+      ])
 }
 
 // MARK: - SimpleTypeSpecifierSyntax
@@ -1174,9 +1160,7 @@ public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeSpecifier, \Self.specifier, \Self.unexpectedAfterSpecifier])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeSpecifier, \Self.specifier, \Self.unexpectedAfterSpecifier])
 }
 
 // MARK: - SomeOrAnyTypeSyntax
@@ -1286,15 +1270,13 @@ public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafType
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSomeOrAnySpecifier, 
-          \Self.someOrAnySpecifier, 
-          \Self.unexpectedBetweenSomeOrAnySpecifierAndConstraint, 
-          \Self.constraint, 
-          \Self.unexpectedAfterConstraint
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSomeOrAnySpecifier, 
+        \Self.someOrAnySpecifier, 
+        \Self.unexpectedBetweenSomeOrAnySpecifierAndConstraint, 
+        \Self.constraint, 
+        \Self.unexpectedAfterConstraint
+      ])
 }
 
 // MARK: - SourceFileSyntax
@@ -1460,17 +1442,15 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeShebang, 
-          \Self.shebang, 
-          \Self.unexpectedBetweenShebangAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedBetweenStatementsAndEndOfFileToken, 
-          \Self.endOfFileToken, 
-          \Self.unexpectedAfterEndOfFileToken
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeShebang, 
+        \Self.shebang, 
+        \Self.unexpectedBetweenShebangAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedBetweenStatementsAndEndOfFileToken, 
+        \Self.endOfFileToken, 
+        \Self.unexpectedAfterEndOfFileToken
+      ])
 }
 
 // MARK: - SpecializeAvailabilityArgumentSyntax
@@ -1673,19 +1653,17 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAvailabilityLabel, 
-          \Self.availabilityLabel, 
-          \Self.unexpectedBetweenAvailabilityLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndAvailabilityArguments, 
-          \Self.availabilityArguments, 
-          \Self.unexpectedBetweenAvailabilityArgumentsAndSemicolon, 
-          \Self.semicolon, 
-          \Self.unexpectedAfterSemicolon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAvailabilityLabel, 
+        \Self.availabilityLabel, 
+        \Self.unexpectedBetweenAvailabilityLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndAvailabilityArguments, 
+        \Self.availabilityArguments, 
+        \Self.unexpectedBetweenAvailabilityArgumentsAndSemicolon, 
+        \Self.semicolon, 
+        \Self.unexpectedAfterSemicolon
+      ])
 }
 
 // MARK: - SpecializeTargetFunctionArgumentSyntax
@@ -1866,19 +1844,17 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeTargetLabel, 
-          \Self.targetLabel, 
-          \Self.unexpectedBetweenTargetLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndDeclName, 
-          \Self.declName, 
-          \Self.unexpectedBetweenDeclNameAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeTargetLabel, 
+        \Self.targetLabel, 
+        \Self.unexpectedBetweenTargetLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndDeclName, 
+        \Self.declName, 
+        \Self.unexpectedBetweenDeclNameAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - StringLiteralExprSyntax
@@ -2122,21 +2098,19 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeOpeningPounds, 
-          \Self.openingPounds, 
-          \Self.unexpectedBetweenOpeningPoundsAndOpeningQuote, 
-          \Self.openingQuote, 
-          \Self.unexpectedBetweenOpeningQuoteAndSegments, 
-          \Self.segments, 
-          \Self.unexpectedBetweenSegmentsAndClosingQuote, 
-          \Self.closingQuote, 
-          \Self.unexpectedBetweenClosingQuoteAndClosingPounds, 
-          \Self.closingPounds, 
-          \Self.unexpectedAfterClosingPounds
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeOpeningPounds, 
+        \Self.openingPounds, 
+        \Self.unexpectedBetweenOpeningPoundsAndOpeningQuote, 
+        \Self.openingQuote, 
+        \Self.unexpectedBetweenOpeningQuoteAndSegments, 
+        \Self.segments, 
+        \Self.unexpectedBetweenSegmentsAndClosingQuote, 
+        \Self.closingQuote, 
+        \Self.unexpectedBetweenClosingQuoteAndClosingPounds, 
+        \Self.closingPounds, 
+        \Self.unexpectedAfterClosingPounds
+      ])
 }
 
 // MARK: - StringSegmentSyntax
@@ -2220,9 +2194,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeContent, \Self.content, \Self.unexpectedAfterContent])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeContent, \Self.content, \Self.unexpectedAfterContent])
 }
 
 // MARK: - StructDeclSyntax
@@ -2613,27 +2585,25 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndStructKeyword, 
-          \Self.structKeyword, 
-          \Self.unexpectedBetweenStructKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
-          \Self.inheritanceClause, 
-          \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
-          \Self.memberBlock, 
-          \Self.unexpectedAfterMemberBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndStructKeyword, 
+        \Self.structKeyword, 
+        \Self.unexpectedBetweenStructKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInheritanceClause, 
+        \Self.inheritanceClause, 
+        \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        \Self.memberBlock, 
+        \Self.unexpectedAfterMemberBlock
+      ])
 }
 
 // MARK: - SubscriptCallExprSyntax
@@ -2898,23 +2868,21 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCalledExpression, 
-          \Self.calledExpression, 
-          \Self.unexpectedBetweenCalledExpressionAndLeftSquare, 
-          \Self.leftSquare, 
-          \Self.unexpectedBetweenLeftSquareAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightSquare, 
-          \Self.rightSquare, 
-          \Self.unexpectedBetweenRightSquareAndTrailingClosure, 
-          \Self.trailingClosure, 
-          \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
-          \Self.additionalTrailingClosures, 
-          \Self.unexpectedAfterAdditionalTrailingClosures
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCalledExpression, 
+        \Self.calledExpression, 
+        \Self.unexpectedBetweenCalledExpressionAndLeftSquare, 
+        \Self.leftSquare, 
+        \Self.unexpectedBetweenLeftSquareAndArguments, 
+        \Self.arguments, 
+        \Self.unexpectedBetweenArgumentsAndRightSquare, 
+        \Self.rightSquare, 
+        \Self.unexpectedBetweenRightSquareAndTrailingClosure, 
+        \Self.trailingClosure, 
+        \Self.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
+        \Self.additionalTrailingClosures, 
+        \Self.unexpectedAfterAdditionalTrailingClosures
+      ])
 }
 
 // MARK: - SubscriptDeclSyntax
@@ -3230,27 +3198,25 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndSubscriptKeyword, 
-          \Self.subscriptKeyword, 
-          \Self.unexpectedBetweenSubscriptKeywordAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndParameterClause, 
-          \Self.parameterClause, 
-          \Self.unexpectedBetweenParameterClauseAndReturnClause, 
-          \Self.returnClause, 
-          \Self.unexpectedBetweenReturnClauseAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndAccessorBlock, 
-          \Self.accessorBlock, 
-          \Self.unexpectedAfterAccessorBlock
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndSubscriptKeyword, 
+        \Self.subscriptKeyword, 
+        \Self.unexpectedBetweenSubscriptKeywordAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndParameterClause, 
+        \Self.parameterClause, 
+        \Self.unexpectedBetweenParameterClauseAndReturnClause, 
+        \Self.returnClause, 
+        \Self.unexpectedBetweenReturnClauseAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedBetweenGenericWhereClauseAndAccessorBlock, 
+        \Self.accessorBlock, 
+        \Self.unexpectedAfterAccessorBlock
+      ])
 }
 
 // MARK: - SuperExprSyntax
@@ -3325,9 +3291,7 @@ public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeSuperKeyword, \Self.superKeyword, \Self.unexpectedAfterSuperKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeSuperKeyword, \Self.superKeyword, \Self.unexpectedAfterSuperKeyword])
 }
 
 // MARK: - SuppressedTypeSyntax
@@ -3435,15 +3399,13 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWithoutTilde, 
-          \Self.withoutTilde, 
-          \Self.unexpectedBetweenWithoutTildeAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWithoutTilde, 
+        \Self.withoutTilde, 
+        \Self.unexpectedBetweenWithoutTildeAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - SwitchCaseItemSyntax
@@ -3580,17 +3542,15 @@ public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndWhereClause, 
-          \Self.whereClause, 
-          \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndWhereClause, 
+        \Self.whereClause, 
+        \Self.unexpectedBetweenWhereClauseAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - SwitchCaseLabelSyntax
@@ -3757,17 +3717,15 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCaseKeyword, 
-          \Self.caseKeyword, 
-          \Self.unexpectedBetweenCaseKeywordAndCaseItems, 
-          \Self.caseItems, 
-          \Self.unexpectedBetweenCaseItemsAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCaseKeyword, 
+        \Self.caseKeyword, 
+        \Self.unexpectedBetweenCaseKeywordAndCaseItems, 
+        \Self.caseItems, 
+        \Self.unexpectedBetweenCaseItemsAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - SwitchCaseSyntax
@@ -4012,17 +3970,15 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttribute, 
-          \Self.attribute, 
-          \Self.unexpectedBetweenAttributeAndLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndStatements, 
-          \Self.statements, 
-          \Self.unexpectedAfterStatements
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttribute, 
+        \Self.attribute, 
+        \Self.unexpectedBetweenAttributeAndLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndStatements, 
+        \Self.statements, 
+        \Self.unexpectedAfterStatements
+      ])
 }
 
 // MARK: - SwitchDefaultLabelSyntax
@@ -4137,15 +4093,13 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeDefaultKeyword, 
-          \Self.defaultKeyword, 
-          \Self.unexpectedBetweenDefaultKeywordAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeDefaultKeyword, 
+        \Self.defaultKeyword, 
+        \Self.unexpectedBetweenDefaultKeywordAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - SwitchExprSyntax
@@ -4387,19 +4341,17 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyn
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSwitchKeyword, 
-          \Self.switchKeyword, 
-          \Self.unexpectedBetweenSwitchKeywordAndSubject, 
-          \Self.subject, 
-          \Self.unexpectedBetweenSubjectAndLeftBrace, 
-          \Self.leftBrace, 
-          \Self.unexpectedBetweenLeftBraceAndCases, 
-          \Self.cases, 
-          \Self.unexpectedBetweenCasesAndRightBrace, 
-          \Self.rightBrace, 
-          \Self.unexpectedAfterRightBrace
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSwitchKeyword, 
+        \Self.switchKeyword, 
+        \Self.unexpectedBetweenSwitchKeywordAndSubject, 
+        \Self.subject, 
+        \Self.unexpectedBetweenSubjectAndLeftBrace, 
+        \Self.leftBrace, 
+        \Self.unexpectedBetweenLeftBraceAndCases, 
+        \Self.cases, 
+        \Self.unexpectedBetweenCasesAndRightBrace, 
+        \Self.rightBrace, 
+        \Self.unexpectedAfterRightBrace
+      ])
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -24,7 +24,7 @@
 public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .regexLiteralExpr else {
       return nil
     }
@@ -232,7 +232,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
 public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .repeatStmt else {
       return nil
     }
@@ -410,7 +410,7 @@ public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
 public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .returnClause else {
       return nil
     }
@@ -526,7 +526,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
 public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .returnStmt else {
       return nil
     }
@@ -647,7 +647,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .sameTypeRequirement else {
       return nil
     }
@@ -799,7 +799,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .sequenceExpr else {
       return nil
     }
@@ -909,7 +909,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprS
 public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .simpleStringLiteralExpr else {
       return nil
     }
@@ -1098,7 +1098,7 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable,
 public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .simpleTypeSpecifier else {
       return nil
     }
@@ -1188,7 +1188,7 @@ public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .someOrAnyType else {
       return nil
     }
@@ -1307,7 +1307,7 @@ public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafType
 public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .sourceFile else {
       return nil
     }
@@ -1490,7 +1490,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
 public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .specializeAvailabilityArgument else {
       return nil
     }
@@ -1705,7 +1705,7 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
 public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .specializeTargetFunctionArgument else {
       return nil
     }
@@ -1912,7 +1912,7 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
 public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .stringLiteralExpr else {
       return nil
     }
@@ -2156,7 +2156,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .stringSegment else {
       return nil
     }
@@ -2298,7 +2298,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .structDecl else {
       return nil
     }
@@ -2649,7 +2649,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
 public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .subscriptCallExpr else {
       return nil
     }
@@ -2932,7 +2932,7 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .subscriptDecl else {
       return nil
     }
@@ -3261,7 +3261,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
 public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .superExpr else {
       return nil
     }
@@ -3339,7 +3339,7 @@ public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
 public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .suppressedType else {
       return nil
     }
@@ -3460,7 +3460,7 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
 public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .switchCaseItem else {
       return nil
     }
@@ -3607,7 +3607,7 @@ public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
 public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .switchCaseLabel else {
       return nil
     }
@@ -3803,7 +3803,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
       self = .case(node)
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(SwitchDefaultLabelSyntax.self) {
         self = .default(node)
         return
@@ -3866,7 +3866,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .switchCase else {
       return nil
     }
@@ -4038,7 +4038,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
 public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .switchDefaultLabel else {
       return nil
     }
@@ -4173,7 +4173,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .switchExpr else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -35,7 +35,7 @@
 public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .ternaryExpr else {
       return nil
     }
@@ -245,7 +245,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .thenStmt else {
       return nil
     }
@@ -361,7 +361,7 @@ public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynta
 public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .throwStmt else {
       return nil
     }
@@ -486,7 +486,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 public struct ThrowsClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .throwsClause else {
       return nil
     }
@@ -690,7 +690,7 @@ public struct ThrowsClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
 public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .tryExpr else {
       return nil
     }
@@ -838,7 +838,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntax
 public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .tupleExpr else {
       return nil
     }
@@ -1018,7 +1018,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
 public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .tuplePatternElement else {
       return nil
     }
@@ -1215,7 +1215,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .tuplePattern else {
       return nil
     }
@@ -1402,7 +1402,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPa
 public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .tupleTypeElement else {
       return nil
     }
@@ -1668,7 +1668,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .tupleType else {
       return nil
     }
@@ -1845,7 +1845,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
 public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .typeAliasDecl else {
       return nil
     }
@@ -2159,7 +2159,7 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .typeAnnotation else {
       return nil
     }
@@ -2284,7 +2284,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
 public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .typeEffectSpecifiers else {
       return nil
     }
@@ -2401,7 +2401,7 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
 public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .typeExpr else {
       return nil
     }
@@ -2481,7 +2481,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynta
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .typeInitializerClause else {
       return nil
     }
@@ -2604,7 +2604,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
 public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .unavailableFromAsyncAttributeArguments else {
       return nil
     }
@@ -2756,7 +2756,7 @@ public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, Synt
 public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .underscorePrivateAttributeArguments else {
       return nil
     }
@@ -2906,7 +2906,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
 public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedAsExpr else {
       return nil
     }
@@ -3031,7 +3031,7 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
 public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedIsExpr else {
       return nil
     }
@@ -3116,7 +3116,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
 public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedTernaryExpr else {
       return nil
     }
@@ -3261,7 +3261,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .valueBindingPattern else {
       return nil
     }
@@ -3391,7 +3391,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, 
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .variableDecl else {
       return nil
     }
@@ -3669,7 +3669,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
 public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .versionComponent else {
       return nil
     }
@@ -3802,7 +3802,7 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .versionTuple else {
       return nil
     }
@@ -3956,7 +3956,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .whereClause else {
       return nil
     }
@@ -4073,7 +4073,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .whileStmt else {
       return nil
     }
@@ -4254,7 +4254,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .wildcardPattern else {
       return nil
     }
@@ -4351,7 +4351,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
       self = .single(ExprSyntax(node))
     }
     
-    public init?(_ node: some SyntaxProtocol) {
+    public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(YieldedExpressionsClauseSyntax.self) {
         self = .multiple(node)
         return
@@ -4414,7 +4414,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
   
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .yieldStmt else {
       return nil
     }
@@ -4534,7 +4534,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .yieldedExpression else {
       return nil
     }
@@ -4655,7 +4655,7 @@ public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
-  public init?(_ node: some SyntaxProtocol) {
+  public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .yieldedExpressionsClause else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -206,21 +206,19 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeCondition, 
-          \Self.condition, 
-          \Self.unexpectedBetweenConditionAndQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
-          \Self.thenExpression, 
-          \Self.unexpectedBetweenThenExpressionAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndElseExpression, 
-          \Self.elseExpression, 
-          \Self.unexpectedAfterElseExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeCondition, 
+        \Self.condition, 
+        \Self.unexpectedBetweenConditionAndQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
+        \Self.thenExpression, 
+        \Self.unexpectedBetweenThenExpressionAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndElseExpression, 
+        \Self.elseExpression, 
+        \Self.unexpectedAfterElseExpression
+      ])
 }
 
 // MARK: - ThenStmtSyntax
@@ -341,15 +339,13 @@ public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeThenKeyword, 
-          \Self.thenKeyword, 
-          \Self.unexpectedBetweenThenKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeThenKeyword, 
+        \Self.thenKeyword, 
+        \Self.unexpectedBetweenThenKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - ThrowStmtSyntax
@@ -457,15 +453,13 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeThrowKeyword, 
-          \Self.throwKeyword, 
-          \Self.unexpectedBetweenThrowKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeThrowKeyword, 
+        \Self.throwKeyword, 
+        \Self.unexpectedBetweenThrowKeywordAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - ThrowsClauseSyntax
@@ -649,19 +643,17 @@ public struct ThrowsClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeThrowsSpecifier, 
-          \Self.throwsSpecifier, 
-          \Self.unexpectedBetweenThrowsSpecifierAndLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeThrowsSpecifier, 
+        \Self.throwsSpecifier, 
+        \Self.unexpectedBetweenThrowsSpecifierAndLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TryExprSyntax
@@ -815,17 +807,15 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntax
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeTryKeyword, 
-          \Self.tryKeyword, 
-          \Self.unexpectedBetweenTryKeywordAndQuestionOrExclamationMark, 
-          \Self.questionOrExclamationMark, 
-          \Self.unexpectedBetweenQuestionOrExclamationMarkAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeTryKeyword, 
+        \Self.tryKeyword, 
+        \Self.unexpectedBetweenTryKeywordAndQuestionOrExclamationMark, 
+        \Self.questionOrExclamationMark, 
+        \Self.unexpectedBetweenQuestionOrExclamationMarkAndExpression, 
+        \Self.expression, 
+        \Self.unexpectedAfterExpression
+      ])
 }
 
 // MARK: - TupleExprSyntax
@@ -988,17 +978,15 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TuplePatternElementSyntax
@@ -1179,19 +1167,17 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLabel, 
-          \Self.label, 
-          \Self.unexpectedBetweenLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedBetweenPatternAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLabel, 
+        \Self.label, 
+        \Self.unexpectedBetweenLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedBetweenPatternAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - TuplePatternSyntax
@@ -1371,17 +1357,15 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPa
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TupleTypeElementSyntax
@@ -1637,25 +1621,23 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeInoutKeyword, 
-          \Self.inoutKeyword, 
-          \Self.unexpectedBetweenInoutKeywordAndFirstName, 
-          \Self.firstName, 
-          \Self.unexpectedBetweenFirstNameAndSecondName, 
-          \Self.secondName, 
-          \Self.unexpectedBetweenSecondNameAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedBetweenTypeAndEllipsis, 
-          \Self.ellipsis, 
-          \Self.unexpectedBetweenEllipsisAndTrailingComma, 
-          \Self.trailingComma, 
-          \Self.unexpectedAfterTrailingComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeInoutKeyword, 
+        \Self.inoutKeyword, 
+        \Self.unexpectedBetweenInoutKeywordAndFirstName, 
+        \Self.firstName, 
+        \Self.unexpectedBetweenFirstNameAndSecondName, 
+        \Self.secondName, 
+        \Self.unexpectedBetweenSecondNameAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedBetweenTypeAndEllipsis, 
+        \Self.ellipsis, 
+        \Self.unexpectedBetweenEllipsisAndTrailingComma, 
+        \Self.trailingComma, 
+        \Self.unexpectedAfterTrailingComma
+      ])
 }
 
 // MARK: - TupleTypeSyntax
@@ -1818,17 +1800,15 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }
 
 // MARK: - TypeAliasDeclSyntax
@@ -2122,25 +2102,23 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndTypealiasKeyword, 
-          \Self.typealiasKeyword, 
-          \Self.unexpectedBetweenTypealiasKeywordAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndGenericParameterClause, 
-          \Self.genericParameterClause, 
-          \Self.unexpectedBetweenGenericParameterClauseAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
-          \Self.genericWhereClause, 
-          \Self.unexpectedAfterGenericWhereClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndTypealiasKeyword, 
+        \Self.typealiasKeyword, 
+        \Self.unexpectedBetweenTypealiasKeywordAndName, 
+        \Self.name, 
+        \Self.unexpectedBetweenNameAndGenericParameterClause, 
+        \Self.genericParameterClause, 
+        \Self.unexpectedBetweenGenericParameterClauseAndInitializer, 
+        \Self.initializer, 
+        \Self.unexpectedBetweenInitializerAndGenericWhereClause, 
+        \Self.genericWhereClause, 
+        \Self.unexpectedAfterGenericWhereClause
+      ])
 }
 
 // MARK: - TypeAnnotationSyntax
@@ -2258,15 +2236,13 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndType, 
-          \Self.type, 
-          \Self.unexpectedAfterType
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndType, 
+        \Self.type, 
+        \Self.unexpectedAfterType
+      ])
 }
 
 // MARK: - TypeEffectSpecifiersSyntax
@@ -2382,15 +2358,13 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsyncSpecifier, 
-          \Self.asyncSpecifier, 
-          \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
-          \Self.throwsClause, 
-          \Self.unexpectedAfterThrowsClause
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsyncSpecifier, 
+        \Self.asyncSpecifier, 
+        \Self.unexpectedBetweenAsyncSpecifierAndThrowsClause, 
+        \Self.throwsClause, 
+        \Self.unexpectedAfterThrowsClause
+      ])
 }
 
 // MARK: - TypeExprSyntax
@@ -2462,9 +2436,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeType, \Self.type, \Self.unexpectedAfterType])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeType, \Self.type, \Self.unexpectedAfterType])
 }
 
 // MARK: - TypeInitializerClauseSyntax
@@ -2577,15 +2549,13 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeEqual, 
-          \Self.equal, 
-          \Self.unexpectedBetweenEqualAndValue, 
-          \Self.value, 
-          \Self.unexpectedAfterValue
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeEqual, 
+        \Self.equal, 
+        \Self.unexpectedBetweenEqualAndValue, 
+        \Self.value, 
+        \Self.unexpectedAfterValue
+      ])
 }
 
 // MARK: - UnavailableFromAsyncAttributeArgumentsSyntax
@@ -2727,17 +2697,15 @@ public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, Synt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeMessageLabel, 
-          \Self.messageLabel, 
-          \Self.unexpectedBetweenMessageLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndMessage, 
-          \Self.message, 
-          \Self.unexpectedAfterMessage
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeMessageLabel, 
+        \Self.messageLabel, 
+        \Self.unexpectedBetweenMessageLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndMessage, 
+        \Self.message, 
+        \Self.unexpectedAfterMessage
+      ])
 }
 
 // MARK: - UnderscorePrivateAttributeArgumentsSyntax
@@ -2879,17 +2847,15 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeSourceFileLabel, 
-          \Self.sourceFileLabel, 
-          \Self.unexpectedBetweenSourceFileLabelAndColon, 
-          \Self.colon, 
-          \Self.unexpectedBetweenColonAndFilename, 
-          \Self.filename, 
-          \Self.unexpectedAfterFilename
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeSourceFileLabel, 
+        \Self.sourceFileLabel, 
+        \Self.unexpectedBetweenSourceFileLabelAndColon, 
+        \Self.colon, 
+        \Self.unexpectedBetweenColonAndFilename, 
+        \Self.filename, 
+        \Self.unexpectedAfterFilename
+      ])
 }
 
 // MARK: - UnresolvedAsExprSyntax
@@ -3007,15 +2973,13 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAsKeyword, 
-          \Self.asKeyword, 
-          \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
-          \Self.questionOrExclamationMark, 
-          \Self.unexpectedAfterQuestionOrExclamationMark
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAsKeyword, 
+        \Self.asKeyword, 
+        \Self.unexpectedBetweenAsKeywordAndQuestionOrExclamationMark, 
+        \Self.questionOrExclamationMark, 
+        \Self.unexpectedAfterQuestionOrExclamationMark
+      ])
 }
 
 // MARK: - UnresolvedIsExprSyntax
@@ -3095,9 +3059,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeIsKeyword, \Self.isKeyword, \Self.unexpectedAfterIsKeyword])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeIsKeyword, \Self.isKeyword, \Self.unexpectedAfterIsKeyword])
 }
 
 // MARK: - UnresolvedTernaryExprSyntax
@@ -3239,17 +3201,15 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeQuestionMark, 
-          \Self.questionMark, 
-          \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
-          \Self.thenExpression, 
-          \Self.unexpectedBetweenThenExpressionAndColon, 
-          \Self.colon, 
-          \Self.unexpectedAfterColon
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeQuestionMark, 
+        \Self.questionMark, 
+        \Self.unexpectedBetweenQuestionMarkAndThenExpression, 
+        \Self.thenExpression, 
+        \Self.unexpectedBetweenThenExpressionAndColon, 
+        \Self.colon, 
+        \Self.unexpectedAfterColon
+      ])
 }
 
 // MARK: - ValueBindingPatternSyntax
@@ -3364,15 +3324,13 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, 
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBindingSpecifier, 
-          \Self.bindingSpecifier, 
-          \Self.unexpectedBetweenBindingSpecifierAndPattern, 
-          \Self.pattern, 
-          \Self.unexpectedAfterPattern
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeBindingSpecifier, 
+        \Self.bindingSpecifier, 
+        \Self.unexpectedBetweenBindingSpecifierAndPattern, 
+        \Self.pattern, 
+        \Self.unexpectedAfterPattern
+      ])
 }
 
 // MARK: - VariableDeclSyntax
@@ -3639,19 +3597,17 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeAttributes, 
-          \Self.attributes, 
-          \Self.unexpectedBetweenAttributesAndModifiers, 
-          \Self.modifiers, 
-          \Self.unexpectedBetweenModifiersAndBindingSpecifier, 
-          \Self.bindingSpecifier, 
-          \Self.unexpectedBetweenBindingSpecifierAndBindings, 
-          \Self.bindings, 
-          \Self.unexpectedAfterBindings
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeAttributes, 
+        \Self.attributes, 
+        \Self.unexpectedBetweenAttributesAndModifiers, 
+        \Self.modifiers, 
+        \Self.unexpectedBetweenModifiersAndBindingSpecifier, 
+        \Self.bindingSpecifier, 
+        \Self.unexpectedBetweenBindingSpecifierAndBindings, 
+        \Self.bindings, 
+        \Self.unexpectedAfterBindings
+      ])
 }
 
 // MARK: - VersionComponentSyntax
@@ -3774,15 +3730,13 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforePeriod, 
-          \Self.period, 
-          \Self.unexpectedBetweenPeriodAndNumber, 
-          \Self.number, 
-          \Self.unexpectedAfterNumber
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforePeriod, 
+        \Self.period, 
+        \Self.unexpectedBetweenPeriodAndNumber, 
+        \Self.number, 
+        \Self.unexpectedAfterNumber
+      ])
 }
 
 // MARK: - VersionTupleSyntax
@@ -3930,15 +3884,13 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeMajor, 
-          \Self.major, 
-          \Self.unexpectedBetweenMajorAndComponents, 
-          \Self.components, 
-          \Self.unexpectedAfterComponents
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeMajor, 
+        \Self.major, 
+        \Self.unexpectedBetweenMajorAndComponents, 
+        \Self.components, 
+        \Self.unexpectedAfterComponents
+      ])
 }
 
 // MARK: - WhereClauseSyntax
@@ -4052,15 +4004,13 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWhereKeyword, 
-          \Self.whereKeyword, 
-          \Self.unexpectedBetweenWhereKeywordAndCondition, 
-          \Self.condition, 
-          \Self.unexpectedAfterCondition
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWhereKeyword, 
+        \Self.whereKeyword, 
+        \Self.unexpectedBetweenWhereKeywordAndCondition, 
+        \Self.condition, 
+        \Self.unexpectedAfterCondition
+      ])
 }
 
 // MARK: - WhileStmtSyntax
@@ -4220,17 +4170,15 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWhileKeyword, 
-          \Self.whileKeyword, 
-          \Self.unexpectedBetweenWhileKeywordAndConditions, 
-          \Self.conditions, 
-          \Self.unexpectedBetweenConditionsAndBody, 
-          \Self.body, 
-          \Self.unexpectedAfterBody
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeWhileKeyword, 
+        \Self.whileKeyword, 
+        \Self.unexpectedBetweenWhileKeywordAndConditions, 
+        \Self.conditions, 
+        \Self.unexpectedBetweenConditionsAndBody, 
+        \Self.body, 
+        \Self.unexpectedAfterBody
+      ])
 }
 
 // MARK: - WildcardPatternSyntax
@@ -4318,9 +4266,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
 }
 
 // MARK: - YieldStmtSyntax
@@ -4510,15 +4456,13 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeYieldKeyword, 
-          \Self.yieldKeyword, 
-          \Self.unexpectedBetweenYieldKeywordAndYieldedExpressions, 
-          \Self.yieldedExpressions, 
-          \Self.unexpectedAfterYieldedExpressions
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeYieldKeyword, 
+        \Self.yieldKeyword, 
+        \Self.unexpectedBetweenYieldKeywordAndYieldedExpressions, 
+        \Self.yieldedExpressions, 
+        \Self.unexpectedAfterYieldedExpressions
+      ])
 }
 
 // MARK: - YieldedExpressionSyntax
@@ -4630,15 +4574,13 @@ public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeExpression, 
-          \Self.expression, 
-          \Self.unexpectedBetweenExpressionAndComma, 
-          \Self.comma, 
-          \Self.unexpectedAfterComma
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeExpression, 
+        \Self.expression, 
+        \Self.unexpectedBetweenExpressionAndComma, 
+        \Self.comma, 
+        \Self.unexpectedAfterComma
+      ])
 }
 
 // MARK: - YieldedExpressionsClauseSyntax
@@ -4805,15 +4747,13 @@ public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable, _L
     }
   }
   
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeLeftParen, 
-          \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElements, 
-          \Self.elements, 
-          \Self.unexpectedBetweenElementsAndRightParen, 
-          \Self.rightParen, 
-          \Self.unexpectedAfterRightParen
-        ])
-  }
+  public static let structure: SyntaxNodeStructure = .layout([
+        \Self.unexpectedBeforeLeftParen, 
+        \Self.leftParen, 
+        \Self.unexpectedBetweenLeftParenAndElements, 
+        \Self.elements, 
+        \Self.unexpectedBetweenElementsAndRightParen, 
+        \Self.rightParen, 
+        \Self.unexpectedAfterRightParen
+      ])
 }

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -61,9 +61,15 @@ function(add_swift_syntax_library name)
   add_custom_command(
       TARGET ${name}
       POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> $<TARGET_OBJECTS:${name}> "${module_base}"
+      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> "${module_base}"
       COMMAND_EXPAND_LISTS
       COMMENT "Update mtime of library outputs workaround")
+  add_custom_command(
+      TARGET ${name}
+      POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_OBJECTS:${name}>
+      COMMAND_EXPAND_LISTS
+      COMMENT "Update mtime of objcect files workaround")
 
   # Install the Swift module into the appropriate location.
   set_target_properties(${name}


### PR DESCRIPTION
Cherry-pick #2726 #2728 #2729 #2741 into release/6.0

* **Explanation**: Several performance optimizations mainly for `BaiscFormat` performance:
  * Factor-out `SyntaxVisitor`'s `Syntax.Info` reusing mechanism into `SyntaxNodeFactory` and adopt it in `SyntaxRewriter`
  * Optimize `SyntaxRewriter`'s new layout creation logic using manually-allocated `UnsafeMutableBufferPointer`
  * Mark the parameter of `Syntax`/`SyntaxProtocol` casting initializers `__shared` to save retain/release operations
  * Turn some static computed properties into stored constants Specifically, `OperatorTable.standardOperators` and `SyntaxProtocol.structure` so that the values are cached.
* **Scope**: `Syntax` performance
* **Risk**: Low-Mid. This introduces some `UnsafeMutablePointer` operations. But tested with ASAN
* **Testing**: Passes the current test suite. PR tested with [ASAN](https://ci.swift.org/job/swift-PR-osx-preset/171/) and [LSAN](https://ci.swift.org/job/swift-PR-Linux-preset/140/)
* **Issue**: Part of rdar://130478685
* **Reviewer**: Alex Hoppen (@ahoppen)
