### PR TITLE
[6.0] Mark `MultithreadingTests` as `@unchecked Sendable` to work around rdar://130094927

### DIFF
--- a/Examples/Sources/MacroExamples/Playground/ExpressionMacrosPlayground.swift
+++ b/Examples/Sources/MacroExamples/Playground/ExpressionMacrosPlayground.swift
@@ -47,7 +47,7 @@ func runExpressionMacrosPlayground() {
 
   //  let domain = "domain.com"
   //print(#URL("https://\(domain)/api/path")) // error: #URL requires a static string literal
-  //print(#URL("https://not a url.com")) // error: Malformed url
+  //print(#URL("https://not a url.com:invalid-port/")) // error: Malformed url
 
   // MARK: - Warning
 

--- a/Examples/Tests/MacroExamples/Implementation/Expression/URLMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Expression/URLMacroTests.swift
@@ -21,13 +21,18 @@ final class URLMacroTests: XCTestCase {
   func testExpansionWithMalformedURLEmitsError() {
     assertMacroExpansion(
       """
-      let invalid = #URL("https://not a url.com")
+      let invalid = #URL("https://not a url.com:invalid-port/")
       """,
       expandedSource: """
-        let invalid = #URL("https://not a url.com")
+        let invalid = #URL("https://not a url.com:invalid-port/")
         """,
       diagnostics: [
-        DiagnosticSpec(message: #"malformed url: "https://not a url.com""#, line: 1, column: 15, severity: .error)
+        DiagnosticSpec(
+          message: #"malformed url: "https://not a url.com:invalid-port/""#,
+          line: 1,
+          column: 15,
+          severity: .error
+        )
       ],
       macros: macros,
       indentationWidth: .spaces(2)

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -20,8 +20,9 @@ extension SyntaxProtocol {
   }
 }
 
-class MultithreadingTests: XCTestCase {
-
+// Marked as `@unchecked Sendable` to work around rdar://130094927, which complains about `MultithreadingTests` not conforming to
+// `Sendable`.
+class MultithreadingTests: XCTestCase, @unchecked Sendable {
   public func testPathological() {
     let tuple = TupleTypeSyntax(
       leftParen: .leftParenToken(),


### PR DESCRIPTION
- **Explanation**: swift-syntax did not build without warnings on Linux due to rdar://130094927. Building without warnings is a requirement for us to release a new swift-syntax version, so work around that warning by adding `@unchecke Sendable`.
- **Scope**: Test-only change
- **Risk**: Low, test-only change
- **Testing**: Checked that swift-syntax builds without warnings on Linux with this change
- **Issue**: n/a
- **Reviewer**:   @bnbarham 