### PR TITLE
Introduce FixIt.Change API that replaces the child of a syntax node

### DIFF
--- a/Release Notes/601.md
+++ b/Release Notes/601.md
@@ -34,6 +34,12 @@
   - Description: Allows retrieving the radix value from the `literal.text`.
   - Issue: https://github.com/apple/swift-syntax/issues/405
   - Pull Request: https://github.com/apple/swift-syntax/pull/2605
+  
+- `FixIt.Change` gained a new case `replaceChild(data:)`.
+  - Description: The new case covers the replacement of a child node with another node.
+  - Issue: https://github.com/swiftlang/swift-syntax/issues/2205
+  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2758
+  - Migration steps: In exhaustive switches over `FixIt.Change`, cover the new case.
 
 ## Template
 

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -130,12 +130,15 @@ extension PluginMessage.Diagnostic {
               to: .afterTrailingTrivia
             )
             text = newTrivia.description
+          case .replaceChild(let replaceChildData):
+            range = sourceManager.range(replaceChildData.replacementRange, in: replaceChildData.parent)
+            text = replaceChildData.newChild.description
           #if RESILIENT_LIBRARIES
           @unknown default:
             fatalError()
           #endif
           }
-          guard let range = range else {
+          guard let range else {
             return nil
           }
           return .init(

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -170,19 +170,24 @@ class SourceManager {
     from startKind: PositionInSyntaxNode = .afterLeadingTrivia,
     to endKind: PositionInSyntaxNode = .beforeTrailingTrivia
   ) -> SourceRange? {
+    range(node.position(at: startKind)..<node.position(at: endKind), in: node)
+  }
+
+  /// Get ``SourceRange`` (file name + UTF-8 offset range) of `localRange` in `node`'s root node, which must be one
+  /// of the returned values from `add(_:)`.
+  func range(
+    _ localRange: @autoclosure () -> Range<AbsolutePosition>,
+    in node: some SyntaxProtocol
+  ) -> SourceRange? {
     guard let base = self.knownSourceSyntax[node.root.id] else {
       return nil
     }
-    let localStartPosition = node.position(at: startKind)
-    let localEndPosition = node.position(at: endKind)
-    precondition(localStartPosition <= localEndPosition)
-
     let positionOffset = base.location.offset
-
+    let localRange = localRange()
     return SourceRange(
       fileName: base.location.fileName,
-      startUTF8Offset: localStartPosition.advanced(by: positionOffset).utf8Offset,
-      endUTF8Offset: localEndPosition.advanced(by: positionOffset).utf8Offset
+      startUTF8Offset: localRange.lowerBound.advanced(by: positionOffset).utf8Offset,
+      endUTF8Offset: localRange.upperBound.advanced(by: positionOffset).utf8Offset
     )
   }
 

--- a/Sources/SwiftDiagnostics/Convenience.swift
+++ b/Sources/SwiftDiagnostics/Convenience.swift
@@ -51,4 +51,20 @@ extension FixIt {
       ]
     )
   }
+
+  public static func replaceChild<Parent: SyntaxProtocol, Child: SyntaxProtocol>(
+    message: FixItMessage,
+    parent: Parent,
+    replacingChildAt keyPath: WritableKeyPath<Parent, Child?> & Sendable,
+    with newChild: Child
+  ) -> Self {
+    FixIt(
+      message: message,
+      changes: [
+        .replaceChild(
+          data: FixIt.Change.ReplacingOptionalChildData(parent: parent, newChild: newChild, keyPath: keyPath)
+        )
+      ]
+    )
+  }
 }

--- a/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
@@ -622,6 +622,15 @@ fileprivate extension FixIt.Change {
         range: start..<end,
         replacement: newTrivia.description
       )
+
+    case .replaceChild(let replacingChildData):
+      let range = replacingChildData.replacementRange
+      let start = expansionContext.position(of: range.lowerBound, anchoredAt: replacingChildData.parent)
+      let end = expansionContext.position(of: range.upperBound, anchoredAt: replacingChildData.parent)
+      return SourceEdit(
+        range: start..<end,
+        replacement: replacingChildData.newChild.description
+      )
     }
   }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -49,24 +49,17 @@ final class PeerMacroTests: XCTestCase {
           newEffects = FunctionEffectSpecifiersSyntax(asyncSpecifier: .keyword(.async))
         }
 
-        let newSignature = funcDecl.signature.with(\.effectSpecifiers, newEffects)
-
         let diag = Diagnostic(
           node: Syntax(funcDecl.funcKeyword),
           message: SwiftSyntaxMacros.MacroExpansionErrorMessage(
             "can only add a completion-handler variant to an 'async' function"
           ),
           fixIts: [
-            FixIt(
-              message: SwiftSyntaxMacros.MacroExpansionFixItMessage(
-                "add 'async'"
-              ),
-              changes: [
-                FixIt.Change.replace(
-                  oldNode: Syntax(funcDecl.signature),
-                  newNode: Syntax(newSignature)
-                )
-              ]
+            .replaceChild(
+              message: SwiftSyntaxMacros.MacroExpansionFixItMessage("add 'async'"),
+              parent: funcDecl,
+              replacingChildAt: \.signature.effectSpecifiers,
+              with: newEffects
             )
           ]
         )


### PR DESCRIPTION
fix #2205