### PR TITLE
Declare rules_swift `max_compatibility_version = 2`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,4 +6,4 @@ module(
 
 bazel_dep(name = "apple_support", version = "1.13.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_apple", version = "3.3.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.16.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_rules_swift")


### PR DESCRIPTION
Cherry-picks https://github.com/swiftlang/swift-syntax/pull/2725 so that its included in the Swift 6 releases going forward