### PR TITLE
Replace self key path as function usage

### DIFF
--- a/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
@@ -178,7 +178,7 @@ final class BodyMacroTests: XCTestCase {
           } else {
             statements
           }
-        return body.map(\.self)
+        return Array(body)
       }
     }
 


### PR DESCRIPTION
Fixes #2796

I used `map(\.self)` but that's only possible since [Subtyping for keypath literals as functions](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0416-keypath-function-subtyping.md), which landed on Swift 6.0. Thanks @AppAppWorks for catching this.