### PR TITLE
Emit a warning if a conformance to `MemberMacro` does not contain the `expansion` method that takes a `conformingTo` parameter

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
@@ -81,6 +81,11 @@ extension MemberMacro {
   }
 
   /// Default implementation that ignores the unhandled conformances.
+  @available(
+    *,
+    deprecated,
+    message: "`MemberMacro` conformance should implement the `expansion` function that takes a `conformingTo` parameter"
+  )
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,


### PR DESCRIPTION
The `expansion` method that takes a `conformingTo` has been defaulted to be source-compatible with older versions of swift-syntax that required a version of the `expansion` function without the `conformingTo` parameter.

That meant that you could state a conformance to `MemberMacro` without implementing any methods and you wouldn’t get any compile time diagnostics.

Deprecate the forwarding default implementation so that you get a warning if you are relying on it.