### PR TITLE
Update MODULE.bazel for 5.10 to support rules_swift 2.x+

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,4 +5,4 @@ module(
 )
 
 bazel_dep(name = "rules_swift", version = "1.16.0", repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "apple_support", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_apple_support")


### PR DESCRIPTION
This is required to support rules_swift 2.x on the 5.10 releases. The `main` branch already contains this change so it should go out with the version 6 releases