### PR TITLE
Do not affect indentation when `formatMode` is set to `off`

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -163,12 +163,18 @@ extension PluginProviderMessageHandler {
         in: context
       )
       if let expansions, hostCapability.hasExpandMacroResult {
+        let collapseIndentationWidth: Trivia?
+        switch macroDefinition.formatMode {
+        case .auto: collapseIndentationWidth = nil
+        case .disabled: collapseIndentationWidth = []
+        }
         // Make a single element array by collapsing the results into a string.
         expandedSources = [
           SwiftSyntaxMacroExpansion.collapse(
             expansions: expansions,
             for: role,
-            attachedTo: declarationNode
+            attachedTo: declarationNode,
+            indentationWidth: collapseIndentationWidth
           )
         ]
       } else {

--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -157,7 +157,7 @@ final class AccessorMacroTests: XCTestCase {
       """,
       expandedSource: """
         var x: Int { // hello
-          get { 1 }
+        get { 1 }
         }
         """,
       macros: ["constantOne": ConstantOneSingleLineGetter.self],


### PR DESCRIPTION
Make two changes:
- Don’t trim the expansions from a macro if `formatMode` is set to `off`. We want to keep all whitespace just as the macro provided it
- Don’t add indentation when collapsing a macro. Again, we want to keep the indentation as the macro provided it.

rdar://132597440
Fixes #2757