### PR TITLE
Fix bad module dep version in 5.10

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,5 +4,5 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_swift", version = "1.16.0", repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "apple_support", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_apple_support")
+bazel_dep(name = "rules_swift", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")


### PR DESCRIPTION
This was using the wrong versions for `apple_support`. We **don't** need a new tag here as we'll be patching the [bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry/pull/2552) but fixing in case there is another 5.10 patch