### PR TITLE
Make the "are syntax errors allowed?" condition independent of evaluation

### DIFF
--- a/Sources/SwiftIfConfig/IfConfigDecl+IfConfig.swift
+++ b/Sources/SwiftIfConfig/IfConfigDecl+IfConfig.swift
@@ -43,9 +43,13 @@ extension IfConfigDeclSyntax {
         return (clause, diagnostics: diagnostics)
       }
 
+      // Apply operator folding for !/&&/||.
+      let (foldedCondition, foldingDiagnostics) = IfConfigClauseSyntax.foldOperators(condition)
+      diagnostics.append(contentsOf: foldingDiagnostics)
+
       // If this condition evaluates true, return this clause.
       let (isActive, _, localDiagnostics) = evaluateIfConfig(
-        condition: condition,
+        condition: foldedCondition,
         configuration: configuration
       )
       diagnostics.append(contentsOf: localDiagnostics)

--- a/Sources/SwiftIfConfig/IfConfigRegionState.swift
+++ b/Sources/SwiftIfConfig/IfConfigRegionState.swift
@@ -32,10 +32,7 @@ public enum IfConfigRegionState {
     in configuration: some BuildConfiguration
   ) -> (state: IfConfigRegionState, syntaxErrorsAllowed: Bool, diagnostics: [Diagnostic]) {
     // Apply operator folding for !/&&/||.
-    var foldingDiagnostics: [Diagnostic] = []
-    let foldedCondition = OperatorTable.logicalOperators.foldAll(condition) { error in
-      foldingDiagnostics.append(contentsOf: error.asDiagnostics(at: condition))
-    }.cast(ExprSyntax.self)
+    let (foldedCondition, foldingDiagnostics) = IfConfigClauseSyntax.foldOperators(condition)
 
     let (active, syntaxErrorsAllowed, evalDiagnostics) = evaluateIfConfig(
       condition: foldedCondition,

--- a/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
+++ b/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
@@ -57,10 +57,10 @@ extension SyntaxProtocol {
           // This was not the active clause, so we know that we're in an
           // inactive block. If syntax errors aren't allowable, this is an
           // unparsed region.
-          let (syntaxErrorsAllowed, localDiagnostics) = ifConfigClause.syntaxErrorsAllowed(
-            configuration: configuration
-          )
-          diagnostics.append(contentsOf: localDiagnostics)
+          let syntaxErrorsAllowed =
+            ifConfigClause.condition.map {
+              IfConfigClauseSyntax.syntaxErrorsAllowed($0).syntaxErrorsAllowed
+            } ?? false
 
           if syntaxErrorsAllowed {
             return (.unparsed, diagnostics)


### PR DESCRIPTION
The compiler needs to be more careful about when it actually evaluates an #if condition, because canImport can have side effects. Make it easier to answer the question "are syntax errors allowed?" without having to evaluate the condition every time.