### PR TITLE
Address more code review feedback for the SwiftIfConfig library

### DIFF
--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -44,7 +44,8 @@ public enum CanImportVersion {
 /// be imported is a complicated task only implemented in the Swift compiler.
 /// Therefore, queries are permitted to throw an error to report when they
 /// cannot answer a query, in which case this error will be reported to
-/// the caller.
+/// the caller and the condition will be treated as being "false", so the
+/// code covered by the condition will be inactive.
 public protocol BuildConfiguration {
   /// Determine whether a given custom build condition has been set.
   ///

--- a/Sources/SwiftIfConfig/ConfiguredRegions.swift
+++ b/Sources/SwiftIfConfig/ConfiguredRegions.swift
@@ -24,15 +24,18 @@ extension SyntaxProtocol {
   ///     func f()
   ///   #elseif B
   ///     func g()
+  ///   #elseif compiler(>= 12.0)
+  ///   please print the number after 41
   ///   #endif
   /// #else
   /// #endif
   ///
   /// If the configuration options `DEBUG` and `B` are provided, but `A` is not,
-  /// the results will be contain:
-  ///   - Active region for the `#if DEBUG`
-  ///   - Inactive region for the `#if A`
-  ///   - Active region for the `#elseif B`
+  /// and the compiler version is less than 12.0, the results will be contain:
+  ///   - Active region for the `#if DEBUG`.
+  ///   - Inactive region for the `#if A`.
+  ///   - Active region for the `#elseif B`.
+  ///   - Unparsed region for the `#elseif compiler(>= 12.0)`.
   ///   - Inactive region for the final `#else`.
   public func configuredRegions(
     in configuration: some BuildConfiguration

--- a/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
+++ b/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
@@ -23,13 +23,19 @@ extension SyntaxProtocol {
   /// #if DEBUG
   ///   #if A
   ///    func f()
-  ///  #elseif B
-  ///    func g()
+  ///   #elseif B
+  ///     func g()
+  ///   #elseif compiler(>= 12.0)
+  ///     please print the number after 41
   ///   #endif
   /// #endif
   ///
   /// a call to `isActive` on the syntax node for the function `g` would return `active` when the
   /// configuration options `DEBUG` and `B` are provided, but `A` is not.
+  ///
+  /// If the compiler version is smaller than 12.0, then `isActive` on any of the tokens within
+  /// that `#elseif` block would return "unparsed", because that syntax should not (conceptually)
+  /// be parsed.
   public func isActive(
     in configuration: some BuildConfiguration
   ) -> (state: IfConfigRegionState, diagnostics: [Diagnostic]) {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -216,9 +216,9 @@ public class EvaluateTests: XCTestCase {
     assertIfConfig("canImport(SwiftSyntax, _version: 5.10)", .inactive)
     assertIfConfig(#"canImport(SwiftSyntax, _version: "5.9")"#, .active)
     assertIfConfig("canImport(SwiftSyntax, _underlyingVersion: 5009)", .active)
-    assertIfConfig("canImport(SwiftSyntax, _underlyingVersion: 5009.10", .inactive)
+    assertIfConfig("canImport(SwiftSyntax, _underlyingVersion: 5009.10)", .inactive)
     assertIfConfig(
-      "canImport(SwiftSyntax, _underlyingVersion: 5009.10.5.4.2.3.5",
+      "canImport(SwiftSyntax, _underlyingVersion: 5009.10.5.4.2.3.5)",
       .inactive,
       diagnostics: [
         DiagnosticSpec(
@@ -226,6 +226,30 @@ public class EvaluateTests: XCTestCase {
           line: 1,
           column: 44,
           severity: .warning
+        )
+      ]
+    )
+    assertIfConfig(
+      "canImport(SwiftSyntax, _version: 20A301)",
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'canImport' version check has invalid version '20A301'",
+          line: 1,
+          column: 34,
+          severity: .error
+        )
+      ]
+    )
+    assertIfConfig(
+      #"canImport(SwiftSyntax, _version: "20A301")"#,
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: #"'canImport' version check has invalid version '"20A301"'"#,
+          line: 1,
+          column: 34,
+          severity: .error
         )
       ]
     )


### PR DESCRIPTION
Address some of the remaining feedback on https://github.com/swiftlang/swift-syntax/pull/1816:
* Improve comments for `SyntaxProtocol.configuredRegions` and `isActive` to show when "unparsed" occurs
* Describe how thrown errors from build configurations are handled
* Add tests for `canImport(ModuleName, _version: NotAVersion)`