### PR TITLE
[6.0] Fix build warnings

### DIFF
--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -27,7 +27,7 @@ class ParsingPerformanceTests: XCTestCase {
   func testNativeParsingPerformance() throws {
     try XCTSkipIf(longTestsDisabled)
 
-    let source = try String(contentsOf: inputFile)
+    let source = try String(contentsOf: inputFile, encoding: .utf8)
 
     try measureInstructions {
       _ = Parser.parse(source: source)

--- a/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
+++ b/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
@@ -28,7 +28,7 @@ class SyntaxClassifierPerformanceTests: XCTestCase {
   func testClassifierPerformance() throws {
     try XCTSkipIf(longTestsDisabled)
 
-    let source = try String(contentsOf: inputFile)
+    let source = try String(contentsOf: inputFile, encoding: .utf8)
     let parsed = Parser.parse(source: source)
 
     try measureInstructions {

--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -28,7 +28,7 @@ class VisitorPerformanceTests: XCTestCase {
     try XCTSkipIf(longTestsDisabled)
     class EmptyVisitor: SyntaxVisitor {}
 
-    let source = try String(contentsOf: inputFile)
+    let source = try String(contentsOf: inputFile, encoding: .utf8)
     let parsed = Parser.parse(source: source)
     let emptyVisitor = EmptyVisitor(viewMode: .sourceAccurate)
 
@@ -41,7 +41,7 @@ class VisitorPerformanceTests: XCTestCase {
     try XCTSkipIf(longTestsDisabled)
     class EmptyRewriter: SyntaxRewriter {}
 
-    let source = try String(contentsOf: inputFile)
+    let source = try String(contentsOf: inputFile, encoding: .utf8)
     let parsed = Parser.parse(source: source)
     let emptyRewriter = EmptyRewriter(viewMode: .sourceAccurate)
 
@@ -54,7 +54,7 @@ class VisitorPerformanceTests: XCTestCase {
     try XCTSkipIf(longTestsDisabled)
     class EmptyAnyVisitor: SyntaxAnyVisitor {}
 
-    let source = try String(contentsOf: inputFile)
+    let source = try String(contentsOf: inputFile, encoding: .utf8)
     let parsed = Parser.parse(source: source)
     let emptyVisitor = EmptyAnyVisitor(viewMode: .sourceAccurate)
 

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -62,7 +62,7 @@ class ParserTests: ParserTestCase {
     shouldExclude: @Sendable (URL) -> Bool = { _ in false }
   ) {
     // nonisolated(unsafe) because [URL] is not marked Sendable on Linux.
-    let _fileURLs = FileManager.default
+    let fileURLs = FileManager.default
       .enumerator(at: path, includingPropertiesForKeys: nil)!
       .compactMap({ $0 as? URL })
       .filter {
@@ -70,12 +70,6 @@ class ParserTests: ParserTestCase {
           || $0.pathExtension == "sil"
           || $0.pathExtension == "swiftinterface"
       }
-    #if swift(>=6.0) && !canImport(Darwin)
-    // URL is not marked as Sendable in corelibs-foundation
-    nonisolated(unsafe) let fileURLs = _fileURLs
-    #else
-    let fileURLs = _fileURLs
-    #endif
 
     print("\(name) - processing \(fileURLs.count) source files")
     DispatchQueue.concurrentPerform(iterations: fileURLs.count) { fileURLIndex in


### PR DESCRIPTION
- **Explanation**: Fix build warnings so that the version of swift-syntax we release as a package dependency doesn’t contain any warnings
- **Scope**: Tests only
- **Risk**: Very low, test only change with no functionality change
- **Testing**: Verified that swift-syntax now builds without warnings on macOS and Linux
- **Issue**: rdar://131047703
- **Reviewer**:   @bnbarham 