### PR TITLE
Minor fixes and cleanups for SwiftIfConfig diagnostics

### DIFF
--- a/Sources/SwiftIfConfig/IfConfigError.swift
+++ b/Sources/SwiftIfConfig/IfConfigError.swift
@@ -46,7 +46,7 @@ enum IfConfigError: Error, CustomStringConvertible {
       return "build configuration cannot handle '\(name)'"
 
     case .requiresUnlabeledArgument(name: let name, role: let role, syntax: _):
-      return "\(name) requires a single unlabeled argument for the \(role)"
+      return "'\(name)' requires a single unlabeled argument for the \(role)"
 
     case .unsupportedVersionOperator(name: let name, operator: let op):
       return "'\(name)' version check does not support operator '\(op.trimmedDescription)'"
@@ -69,13 +69,13 @@ enum IfConfigError: Error, CustomStringConvertible {
       return "compiler version must not have more than five components"
 
     case .canImportMissingModule(syntax: _):
-      return "canImport requires a module name"
+      return "'canImport' requires a module name"
 
     case .canImportLabel(syntax: _):
-      return "second parameter of canImport should be labeled as _version or _underlyingVersion"
+      return "second parameter of 'canImport' should be labeled as _version or _underlyingVersion"
 
     case .canImportTwoParameters(syntax: _):
-      return "canImport can take only two parameters"
+      return "'canImport' can take only two parameters"
 
     case .ignoredTrailingComponents(version: let version, syntax: _):
       return "trailing components of version '\(version.description)' are ignored"

--- a/Sources/SwiftIfConfig/SyntaxLiteralUtils.swift
+++ b/Sources/SwiftIfConfig/SyntaxLiteralUtils.swift
@@ -28,7 +28,7 @@ extension TupleExprSyntax {
 extension LabeledExprListSyntax {
   /// If this list is a single, unlabeled expression, return it.
   var singleUnlabeledExpression: ExprSyntax? {
-    guard count == 1, let element = first else { return nil }
+    guard count == 1, let element = first, element.label == nil else { return nil }
     return element.expression
   }
 }

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -314,7 +314,7 @@ public class EvaluateTests: XCTestCase {
       .unparsed,
       diagnostics: [
         DiagnosticSpec(
-          message: "swift requires a single unlabeled argument for the version comparison (>= or <= a version)",
+          message: "'swift' requires a single unlabeled argument for the version comparison (>= or <= a version)",
           line: 1,
           column: 1,
           severity: .error
@@ -374,7 +374,7 @@ public class EvaluateTests: XCTestCase {
       .unparsed,
       diagnostics: [
         DiagnosticSpec(
-          message: #"second parameter of canImport should be labeled as _version or _underlyingVersion"#,
+          message: #"second parameter of 'canImport' should be labeled as _version or _underlyingVersion"#,
           line: 1,
           column: 14,
           severity: .error
@@ -387,7 +387,7 @@ public class EvaluateTests: XCTestCase {
       .unparsed,
       diagnostics: [
         DiagnosticSpec(
-          message: #"canImport can take only two parameters"#,
+          message: #"'canImport' can take only two parameters"#,
           line: 1,
           column: 1,
           severity: .error

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -308,6 +308,19 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      "swift(version: >=5.5)",
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "swift requires a single unlabeled argument for the version comparison (>= or <= a version)",
+          line: 1,
+          column: 1,
+          severity: .error
+        )
+      ]
+    )
   }
 
   func testCanImport() throws {


### PR DESCRIPTION
This covers two changes:
* Make sure we diagnostic a spurious label on build conditions that have a single unlabeled argument (oops)
* Make sure we consistently quote build condition names in diagnostics (it was a mix before)