### PR TITLE
Support body macros that don’t return any statements

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -462,7 +462,8 @@ private func expandBodyMacro(
       conformanceList: nil,
       in: context,
       indentationWidth: indentationWidth
-    )
+    ),
+    !expanded.isEmpty
   else {
     return nil
   }

--- a/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
@@ -125,4 +125,34 @@ final class BodyMacroTests: XCTestCase {
       indentationWidth: indentationWidth
     )
   }
+
+  func testEmptyBodyMacro() {
+    struct EmptyBodyMacro: BodyMacro {
+      public static var formatMode: FormatMode { .disabled }
+
+      public static func expansion(
+        of node: AttributeSyntax,
+        providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+        in context: some MacroExpansionContext
+      ) throws -> [CodeBlockItemSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      @EmptyBody
+      func f() {
+        print(42)
+      }
+      """,
+      expandedSource: """
+        func f() {
+          print(42)
+        }
+        """,
+      diagnostics: [],
+      macros: ["EmptyBody": EmptyBodyMacro.self]
+    )
+  }
 }


### PR DESCRIPTION
Previously, when a body macro returned no statements, we would return an empty expansion and not add the braces in `collapse`. Fix that.