### PR TITLE
[6.0] Fix typo in 600 release notes: `isValidIdentifier` -> `isValidSwiftIdentifier`

### DIFF
--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -32,7 +32,7 @@
   - Description: The `throwsSpecifier` for the effects nodes (`AccessorEffectSpecifiers`, `FunctionEffectSpecifiers`, `TypeEffectSpecifiers`, `EffectSpecifiers`) has been replaced with `throwsClause`, which captures both the throws specifier and the (optional) thrown error type, as introduced by SE-0413.
   - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2379
 
-- `String.isValidIdentifier(for:)`
+- `String.isValidSwiftIdentifier(for:)`
   - Description: `SwiftParser` adds an extension on `String` to check if it can be used as an identifier in a given context.
   - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2434
 


### PR DESCRIPTION
- **Explanation**: Fix typo in 600 release notes: `isValidIdentifier` -> `isValidSwiftIdentifier`
- **Scope**: Release nots
- **Risk**: None, only affects release notes
- **Testing**: None
- **Issue**: n/a
- **Reviewer**:   @bnbarham 