### PR TITLE
[SwiftParser] Improve diagnostics for misspelled keywords

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -203,8 +203,14 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var missingConformanceRequirement: Self {
     .init("expected ':' or '==' to indicate a conformance or same-type requirement")
   }
+  public static var misspelledAssociatedtype: Self {
+    .init("expected 'associatedtype' keyword; did you mean 'associatedtype'?")
+  }
   public static var misspelledAsync: Self {
     .init("expected async specifier; did you mean 'async'?")
+  }
+  public static var misspelledDeinit: Self {
+    .init("expected 'deinit' keyword; did you mean 'deinit'?")
   }
   public static var misspelledThrows: Self {
     .init("expected throwing specifier; did you mean 'throws'?")
@@ -478,6 +484,15 @@ public struct MissingExpressionInStatement: ParserError {
     } else {
       return "expected expression in statement"
     }
+  }
+}
+
+public struct MisspelledKeyword: ParserError {
+  let keywordRole: String
+  let token: TokenSyntax
+
+  public var message: String {
+    "expected \(keywordRole); did you mean '\(token.text)'?"
   }
 }
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -317,6 +317,42 @@ final class DeclarationTests: ParserTestCase {
         }
         """
     )
+
+    assertParse(
+      """
+      protocol P {
+        1️⃣associatedType A
+        2️⃣associatetype B
+        3️⃣associateType C
+        associatedtype D
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected 'associatedtype' keyword; did you mean 'associatedtype'?",
+          fixIts: ["replace 'associatedType' with 'associatedtype'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected 'associatedtype' keyword; did you mean 'associatedtype'?",
+          fixIts: ["replace 'associatetype' with 'associatedtype'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "3️⃣",
+          message: "expected 'associatedtype' keyword; did you mean 'associatedtype'?",
+          fixIts: ["replace 'associateType' with 'associatedtype'"]
+        ),
+      ],
+      fixedSource: """
+        protocol P {
+          associatedtype A
+          associatedtype B
+          associatedtype C
+          associatedtype D
+        }
+        """
+    )
   }
 
   func testVariableDeclarations() {
@@ -404,6 +440,37 @@ final class DeclarationTests: ParserTestCase {
         }
       }
       """
+    )
+
+    assertParse(
+      """
+      var foo: Int {
+        1️⃣consume set {
+          test += 1
+        }
+        2️⃣borrow get {}
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected accessor modifier; did you mean 'consuming'?",
+          fixIts: ["replace 'consume' with 'consuming'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected accessor modifier; did you mean 'borrowing'?",
+          fixIts: ["replace 'borrow' with 'borrowing'"]
+        ),
+      ],
+      fixedSource: """
+        var foo: Int {
+          consuming set {
+            test += 1
+          }
+          borrowing get {}
+        }
+        """
     )
   }
 
@@ -1615,6 +1682,42 @@ final class DeclarationTests: ParserTestCase {
   func testDeinitializers() {
     assertParse("deinit {}")
     assertParse("deinit")
+    assertParse(
+      """
+      class A {
+        1️⃣deInit {}
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected 'deinit' keyword; did you mean 'deinit'?",
+          fixIts: ["replace 'deInit' with 'deinit'"]
+        )
+      ],
+      fixedSource: """
+        class A {
+          deinit {}
+        }
+        """
+    )
+    assertParse(
+      """
+      class A {
+        1️⃣deInit
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected 'deinit' keyword; did you mean 'deinit'?",
+          fixIts: ["replace 'deInit' with 'deinit'"]
+        )
+      ],
+      fixedSource: """
+        class A {
+          deinit
+        }
+        """
+    )
   }
 
   func testAttributedMember() {

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -917,6 +917,22 @@ final class StatementTests: ParserTestCase {
         } else {}
         """
     )
+
+    assertParse(
+      """
+      1️⃣gaurd test else {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected 'guard' keyword; did you mean 'guard'?",
+          fixIts: ["replace 'gaurd' with 'guard'"]
+        )
+      ],
+      fixedSource: """
+        guard test else {}
+        """
+    )
   }
 
   func testTypedThrows() {


### PR DESCRIPTION
fixes #2198 #2180

This is preliminary work on emitting better diagnostics for misspelled keywords. More discussions would be needed to ascertain the scope of misspelling corrections.