### PR TITLE
[SwiftLexicalLookup][GSoC] Fix Swift 5.8 compatibility and update documentation.

### DIFF
--- a/Sources/SwiftLexicalLookup/Configurations/FileScopeHandlingConfig.swift
+++ b/Sources/SwiftLexicalLookup/Configurations/FileScopeHandlingConfig.swift
@@ -20,6 +20,4 @@ import SwiftSyntax
   /// This is the behavior that is being used
   /// for Swift files that don’t allow top-level code.
   case memberBlock
-  /// This is the behavior that is being used for e.g. function bodies.
-  case codeBlock
 }

--- a/Sources/SwiftLexicalLookup/Configurations/FileScopeNameIntroductionStrategy.swift
+++ b/Sources/SwiftLexicalLookup/Configurations/FileScopeNameIntroductionStrategy.swift
@@ -14,12 +14,12 @@ import SwiftSyntax
 
 /// Specifies how names should be introduced at the file scope.
 @_spi(Experimental) public enum FileScopeHandlingConfig {
-  /// Default behavior. Names introduced sequentially like in member block
-  /// scope up to the first non-declaration after and including which,
-  /// the declarations are treated like in code block scope.
+  /// This is the behavior that is being used
+  /// for Swift files with top-level code.
   case memberBlockUpToLastDecl
-  /// File scope behaves like member block scope.
+  /// This is the behavior that is being used
+  /// for Swift files that don’t allow top-level code.
   case memberBlock
-  /// File scope behaves like code block scope.
+  /// This is the behavior that is being used for e.g. function bodies.
   case codeBlock
 }

--- a/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
+++ b/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
@@ -13,11 +13,16 @@
 import Foundation
 
 @_spi(Experimental) public struct LookupConfig {
-  /// Specifies behaviour of file scope.
-  /// `memberBlockUpToLastDecl` by default.
-  public var fileScopeHandling: FileScopeHandlingConfig = .memberBlockUpToLastDecl
+  /// Specifies behavior of file scope.
+  @_spi(Experimental) public var fileScopeHandling: FileScopeHandlingConfig
 
-  public init(fileScopeHandling: FileScopeHandlingConfig = .memberBlockUpToLastDecl) {
+  /// Creates a new lookup configuration.
+  ///
+  /// - `fileScopeHandling` - specifies behavior of file scope.
+  ///   `memberBlockUpToLastDecl` by default.
+  @_spi(Experimental) public init(
+    fileScopeHandling: FileScopeHandlingConfig = .memberBlockUpToLastDecl
+  ) {
     self.fileScopeHandling = fileScopeHandling
   }
 }

--- a/Sources/SwiftLexicalLookup/IdentifiableSyntax.swift
+++ b/Sources/SwiftLexicalLookup/IdentifiableSyntax.swift
@@ -13,25 +13,25 @@
 import SwiftSyntax
 
 /// Syntax node that can be refered to with an identifier.
-public protocol IdentifiableSyntax: SyntaxProtocol {
+@_spi(Experimental) public protocol IdentifiableSyntax: SyntaxProtocol {
   var identifier: TokenSyntax { get }
 }
 
-extension IdentifierPatternSyntax: IdentifiableSyntax {}
+@_spi(Experimental) extension IdentifierPatternSyntax: IdentifiableSyntax {}
 
-extension ClosureParameterSyntax: IdentifiableSyntax {
+@_spi(Experimental) extension ClosureParameterSyntax: IdentifiableSyntax {
   @_spi(Experimental) public var identifier: TokenSyntax {
     secondName ?? firstName
   }
 }
 
-extension ClosureShorthandParameterSyntax: IdentifiableSyntax {
+@_spi(Experimental) extension ClosureShorthandParameterSyntax: IdentifiableSyntax {
   @_spi(Experimental) public var identifier: TokenSyntax {
     name
   }
 }
 
-extension ClosureCaptureSyntax: IdentifiableSyntax {
+@_spi(Experimental) extension ClosureCaptureSyntax: IdentifiableSyntax {
   @_spi(Experimental) public var identifier: TokenSyntax {
     /* Doesn't work with closures like:
      _ = { [y=1+2] in

--- a/Sources/SwiftLexicalLookup/LookupName.swift
+++ b/Sources/SwiftLexicalLookup/LookupName.swift
@@ -18,14 +18,14 @@ import SwiftSyntax
   case identifier(IdentifiableSyntax, accessibleAfter: AbsolutePosition?)
   /// Declaration associated with the name.
   /// Could be class, struct, actor, protocol, function and more.
-  case declaration(NamedDeclSyntax, accessibleAfter: AbsolutePosition?)
+  case declaration(NamedDeclSyntax)
 
   /// Syntax associated with this name.
   @_spi(Experimental) public var syntax: SyntaxProtocol {
     switch self {
     case .identifier(let syntax, _):
       return syntax
-    case .declaration(let syntax, _):
+    case .declaration(let syntax):
       return syntax
     }
   }
@@ -35,7 +35,7 @@ import SwiftSyntax
     switch self {
     case .identifier(let syntax, _):
       return Identifier(syntax.identifier)
-    case .declaration(let syntax, _):
+    case .declaration(let syntax):
       return Identifier(syntax.name)
     }
   }
@@ -44,8 +44,10 @@ import SwiftSyntax
   /// If set to `nil`, the name is available at any point in scope.
   var accessibleAfter: AbsolutePosition? {
     switch self {
-    case .identifier(_, let absolutePosition), .declaration(_, let absolutePosition):
+    case .identifier(_, let absolutePosition):
       return absolutePosition
+    default:
+      return nil
     }
   }
 
@@ -133,6 +135,6 @@ import SwiftSyntax
     namedDecl: NamedDeclSyntax,
     accessibleAfter: AbsolutePosition? = nil
   ) -> [LookupName] {
-    [.declaration(namedDecl, accessibleAfter: accessibleAfter)]
+    [.declaration(namedDecl)]
   }
 }

--- a/Sources/SwiftLexicalLookup/LookupResult.swift
+++ b/Sources/SwiftLexicalLookup/LookupResult.swift
@@ -12,7 +12,7 @@
 
 import SwiftSyntax
 
-/// Represents resul
+/// Represents result from a specific scope.
 @_spi(Experimental) public enum LookupResult {
   /// Scope and the names that matched lookup.
   case fromScope(ScopeSyntax, withNames: [LookupName])
@@ -23,9 +23,9 @@ import SwiftSyntax
   @_spi(Experimental) public var scope: ScopeSyntax? {
     switch self {
     case .fromScope(let scopeSyntax, _):
-      scopeSyntax
+      return scopeSyntax
     case .fromFileScope(let fileScopeSyntax, _):
-      fileScopeSyntax
+      return fileScopeSyntax
     }
   }
 
@@ -33,7 +33,7 @@ import SwiftSyntax
   @_spi(Experimental) public var names: [LookupName] {
     switch self {
     case .fromScope(_, let names), .fromFileScope(_, let names):
-      names
+      return names
     }
   }
 }

--- a/Sources/SwiftLexicalLookup/ScopeImplementations.swift
+++ b/Sources/SwiftLexicalLookup/ScopeImplementations.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 
 @_spi(Experimental) extension SyntaxProtocol {
   /// Parent scope of this syntax node, or scope introduced by this syntax node.
-  @_spi(Experimental) public var scope: ScopeSyntax? {
+  var scope: ScopeSyntax? {
     if let scopeSyntax = Syntax(self).asProtocol(SyntaxProtocol.self) as? ScopeSyntax {
       return scopeSyntax
     } else {
@@ -68,10 +68,6 @@ import SwiftSyntax
             return LookupName.getNames(from: item, accessibleAfter: codeBlockItem.endPosition)
           }
         }
-      }
-    case .codeBlock:
-      return statements.flatMap { codeBlockItem in
-        LookupName.getNames(from: codeBlockItem.item, accessibleAfter: codeBlockItem.endPosition)
       }
     case .memberBlock:
       return statements.flatMap { codeBlockItem in

--- a/Sources/SwiftLexicalLookup/ScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/ScopeSyntax.swift
@@ -92,7 +92,7 @@ extension SyntaxProtocol {
     let filteredNames =
       introducedNames
       .filter { introducedName in
-        does(name: name, referTo: introducedName, at: syntax)
+        checkName(name, refersTo: introducedName, at: syntax)
       }
 
     if filteredNames.isEmpty {
@@ -111,7 +111,7 @@ extension SyntaxProtocol {
     parentScope?.lookup(for: name, at: syntax, with: config) ?? []
   }
 
-  func does(name: String?, referTo introducedName: LookupName, at syntax: SyntaxProtocol) -> Bool {
+  func checkName(_ name: String?, refersTo introducedName: LookupName, at syntax: SyntaxProtocol) -> Bool {
     introducedName.isAccessible(at: syntax) && (name == nil || introducedName.refersTo(name!))
   }
 }

--- a/Tests/SwiftLexicalLookupTest/Assertions.swift
+++ b/Tests/SwiftLexicalLookupTest/Assertions.swift
@@ -52,7 +52,7 @@ enum MarkerExpectation {
   }
 }
 
-/// Used to define
+/// Used to define result assertion.
 enum ResultExpectation {
   case fromScope(ScopeSyntax.Type, expectedNames: [String])
   case fromFileScope(expectedNames: [String])
@@ -118,19 +118,7 @@ func assertLexicalScopeQuery(
 
     // Assert validity of the output
     for (actual, (expectedMarker, expectedPosition)) in zip(result, zip(expectedMarkers, expectedPositions)) {
-      if actual == nil && expectedPosition == nil { continue }
-
-      guard let actual else {
-        XCTFail(
-          "For marker \(marker), actual is nil while expected is \(sourceFileSyntax.token(at: expectedPosition!)?.description ?? "nil")"
-        )
-        continue
-      }
-
-      guard let expectedPosition else {
-        XCTFail("For marker \(marker), actual is \(actual) while expected position is nil")
-        continue
-      }
+      guard let actual, let expectedPosition else { continue }
 
       XCTAssert(
         actual.positionAfterSkippingLeadingTrivia == expectedPosition,

--- a/Tests/SwiftLexicalLookupTest/Assertions.swift
+++ b/Tests/SwiftLexicalLookupTest/Assertions.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 @_spi(Experimental) import SwiftLexicalLookup
 import SwiftParser
 import SwiftSyntax
@@ -61,9 +60,9 @@ enum ResultExpectation {
   var expectedNames: [String] {
     switch self {
     case .fromScope(_, let expectedNames):
-      expectedNames
+      return expectedNames
     case .fromFileScope(expectedNames: let expectedNames):
-      expectedNames
+      return expectedNames
     }
   }
 }
@@ -73,7 +72,7 @@ enum ResultExpectation {
 /// It also checks whether result types match rules specified in `expectedResultTypes`.
 func assertLexicalScopeQuery(
   source: String,
-  methodUnderTest: (String, TokenSyntax) -> ([SyntaxProtocol?]),
+  methodUnderTest: (_ marker: String, _ tokenAtMarker: TokenSyntax) -> ([SyntaxProtocol?]),
   expected: [String: [String?]],
   expectedResultTypes: MarkerExpectation = .none
 ) {
@@ -118,27 +117,27 @@ func assertLexicalScopeQuery(
     }
 
     // Assert validity of the output
-    for (actual, expected) in zip(result, zip(expectedMarkers, expectedPositions)) {
-      if actual == nil && expected.1 == nil { continue }
+    for (actual, (expectedMarker, expectedPosition)) in zip(result, zip(expectedMarkers, expectedPositions)) {
+      if actual == nil && expectedPosition == nil { continue }
 
       guard let actual else {
         XCTFail(
-          "For marker \(marker), actual is nil while expected is \(sourceFileSyntax.token(at: expected.1!)?.description ?? "nil")"
+          "For marker \(marker), actual is nil while expected is \(sourceFileSyntax.token(at: expectedPosition!)?.description ?? "nil")"
         )
         continue
       }
 
-      guard let expectedPosition = expected.1 else {
+      guard let expectedPosition else {
         XCTFail("For marker \(marker), actual is \(actual) while expected position is nil")
         continue
       }
 
       XCTAssert(
         actual.positionAfterSkippingLeadingTrivia == expectedPosition,
-        "For marker \(marker), actual result: \(actual) doesn't match expected value: \(sourceFileSyntax.token(at: expected.1!)?.description ?? "nil")"
+        "For marker \(marker), actual result: \(actual) doesn't match expected value: \(sourceFileSyntax.token(at: expectedPosition)?.description ?? "nil")"
       )
 
-      if let expectedMarker = expected.0 {
+      if let expectedMarker {
         expectedResultTypes.assertMarkerType(marker: expectedMarker, actual: actual)
       }
     }
@@ -157,8 +156,8 @@ func assertLexicalNameLookup(
 ) {
   assertLexicalScopeQuery(
     source: source,
-    methodUnderTest: { marker, argument in
-      let result = argument.lookup(for: useNilAsTheParameter ? nil : argument.text, with: config)
+    methodUnderTest: { marker, tokenAtMarker in
+      let result = tokenAtMarker.lookup(for: useNilAsTheParameter ? nil : tokenAtMarker.text, with: config)
 
       guard let expectedValues = references[marker] else {
         XCTFail("For marker \(marker), couldn't find result expectation")

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -50,7 +50,7 @@ final class testNameLookup: XCTestCase {
       source: """
         for i in 1..<4 {
           let (1️⃣a, 2️⃣b) = (1, 2)
-          let 3️⃣c = 3, 4️⃣d = 4
+          let 3️⃣c = 3, 4️⃣d = 9️⃣c
 
           5️⃣a
           6️⃣b
@@ -63,6 +63,7 @@ final class testNameLookup: XCTestCase {
         "6️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: ["2️⃣"])],
         "7️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: ["3️⃣"])],
         "8️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: ["4️⃣"])],
+        "9️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: ["3️⃣"])],
       ],
       expectedResultTypes: .all(IdentifierPatternSyntax.self)
     )
@@ -73,8 +74,8 @@ final class testNameLookup: XCTestCase {
       source: """
         for 1️⃣i in 1..<4 {
           let (a, b) = (2️⃣i, 3️⃣j)
-          for (4️⃣i, 5️⃣j) in foo {
-            let (c, d) = (6️⃣i, 7️⃣j)
+          for (4️⃣i, (5️⃣j, 8️⃣k)) in foo {
+            let (c, d, e) = (6️⃣i, 7️⃣j, 9️⃣k)
           }
         }
         """,
@@ -86,6 +87,7 @@ final class testNameLookup: XCTestCase {
           .fromScope(ForStmtSyntax.self, expectedNames: ["1️⃣"]),
         ],
         "7️⃣": [.fromScope(ForStmtSyntax.self, expectedNames: ["5️⃣"])],
+        "9️⃣": [.fromScope(ForStmtSyntax.self, expectedNames: ["8️⃣"])],
       ],
       expectedResultTypes: .all(IdentifierPatternSyntax.self)
     )

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -525,22 +525,25 @@ final class testNameLookup: XCTestCase {
         "6️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
         "0️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
       ],
-      expectedResultTypes: .all(ClassDeclSyntax.self, except: [
-        "8️⃣": IdentifierPatternSyntax.self,
-        "🔟": IdentifierPatternSyntax.self
-      ]),
+      expectedResultTypes: .all(
+        ClassDeclSyntax.self,
+        except: [
+          "8️⃣": IdentifierPatternSyntax.self,
+          "🔟": IdentifierPatternSyntax.self,
+        ]
+      ),
       config: LookupConfig(fileScopeHandling: .memberBlock)
     )
   }
-  
+
   func testDeclarationAvailabilityInCodeBlock() {
     assertLexicalNameLookup(
       source: """
         func x {
           1️⃣class A {}
-        
+
           let a = 2️⃣A()
-        
+
           3️⃣class A {}
         }
         """,

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -532,37 +532,6 @@ final class testNameLookup: XCTestCase {
       config: LookupConfig(fileScopeHandling: .memberBlock)
     )
   }
-
-  func testFileScopeAsCodeBlock() {
-    assertLexicalNameLookup(
-      source: """
-        1️⃣class a {}
-
-        2️⃣class b {
-          let x = 3️⃣a + 4️⃣b + 5️⃣c + 6️⃣d
-        }
-         
-        let 8️⃣a = 0
-
-        7️⃣class c {}
-
-        if a == 0 {}
-
-        9️⃣class d {}
-
-        let 🔟a = 0️⃣d
-        """,
-      references: [
-        "3️⃣": [.fromFileScope(expectedNames: ["1️⃣"])],
-        "4️⃣": [.fromFileScope(expectedNames: ["2️⃣"])],
-        "5️⃣": [.fromFileScope(expectedNames: ["7️⃣"])],
-        "6️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
-        "0️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
-      ],
-      expectedResultTypes: .all(ClassDeclSyntax.self, except: ["8️⃣": IdentifierPatternSyntax.self]),
-      config: LookupConfig(fileScopeHandling: .codeBlock)
-    )
-  }
   
   func testDeclarationAvailabilityInCodeBlock() {
     assertLexicalNameLookup(

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -486,13 +486,13 @@ final class testNameLookup: XCTestCase {
 
         9️⃣class d {}
 
-        let x = 0️⃣d
+        let 🔟a = 0️⃣d
         """,
       references: [
         "3️⃣": [.fromFileScope(expectedNames: ["1️⃣", "8️⃣"])],
         "4️⃣": [.fromFileScope(expectedNames: ["2️⃣"])],
         "5️⃣": [.fromFileScope(expectedNames: ["7️⃣"])],
-        "6️⃣": [],
+        "6️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
         "0️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
       ],
       expectedResultTypes: .all(ClassDeclSyntax.self, except: ["8️⃣": IdentifierPatternSyntax.self])
@@ -516,16 +516,19 @@ final class testNameLookup: XCTestCase {
 
         9️⃣class d {}
 
-        let x = 0️⃣d
+        let 🔟a = 0️⃣d
         """,
       references: [
-        "3️⃣": [.fromFileScope(expectedNames: ["1️⃣", "8️⃣"])],
+        "3️⃣": [.fromFileScope(expectedNames: ["1️⃣", "8️⃣", "🔟"])],
         "4️⃣": [.fromFileScope(expectedNames: ["2️⃣"])],
         "5️⃣": [.fromFileScope(expectedNames: ["7️⃣"])],
         "6️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
         "0️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
       ],
-      expectedResultTypes: .all(ClassDeclSyntax.self, except: ["8️⃣": IdentifierPatternSyntax.self]),
+      expectedResultTypes: .all(ClassDeclSyntax.self, except: [
+        "8️⃣": IdentifierPatternSyntax.self,
+        "🔟": IdentifierPatternSyntax.self
+      ]),
       config: LookupConfig(fileScopeHandling: .memberBlock)
     )
   }
@@ -547,17 +550,35 @@ final class testNameLookup: XCTestCase {
 
         9️⃣class d {}
 
-        let x = 0️⃣d
+        let 🔟a = 0️⃣d
         """,
       references: [
         "3️⃣": [.fromFileScope(expectedNames: ["1️⃣"])],
-        "4️⃣": [],
-        "5️⃣": [],
-        "6️⃣": [],
+        "4️⃣": [.fromFileScope(expectedNames: ["2️⃣"])],
+        "5️⃣": [.fromFileScope(expectedNames: ["7️⃣"])],
+        "6️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
         "0️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
       ],
       expectedResultTypes: .all(ClassDeclSyntax.self, except: ["8️⃣": IdentifierPatternSyntax.self]),
       config: LookupConfig(fileScopeHandling: .codeBlock)
+    )
+  }
+  
+  func testDeclarationAvailabilityInCodeBlock() {
+    assertLexicalNameLookup(
+      source: """
+        func x {
+          1️⃣class A {}
+        
+          let a = 2️⃣A()
+        
+          3️⃣class A {}
+        }
+        """,
+      references: [
+        "2️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: ["1️⃣", "3️⃣"])]
+      ],
+      expectedResultTypes: .all(ClassDeclSyntax.self)
     )
   }
 }


### PR DESCRIPTION
This PR addresses requested changes by @ahoppen from #2719 that were not included before its merging. Those include mainly fixing Swift 5.8 compatibility and documentation enhancements.