### PR TITLE
[SwiftIfConfig] Rename "versioned" to "syntaxErrorsAllowed" throughout

### DIFF
--- a/Sources/SwiftIfConfig/ConfiguredRegions.swift
+++ b/Sources/SwiftIfConfig/ConfiguredRegions.swift
@@ -78,19 +78,19 @@ fileprivate class ConfiguredRegionVisitor<Configuration: BuildConfiguration>: Sy
       }
 
       // For inactive clauses, distinguish between inactive and unparsed.
-      let isVersioned = clause.isVersioned(
+      let syntaxErrorsAllowed = clause.syntaxErrorsAllowed(
         configuration: configuration
-      ).versioned
+      ).syntaxErrorsAllowed
 
       // If this is within an active region, or this is an unparsed region,
       // record it.
-      if inActiveRegion || isVersioned {
-        regions.append((clause, isVersioned ? .unparsed : .inactive))
+      if inActiveRegion || syntaxErrorsAllowed {
+        regions.append((clause, syntaxErrorsAllowed ? .unparsed : .inactive))
       }
 
       // Recurse into inactive (but not unparsed) regions to find any
       // unparsed regions below.
-      if !isVersioned, let elements = clause.elements {
+      if !syntaxErrorsAllowed, let elements = clause.elements {
         let priorInActiveRegion = inActiveRegion
         inActiveRegion = false
         defer {

--- a/Sources/SwiftIfConfig/IfConfigFunctions.swift
+++ b/Sources/SwiftIfConfig/IfConfigFunctions.swift
@@ -57,9 +57,10 @@ enum IfConfigFunctions: String {
   /// via `_ptrauth(<name>)`.
   case _ptrauth
 
-  /// Whether uses of this function consistute a "versioned" check. Such checks
-  /// suppress parser diagnostics if the block failed.
-  var isVersioned: Bool {
+  /// Whether uses of this function consitutes a check that guards new syntax.
+  /// When such a check fails, the compiler should not diagnose syntax errors
+  /// within the covered block.
+  var syntaxErrorsAllowed: Bool {
     switch self {
     case .swift, .compiler, ._compiler_version:
       return true

--- a/Sources/SwiftIfConfig/IfConfigRegionState.swift
+++ b/Sources/SwiftIfConfig/IfConfigRegionState.swift
@@ -37,13 +37,13 @@ public enum IfConfigRegionState {
       foldingDiagnostics.append(contentsOf: error.asDiagnostics(at: condition))
     }.cast(ExprSyntax.self)
 
-    let (active, versioned, evalDiagnostics) = evaluateIfConfig(
+    let (active, syntaxErrorsAllowed, evalDiagnostics) = evaluateIfConfig(
       condition: foldedCondition,
       configuration: configuration
     )
 
     let diagnostics = foldingDiagnostics + evalDiagnostics
-    switch (active, versioned) {
+    switch (active, syntaxErrorsAllowed) {
     case (true, _): return (.active, diagnostics)
     case (false, false): return (.inactive, diagnostics)
     case (false, true): return (.unparsed, diagnostics)

--- a/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
+++ b/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
@@ -49,14 +49,14 @@ extension SyntaxProtocol {
 
         if activeClause != ifConfigClause {
           // This was not the active clause, so we know that we're in an
-          // inactive block. However, if the condition is versioned, this is an
+          // inactive block. If syntax errors aren't allowable, this is an
           // unparsed region.
-          let (isVersioned, localDiagnostics) = ifConfigClause.isVersioned(
+          let (syntaxErrorsAllowed, localDiagnostics) = ifConfigClause.syntaxErrorsAllowed(
             configuration: configuration
           )
           diagnostics.append(contentsOf: localDiagnostics)
 
-          if isVersioned {
+          if syntaxErrorsAllowed {
             return (.unparsed, diagnostics)
           }
 


### PR DESCRIPTION
The "versioned" terminology was brought over from the C++ implementation of `#if`, and really meant "if this code is inactive, it's allowed ot have syntax errors." Rename accordingly.