### PR TITLE
Fix build issue when using a Swift 5.8 compiler

### DIFF
--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -58,7 +58,7 @@ final class PeerMacroTests: XCTestCase {
             .replaceChild(
               message: SwiftSyntaxMacros.MacroExpansionFixItMessage("add 'async'"),
               parent: funcDecl,
-              replacingChildAt: \.signature.effectSpecifiers,
+              replacingChildAt: \FunctionDeclSyntax.signature.effectSpecifiers,
               with: newEffects
             )
           ]


### PR DESCRIPTION
We were unable to infer the base of the subscript with a Swift 5.8 compiler.