### PR TITLE
[6.0][CMake] Enable package CMO only in newer compiler

### DIFF
--- a/cmake/modules/SwiftCompilerCapability.cmake
+++ b/cmake/modules/SwiftCompilerCapability.cmake
@@ -22,6 +22,19 @@ macro(swift_supports_implicit_module module_name out_var)
   )
 endmacro()
 
+function(swift_get_swiftlang_version out_var)
+  execute_process(
+    COMMAND "${CMAKE_Swift_COMPILER}" -version
+    OUTPUT_VARIABLE output ERROR_VARIABLE output
+    RESULT_VARIABLE result
+    TIMEOUT 10
+  )
+
+  if(output MATCHES [[swiftlang-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)]])
+    set("${out_var}" "${CMAKE_MATCH_1}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Get "package cross-module-optimization" compiler arguments suitable for the compiler.
 function(swift_get_package_cmo_support out_var)
   # > 6.0 : Fixed feature.
@@ -43,8 +56,13 @@ function(swift_get_package_cmo_support out_var)
     -Xfrontend -experimental-package-bypass-resilience
   )
   if(result)
-    set(${out_var} EXPERIMENTAL PARENT_SCOPE)
-    return()
+    # Package CMO is implmented in Xcode 16 Beta 4 (swiftlang-6.0.0.6.8) or later.
+    # Consider it's not supported in non Xcode toolchain with "-experimental" options.
+    swift_get_swiftlang_version(swiftlang_version)
+    if(swiftlang_version AND swiftlang_version VERSION_GREATER_EQUAL 6.0.0.6)
+      set(${out_var} EXPERIMENTAL PARENT_SCOPE)
+      return()
+    endif()
   endif()
 
   # < 6.0 : Not supported.


### PR DESCRIPTION
Cherry-pick #2764 into release/6.0

* **Explanation**: Restricts enabling package CMO to only toolchains that properly support it to avoid linkage errors.
* **Scope**: swift-syntax
* **Risk**: Very low, disables package CMO in more cases
* **Testing**: No extra tests, this is a build time issue
* **Issue**: rdar://132708551
* **Reviewer**: Ben Barham (@bnbarham)