### PR TITLE
Various improvements and tweaks to bring SwiftIfConfig in line with the compiler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -143,7 +143,7 @@ let package = Package(
 
     .target(
       name: "SwiftIfConfig",
-      dependencies: ["SwiftSyntax", "SwiftDiagnostics", "SwiftOperators"],
+      dependencies: ["SwiftSyntax", "SwiftSyntaxBuilder", "SwiftDiagnostics", "SwiftOperators"],
       exclude: ["CMakeLists.txt"]
     ),
 

--- a/Sources/SwiftIfConfig/CMakeLists.txt
+++ b/Sources/SwiftIfConfig/CMakeLists.txt
@@ -24,5 +24,6 @@ add_swift_syntax_library(SwiftIfConfig
 
 target_link_swift_syntax_libraries(SwiftIfConfig PUBLIC
   SwiftSyntax
+  SwiftSyntaxBuilder
   SwiftDiagnostics
   SwiftOperators)

--- a/Sources/SwiftIfConfig/IfConfigError.swift
+++ b/Sources/SwiftIfConfig/IfConfigError.swift
@@ -31,6 +31,7 @@ enum IfConfigError: Error, CustomStringConvertible {
   case ignoredTrailingComponents(version: VersionTuple, syntax: ExprSyntax)
   case integerLiteralCondition(syntax: ExprSyntax, replacement: Bool)
   case likelySimulatorPlatform(syntax: ExprSyntax)
+  case endiannessDoesNotMatch(syntax: ExprSyntax, argument: String)
 
   var description: String {
     switch self {
@@ -81,6 +82,9 @@ enum IfConfigError: Error, CustomStringConvertible {
     case .likelySimulatorPlatform:
       return
         "platform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead"
+
+    case .endiannessDoesNotMatch:
+      return "unknown endianness for build configuration '_endian' (must be 'big' or 'little')"
     }
   }
 
@@ -100,7 +104,8 @@ enum IfConfigError: Error, CustomStringConvertible {
       .canImportTwoParameters(syntax: let syntax),
       .ignoredTrailingComponents(version: _, syntax: let syntax),
       .integerLiteralCondition(syntax: let syntax, replacement: _),
-      .likelySimulatorPlatform(syntax: let syntax):
+      .likelySimulatorPlatform(syntax: let syntax),
+      .endiannessDoesNotMatch(syntax: let syntax, argument: _):
       return Syntax(syntax)
 
     case .unsupportedVersionOperator(name: _, operator: let op):
@@ -118,7 +123,8 @@ extension IfConfigError: DiagnosticMessage {
 
   var severity: SwiftDiagnostics.DiagnosticSeverity {
     switch self {
-    case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents, .likelySimulatorPlatform:
+    case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents,
+      .likelySimulatorPlatform, .endiannessDoesNotMatch:
       return .warning
     default: return .error
     }

--- a/Sources/SwiftIfConfig/IfConfigError.swift
+++ b/Sources/SwiftIfConfig/IfConfigError.swift
@@ -33,6 +33,7 @@ enum IfConfigError: Error, CustomStringConvertible {
   case likelySimulatorPlatform(syntax: ExprSyntax)
   case endiannessDoesNotMatch(syntax: ExprSyntax, argument: String)
   case macabiIsMacCatalyst(syntax: ExprSyntax)
+  case expectedModuleName(syntax: ExprSyntax)
 
   var description: String {
     switch self {
@@ -89,6 +90,9 @@ enum IfConfigError: Error, CustomStringConvertible {
 
     case .endiannessDoesNotMatch:
       return "unknown endianness for build configuration '_endian' (must be 'big' or 'little')"
+
+    case .expectedModuleName:
+      return "expected module name"
     }
   }
 
@@ -110,7 +114,8 @@ enum IfConfigError: Error, CustomStringConvertible {
       .integerLiteralCondition(syntax: let syntax, replacement: _),
       .likelySimulatorPlatform(syntax: let syntax),
       .endiannessDoesNotMatch(syntax: let syntax, argument: _),
-      .macabiIsMacCatalyst(syntax: let syntax):
+      .macabiIsMacCatalyst(syntax: let syntax),
+      .expectedModuleName(syntax: let syntax):
       return Syntax(syntax)
 
     case .unsupportedVersionOperator(name: _, operator: let op):

--- a/Sources/SwiftIfConfig/IfConfigError.swift
+++ b/Sources/SwiftIfConfig/IfConfigError.swift
@@ -34,6 +34,7 @@ enum IfConfigError: Error, CustomStringConvertible {
   case endiannessDoesNotMatch(syntax: ExprSyntax, argument: String)
   case macabiIsMacCatalyst(syntax: ExprSyntax)
   case expectedModuleName(syntax: ExprSyntax)
+  case badInfixOperator(syntax: ExprSyntax)
 
   var description: String {
     switch self {
@@ -93,6 +94,9 @@ enum IfConfigError: Error, CustomStringConvertible {
 
     case .expectedModuleName:
       return "expected module name"
+
+    case .badInfixOperator:
+      return "expected '&&' or '||' expression"
     }
   }
 
@@ -115,7 +119,8 @@ enum IfConfigError: Error, CustomStringConvertible {
       .likelySimulatorPlatform(syntax: let syntax),
       .endiannessDoesNotMatch(syntax: let syntax, argument: _),
       .macabiIsMacCatalyst(syntax: let syntax),
-      .expectedModuleName(syntax: let syntax):
+      .expectedModuleName(syntax: let syntax),
+      .badInfixOperator(syntax: let syntax):
       return Syntax(syntax)
 
     case .unsupportedVersionOperator(name: _, operator: let op):

--- a/Sources/SwiftIfConfig/IfConfigError.swift
+++ b/Sources/SwiftIfConfig/IfConfigError.swift
@@ -35,6 +35,7 @@ enum IfConfigError: Error, CustomStringConvertible {
   case macabiIsMacCatalyst(syntax: ExprSyntax)
   case expectedModuleName(syntax: ExprSyntax)
   case badInfixOperator(syntax: ExprSyntax)
+  case badPrefixOperator(syntax: ExprSyntax)
 
   var description: String {
     switch self {
@@ -97,6 +98,9 @@ enum IfConfigError: Error, CustomStringConvertible {
 
     case .badInfixOperator:
       return "expected '&&' or '||' expression"
+
+    case .badPrefixOperator:
+      return "expected unary '!' expression"
     }
   }
 
@@ -120,7 +124,8 @@ enum IfConfigError: Error, CustomStringConvertible {
       .endiannessDoesNotMatch(syntax: let syntax, argument: _),
       .macabiIsMacCatalyst(syntax: let syntax),
       .expectedModuleName(syntax: let syntax),
-      .badInfixOperator(syntax: let syntax):
+      .badInfixOperator(syntax: let syntax),
+      .badPrefixOperator(syntax: let syntax):
       return Syntax(syntax)
 
     case .unsupportedVersionOperator(name: _, operator: let op):

--- a/Sources/SwiftIfConfig/IfConfigError.swift
+++ b/Sources/SwiftIfConfig/IfConfigError.swift
@@ -67,7 +67,7 @@ enum IfConfigError: Error, CustomStringConvertible {
       return "canImport requires a module name"
 
     case .canImportLabel(syntax: _):
-      return "2nd parameter of canImport should be labeled as _version or _underlyingVersion"
+      return "second parameter of canImport should be labeled as _version or _underlyingVersion"
 
     case .canImportTwoParameters(syntax: _):
       return "canImport can take only two parameters"

--- a/Sources/SwiftIfConfig/IfConfigError.swift
+++ b/Sources/SwiftIfConfig/IfConfigError.swift
@@ -118,7 +118,8 @@ extension IfConfigError: DiagnosticMessage {
 
   var severity: SwiftDiagnostics.DiagnosticSeverity {
     switch self {
-    case .ignoredTrailingComponents, .likelySimulatorPlatform: return .warning
+    case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents, .likelySimulatorPlatform:
+      return .warning
     default: return .error
     }
   }

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -374,6 +374,10 @@ func evaluateIfConfig(
         return recordError(.canImportMissingModule(syntax: ExprSyntax(call)))
       }
 
+      if call.arguments.count > 2 {
+        return recordError(.canImportTwoParameters(syntax: ExprSyntax(call)))
+      }
+
       // FIXME: This is a gross hack. Actually look at the sequence of
       // `MemberAccessExprSyntax` nodes and pull out the identifiers.
       let importPath = firstArg.expression.trimmedDescription.split(separator: ".")
@@ -422,10 +426,6 @@ func evaluateIfConfig(
         } else {
           assert(secondArg.label?.text == "_underlyingVersion")
           version = .underlyingVersion(versionTuple)
-        }
-
-        if call.arguments.count > 2 {
-          return recordError(.canImportTwoParameters(syntax: ExprSyntax(call)))
         }
       } else {
         version = .unversioned

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -96,10 +96,9 @@ func evaluateIfConfig(
   }
 
   // Declaration references are for custom compilation flags.
-  if let identExpr = condition.as(DeclReferenceExprSyntax.self) {
-    // FIXME: Need a real notion of an identifier.
-    let ident = identExpr.baseName.text
-
+  if let identExpr = condition.as(DeclReferenceExprSyntax.self),
+    let ident = identExpr.simpleIdentifier
+  {
     // Evaluate the custom condition. If the build configuration cannot answer this query, fail.
     return checkConfiguration(at: identExpr) {
       (active: try configuration.isCustomConditionSet(name: ident), syntaxErrorsAllowed: false)
@@ -497,18 +496,6 @@ private func extractImportPath(_ expression: some ExprSyntaxProtocol) throws -> 
   }
 
   throw IfConfigError.expectedModuleName(syntax: ExprSyntax(expression))
-}
-
-extension DeclReferenceExprSyntax {
-  /// If this declaration reference is a simple identifier, return that
-  /// string.
-  fileprivate var simpleIdentifier: String? {
-    guard argumentNames == nil else {
-      return nil
-    }
-
-    return baseName.text
-  }
 }
 
 /// Determine whether the given condition only involves disjunctions that

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -354,7 +354,11 @@ func evaluateIfConfig(
       let versionString = stringSegment.content.text
       let expectedVersion: VersionTuple
       do {
-        expectedVersion = try VersionTuple(parsingCompilerBuildVersion: versionString, argExpr)
+        expectedVersion = try VersionTuple.parseCompilerBuildVersion(
+          versionString,
+          argExpr,
+          extraDiagnostics: &extraDiagnostics
+        )
       } catch {
         return recordError(error, at: stringSegment.content)
       }

--- a/Sources/SwiftIfConfig/SyntaxLiteralUtils.swift
+++ b/Sources/SwiftIfConfig/SyntaxLiteralUtils.swift
@@ -36,13 +36,23 @@ extension LabeledExprListSyntax {
 extension ExprSyntax {
   /// Whether this is a simple identifier expression and, if so, what the identifier string is.
   var simpleIdentifierExpr: String? {
-    guard let identExpr = self.as(DeclReferenceExprSyntax.self),
-      identExpr.argumentNames == nil
-    else {
+    guard let identExpr = self.as(DeclReferenceExprSyntax.self) else {
       return nil
     }
 
-    // FIXME: Handle escaping here.
-    return identExpr.baseName.text
+    return identExpr.simpleIdentifier
+  }
+}
+
+extension DeclReferenceExprSyntax {
+  /// If this declaration reference is a simple identifier, return that
+  /// string.
+  var simpleIdentifier: String? {
+    guard argumentNames == nil else {
+      return nil
+    }
+
+    /// FIXME: Make this an Identifier so we handle escaping properly.
+    return baseName.text
   }
 }

--- a/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
+++ b/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 import SwiftSyntax
 
 extension VersionTuple {
@@ -20,11 +21,35 @@ extension VersionTuple {
   ///   we are parsing.
   ///   - versionSyntax: The syntax node that contains the version string, used
   ///   only for diagnostic purposes.
-  init(
-    parsingCompilerBuildVersion versionString: String,
+  static func parseCompilerBuildVersion(
+    _ versionString: String,
     _ versionSyntax: ExprSyntax
-  ) throws {
-    components = []
+  ) -> (version: VersionTuple?, diagnostics: [Diagnostic]) {
+    var extraDiagnostics: [Diagnostic] = []
+    let version: VersionTuple?
+    do {
+      version = try parseCompilerBuildVersion(versionString, versionSyntax, extraDiagnostics: &extraDiagnostics)
+    } catch {
+      version = nil
+      extraDiagnostics.append(contentsOf: error.asDiagnostics(at: versionSyntax))
+    }
+
+    return (version, extraDiagnostics)
+  }
+
+  /// Parse a compiler build version of the form "5007.*.1.2.3*", which is
+  /// used by an older if configuration form `_compiler_version("...")`.
+  /// - Parameters:
+  ///   - versionString: The version string for the compiler build version that
+  ///   we are parsing.
+  ///   - versionSyntax: The syntax node that contains the version string, used
+  ///   only for diagnostic purposes.
+  static func parseCompilerBuildVersion(
+    _ versionString: String,
+    _ versionSyntax: ExprSyntax,
+    extraDiagnostics: inout [Diagnostic]
+  ) throws -> VersionTuple {
+    var components: [Int] = []
 
     // Version value are separated by periods.
     let componentStrings = versionString.split(separator: ".", omittingEmptySubsequences: false)
@@ -49,7 +74,9 @@ extension VersionTuple {
       // The second component is always "*", and is never used for comparison.
       if index == 1 {
         if componentString != "*" {
-          throw IfConfigError.compilerVersionSecondComponentNotWildcard(syntax: versionSyntax)
+          extraDiagnostics.append(
+            IfConfigError.compilerVersionSecondComponentNotWildcard(syntax: versionSyntax).asDiagnostic
+          )
         }
         try recordComponent(0)
         continue
@@ -102,5 +129,7 @@ extension VersionTuple {
       }
       components[0] = components[0] / 1000
     }
+
+    return VersionTuple(components: components)
   }
 }

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -277,6 +277,32 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      "canImport(A, 2.2)",
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: #"second parameter of canImport should be labeled as _version or _underlyingVersion"#,
+          line: 1,
+          column: 14,
+          severity: .error
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "canImport(A, 2.2, 1.1)",
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: #"canImport can take only two parameters"#,
+          line: 1,
+          column: 1,
+          severity: .error
+        )
+      ]
+    )
   }
 
   func testLikelySimulatorEnvironment() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -391,7 +391,7 @@ public class EvaluateTests: XCTestCase {
 
   func testLikelySimulatorEnvironment() throws {
     assertIfConfig(
-      "((os(iOS) || os(tvOS)) && (arch(i386) || arch(x86_64))) && DEBUG",
+      "((os(iOS) || os(tvOS)) && (arch(i386) || arch(x86_64)))",
       .inactive,
       diagnostics: [
         DiagnosticSpec(
@@ -408,7 +408,12 @@ public class EvaluateTests: XCTestCase {
     )
 
     assertIfConfig(
-      "((os(iOS) || os(tvOS)) && (arch(arm64) || arch(x86_64))) && DEBUG",
+      "((os(iOS) || os(tvOS)) && (arch(arm64) || arch(x86_64)))",
+      .inactive
+    )
+
+    assertIfConfig(
+      "((os(iOS) || os(tvOS)) && (arch(i386) || arch(x86_64))) && DEBUG",
       .inactive
     )
   }

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -170,6 +170,19 @@ public class EvaluateTests: XCTestCase {
     assertIfConfig("_pointerBitWidth(_32)", .inactive)
     assertIfConfig("_hasAtomicBitWidth(_64)", .active)
     assertIfConfig("_hasAtomicBitWidth(_128)", .inactive)
+
+    assertIfConfig(
+      "_endian(mid)",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "unknown endianness for build configuration '_endian' (must be 'big' or 'little')",
+          line: 1,
+          column: 9,
+          severity: .warning
+        )
+      ]
+    )
   }
 
   func testVersions() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -230,6 +230,19 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      #"_compiler_version("5.7.100")"#,
+      .active,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "the second version component is not used for comparison in legacy compiler versions",
+          line: 1,
+          column: 19,
+          severity: .warning
+        )
+      ]
+    )
   }
 
   func testCanImport() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -148,6 +148,24 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      "A == B",
+      .unparsed,
+      configuration: buildConfig,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected '&&' or '||' expression",
+          line: 1,
+          column: 3
+        ),
+        DiagnosticSpec(
+          message: "invalid conditional compilation expression",
+          line: 1,
+          column: 1
+        ),
+      ]
+    )
   }
 
   func testFeatures() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -387,6 +387,11 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      "canImport(SwiftSyntax) || canImport(ExplodingModule)",
+      .active
+    )
   }
 
   func testLikelySimulatorEnvironment() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -278,6 +278,30 @@ public class EvaluateTests: XCTestCase {
       ]
     )
   }
+
+  func testLikelySimulatorEnvironment() throws {
+    assertIfConfig(
+      "((os(iOS) || os(tvOS)) && (arch(i386) || arch(x86_64))) && DEBUG",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message:
+            "platform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead",
+          line: 1,
+          column: 2,
+          severity: .warning,
+          fixIts: [
+            FixItSpec(message: "replace with 'targetEnvironment(simulator)'")
+          ]
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "((os(iOS) || os(tvOS)) && (arch(arm64) || arch(x86_64))) && DEBUG",
+      .inactive
+    )
+  }
 }
 
 /// Assert the results of evaluating the condition within an `#if` against the

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -120,6 +120,17 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+    assertIfConfig(
+      "BAR(_:)",
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "invalid conditional compilation expression",
+          line: 1,
+          column: 1
+        )
+      ]
+    )
   }
 
   func testBadExpressions() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -183,6 +183,22 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      "targetEnvironment(macabi)",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'macabi' has been renamed to 'macCatalyst'",
+          line: 1,
+          column: 19,
+          severity: .warning,
+          fixIts: [
+            FixItSpec(message: "replace with 'macCatalyst'")
+          ]
+        )
+      ]
+    )
   }
 
   func testVersions() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -345,6 +345,19 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      "canImport(A(b: 1, c: 2).B.C)",
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected module name",
+          line: 1,
+          column: 11,
+          severity: .error
+        )
+      ]
+    )
   }
 
   func testLikelySimulatorEnvironment() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -158,12 +158,19 @@ public class EvaluateTests: XCTestCase {
           message: "expected '&&' or '||' expression",
           line: 1,
           column: 3
-        ),
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "^DEBUG",
+      .unparsed,
+      diagnostics: [
         DiagnosticSpec(
-          message: "invalid conditional compilation expression",
+          message: "expected unary '!' expression",
           line: 1,
           column: 1
-        ),
+        )
       ]
     )
   }

--- a/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
+++ b/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
@@ -15,11 +15,14 @@ import SwiftSyntax
 
 enum BuildConfigurationError: Error, CustomStringConvertible {
   case badAttribute(String)
+  case badModule(String)
 
   var description: String {
     switch self {
     case .badAttribute(let attribute):
       return "unacceptable attribute '\(attribute)'"
+    case .badModule(let module):
+      return "unacceptable module '\(module)'"
     }
   }
 }
@@ -53,9 +56,13 @@ struct TestingBuildConfiguration: BuildConfiguration {
   func canImport(
     importPath: [String],
     version: CanImportVersion
-  ) -> Bool {
+  ) throws -> Bool {
     guard let moduleName = importPath.first else {
       return false
+    }
+
+    if moduleName == "ExplodingModule" {
+      throw BuildConfigurationError.badModule(moduleName)
     }
 
     guard moduleName == "SwiftSyntax" else { return false }


### PR DESCRIPTION
Implement a number of improvements and minor wording tweaks to bring SwiftIfConfig in line with the expectations of the compiler, as determined by the compiler's test suite. This includes:

* Add warning for `#if` conditions like `(os(iOS) || os(tvOS)) && (arch(i386) || arch(x86_64))` that should be replaced by `targetEnvironment(simulator)`.
* Add warning and remapping for the rename of the `macabi` target environment to `macCatalyst`.
* Downgrade the error about `_compiler_version`'s second version component being non-`*` to a warning.
* Downgrade error about bad `_endian` platform condition to a warning.
* Properly process expressions as import paths, replacing my horrible "grab the string and split on `.`" hack.
* Ensure that we diagnose compound names where they aren't permitted.
* Improve diagnostics for uses of operators other than `&&`, `||`, or `!`.
* Avoid evaluating `canImport` when it won't affect the result, because `canImport` in the compiler has side effects.