### PR TITLE
[CodeGeneration] Improve ergonomics for initializers of raw syntax nodes

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
@@ -65,13 +65,11 @@ let layoutNodesParsableFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           // The missing item is not necessary to be a declaration,
           // which is just a placeholder here
           return RawCodeBlockItemSyntax(
-            item: .decl(
-              RawDeclSyntax(
-                RawMissingDeclSyntax(
-                  attributes: self.emptyCollection(RawAttributeListSyntax.self),
-                  modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
-                  arena: self.arena
-                )
+            item: .init(
+              RawMissingDeclSyntax(
+                attributes: self.emptyCollection(RawAttributeListSyntax.self),
+                modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
+                arena: self.arena
               )
             ),
             semicolon: nil,

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -156,7 +156,7 @@ extension Parser {
   mutating func parseAttributeWithoutArguments() -> RawAttributeListSyntax.Element {
     let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     let attributeName = self.parseType()
-    return .attribute(
+    return .init(
       RawAttributeSyntax(
         unexpectedBeforeAtSign,
         atSign: atSign,
@@ -215,7 +215,7 @@ extension Parser {
       }
       let argument = parseArguments(&self)
       let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
-      return .attribute(
+      return .init(
         RawAttributeSyntax(
           unexpectedBeforeAtSign,
           atSign: atSign,
@@ -229,7 +229,7 @@ extension Parser {
         )
       )
     } else {
-      return .attribute(
+      return .init(
         RawAttributeSyntax(
           unexpectedBeforeAtSign,
           atSign: atSign,
@@ -249,7 +249,7 @@ extension Parser {
         self.parsePoundIfDirective { (parser, _) -> RawAttributeListSyntax.Element in
           return parser.parseAttribute()
         } syntax: { parser, attributes in
-          return .attributes(RawAttributeListSyntax(elements: attributes, arena: parser.arena))
+          return .init(RawAttributeListSyntax(elements: attributes, arena: parser.arena))
         }
       )
     }
@@ -257,39 +257,39 @@ extension Parser {
     switch peek(isAtAnyIn: DeclarationAttributeWithSpecialSyntax.self) {
     case .available, ._spi_available:
       return parseAttribute(argumentMode: .required) { parser in
-        return .availability(parser.parseAvailabilityArgumentSpecList())
+        return .init(parser.parseAvailabilityArgumentSpecList())
       }
     case .backDeployed, ._backDeploy:
       return parseAttribute(argumentMode: .required) { parser in
-        return .backDeployedArguments(parser.parseBackDeployedAttributeArguments())
+        return .init(parser.parseBackDeployedAttributeArguments())
       }
     case .differentiable:
       return parseAttribute(argumentMode: .required) { parser in
-        return .differentiableArguments(parser.parseDifferentiableAttributeArguments())
+        return .init(parser.parseDifferentiableAttributeArguments())
       }
     case .derivative, .transpose:
       return parseAttribute(argumentMode: .required) { parser in
-        return .derivativeRegistrationArguments(parser.parseDerivativeAttributeArguments())
+        return .init(parser.parseDerivativeAttributeArguments())
       }
     case .objc:
       return parseAttribute(argumentMode: .optional) { parser in
-        return .objCName(parser.parseObjectiveCSelector())
+        return .init(parser.parseObjectiveCSelector())
       }
     case ._specialize:
       return parseAttribute(argumentMode: .required) { parser in
-        return .specializeArguments(parser.parseSpecializeAttributeArgumentList())
+        return .init(parser.parseSpecializeAttributeArgumentList())
       }
     case ._private:
       return parseAttribute(argumentMode: .required) { parser in
-        return .underscorePrivateAttributeArguments(parser.parseUnderscorePrivateAttributeArguments())
+        return .init(parser.parseUnderscorePrivateAttributeArguments())
       }
     case ._dynamicReplacement:
       return parseAttribute(argumentMode: .required) { parser in
-        return .dynamicReplacementArguments(parser.parseDynamicReplacementAttributeArguments())
+        return .init(parser.parseDynamicReplacementAttributeArguments())
       }
     case ._documentation:
       return parseAttribute(argumentMode: .required) { parser in
-        return .documentationArguments(parser.parseDocumentationAttributeArguments())
+        return .init(parser.parseDocumentationAttributeArguments())
       }
     case ._spi, ._objcRuntimeName, ._projectedValueProperty, ._swift_native_objc_runtime_base, ._typeEraser, ._optimize,
       .exclusivity, .inline, ._alignment:
@@ -300,18 +300,18 @@ extension Parser {
       //  Because there seem to be very little restrictions on these parameters (they could be keywords instead of identifiers), we just allow any token.
       return parseAttribute(argumentMode: .required) { parser in
         if !parser.at(.rightParen) {
-          return .token(parser.consumeAnyToken())
+          return .init(parser.consumeAnyToken())
         } else {
-          return .token(parser.missingToken(.identifier))
+          return .init(parser.missingToken(.identifier))
         }
       }
     case ._objcImplementation, ._nonSendable:
       // Similar to the above but the argument is optional
       return parseAttribute(argumentMode: .optional) { parser in
         if !parser.at(.rightParen) {
-          return .token(parser.consumeAnyToken())
+          return .init(parser.consumeAnyToken())
         } else {
-          return .token(parser.missingToken(.identifier))
+          return .init(parser.missingToken(.identifier))
         }
       }
     case ._effects:
@@ -322,48 +322,46 @@ extension Parser {
         while !parser.at(.rightParen, .endOfFile) {
           tokens.append(parser.consumeAnyToken())
         }
-        return .effectsArguments(RawEffectsAttributeArgumentListSyntax(elements: tokens, arena: parser.arena))
+        return .init(RawEffectsAttributeArgumentListSyntax(elements: tokens, arena: parser.arena))
       }
     case ._cdecl:
       return parseAttribute(argumentMode: .required) { parser in
-        return .string(parser.parseStringLiteral())
+        return .init(parser.parseStringLiteral())
       }
     case ._implements:
       return parseAttribute(argumentMode: .required) { parser in
-        return .implementsArguments(parser.parseImplementsAttributeArguments())
+        return .init(parser.parseImplementsAttributeArguments())
       }
     case ._semantics:
       return parseAttribute(argumentMode: .required) { parser in
-        return .string(parser.parseStringLiteral())
+        return .init(parser.parseStringLiteral())
       }
     case ._expose:
       return parseAttribute(argumentMode: .required) { parser in
-        return .exposeAttributeArguments(parser.parseExposeArguments())
+        return .init(parser.parseExposeArguments())
       }
     case ._originallyDefinedIn:
       return parseAttribute(argumentMode: .required) { parser in
-        return .originallyDefinedInArguments(parser.parseOriginallyDefinedInAttributeArguments())
+        return .init(parser.parseOriginallyDefinedInAttributeArguments())
       }
     case ._unavailableFromAsync:
       return parseAttribute(argumentMode: .optional) { parser in
-        return .unavailableFromAsyncArguments(parser.parseUnavailableFromAsyncAttributeArguments())
+        return .init(parser.parseUnavailableFromAsyncAttributeArguments())
       }
     case .attached, .freestanding:
       return parseAttribute(argumentMode: .customAttribute) { parser in
         let arguments = parser.parseMacroRoleArguments()
-        return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
+        return .init(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }
     case .rethrows:
       let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
       let (unexpectedBeforeAttributeName, attributeName) = self.expect(TokenSpec(.rethrows, remapping: .identifier))
-      return .attribute(
+      return .init(
         RawAttributeSyntax(
           unexpectedBeforeAtSign,
           atSign: atSign,
           unexpectedBeforeAttributeName,
-          attributeName: RawTypeSyntax(
-            RawIdentifierTypeSyntax(name: attributeName, genericArgumentClause: nil, arena: self.arena)
-          ),
+          attributeName: RawIdentifierTypeSyntax(name: attributeName, genericArgumentClause: nil, arena: self.arena),
           leftParen: nil,
           arguments: nil,
           rightParen: nil,
@@ -377,7 +375,7 @@ extension Parser {
     case nil:
       return parseAttribute(argumentMode: .customAttribute) { parser in
         let arguments = parser.parseArgumentListElements(pattern: .none, allowTrailingComma: false)
-        return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
+        return .init(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }
     }
   }
@@ -394,13 +392,11 @@ extension RawLabeledExprSyntax {
     self.init(
       label: nil,
       colon: nil,
-      expression: RawExprSyntax(
-        RawDeclReferenceExprSyntax(
-          unexpectedBeforeIdentifier,
-          baseName: identifier,
-          argumentNames: nil,
-          arena: arena
-        )
+      expression: RawDeclReferenceExprSyntax(
+        unexpectedBeforeIdentifier,
+        baseName: identifier,
+        argumentNames: nil,
+        arena: arena
       ),
       unexpectedBetweenIdentifierAndTrailingComma,
       trailingComma: trailingComma,
@@ -448,9 +444,7 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSign: atSign,
       unexpectedBeforeDifferentiable,
-      attributeName: RawTypeSyntax(
-        RawIdentifierTypeSyntax(name: differentiable, genericArgumentClause: nil, arena: self.arena)
-      ),
+      attributeName: RawIdentifierTypeSyntax(name: differentiable, genericArgumentClause: nil, arena: self.arena),
       unexpectedBeforeLeftParen,
       leftParen: leftParen,
       arguments: .differentiableArguments(argument),
@@ -592,9 +586,7 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSign: atSign,
       unexpectedBeforeDerivative,
-      attributeName: RawTypeSyntax(
-        RawIdentifierTypeSyntax(name: derivative, genericArgumentClause: nil, arena: self.arena)
-      ),
+      attributeName: RawIdentifierTypeSyntax(name: derivative, genericArgumentClause: nil, arena: self.arena),
       unexpectedBeforeLeftParen,
       leftParen: leftParen,
       arguments: .derivativeRegistrationArguments(argument),
@@ -616,9 +608,7 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSign: atSign,
       unexpectedBeforeTranspose,
-      attributeName: RawTypeSyntax(
-        RawIdentifierTypeSyntax(name: transpose, genericArgumentClause: nil, arena: self.arena)
-      ),
+      attributeName: RawIdentifierTypeSyntax(name: transpose, genericArgumentClause: nil, arena: self.arena),
       unexpectedBeforeLeftParen,
       leftParen: leftParen,
       arguments: .derivativeRegistrationArguments(argument),
@@ -723,7 +713,7 @@ extension Parser {
         let declName = self.parseDeclReferenceExpr([.zeroArgCompoundNames, .keywordsUsingSpecialNames, .operators])
         let comma = self.consume(if: .comma)
         elements.append(
-          .specializeTargetFunctionArgument(
+          .init(
             RawSpecializeTargetFunctionArgumentSyntax(
               targetLabel: label,
               unexpectedBeforeColon,
@@ -740,7 +730,7 @@ extension Parser {
         let availability = self.parseAvailabilitySpecList()
         let (unexpectedBeforeSemi, semi) = self.expect(.semicolon)
         elements.append(
-          .specializeAvailabilityArgument(
+          .init(
             RawSpecializeAvailabilityArgumentSyntax(
               availabilityLabel: label,
               unexpectedBeforeColon,
@@ -758,7 +748,7 @@ extension Parser {
         let (unexpectedBeforeValue, value) = self.expect(.keyword(.true), .keyword(.false), default: .keyword(.false))
         let comma = self.consume(if: .comma)
         elements.append(
-          .labeledSpecializeArgument(
+          .init(
             RawLabeledSpecializeArgumentSyntax(
               label: label,
               unexpectedBeforeColon,
@@ -776,7 +766,7 @@ extension Parser {
         let valueLabel = self.parseAnyIdentifier()
         let comma = self.consume(if: .comma)
         elements.append(
-          .labeledSpecializeArgument(
+          .init(
             RawLabeledSpecializeArgumentSyntax(
               label: label,
               unexpectedBeforeColon,
@@ -794,7 +784,7 @@ extension Parser {
         let valueLabel = self.consumeAnyToken()
         let comma = self.consume(if: .comma)
         elements.append(
-          .labeledSpecializeArgument(
+          .init(
             RawLabeledSpecializeArgumentSyntax(
               label: label,
               unexpectedBeforeColon,
@@ -813,7 +803,7 @@ extension Parser {
     // Parse the where clause.
     if self.at(.keyword(.where)) {
       let whereClause = self.parseGenericWhereClause()
-      elements.append(.genericWhereClause(whereClause))
+      elements.append(.init(whereClause))
     }
     return RawSpecializeAttributeArgumentListSyntax(elements: elements, arena: self.arena)
   }
@@ -858,7 +848,7 @@ extension Parser {
     if let witnessMethod = self.consume(if: .keyword(.witness_method)) {
       let (unexpectedBeforeColon, colon) = self.expect(.colon)
       let name = self.parseAnyIdentifier()
-      return .conventionWitnessMethodArguments(
+      return .init(
         RawConventionWitnessMethodAttributeArgumentsSyntax(
           witnessMethodLabel: witnessMethod,
           unexpectedBeforeColon,
@@ -890,7 +880,7 @@ extension Parser {
         colon = nil
         cTypeString = nil
       }
-      return .conventionArguments(
+      return .init(
         RawConventionAttributeArgumentsSyntax(
           unexpectedBeforeLabel,
           conventionLabel: label,
@@ -1132,17 +1122,17 @@ extension Parser {
 
         let (unexpected, token) = self.expect(anyIn: AccessLevelModifier.self, default: .internal)
         unexpectedBeforeValue = unexpected
-        value = .token(token)
+        value = .init(token)
       case "metadata":
         unexpectedBeforeValue = nil
         if let identifier = self.consume(if: .identifier) {
-          value = .token(identifier)
+          value = .init(identifier)
         } else {
-          value = .string(self.parseStringLiteral())
+          value = .init(self.parseStringLiteral())
         }
       default:
         unexpectedBeforeValue = nil
-        value = .token(missingToken(.identifier))
+        value = .init(missingToken(.identifier))
       }
       keepGoing = self.consume(if: .comma)
       arguments.append(

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -26,7 +26,7 @@ extension Parser {
       repeat {
         let argument: RawAvailabilityArgumentSyntax.Argument
         if self.at(.identifier) {
-          argument = .availabilityVersionRestriction(self.parsePlatformVersion())
+          argument = .init(self.parsePlatformVersion())
         } else {
           argument = self.parseAvailabilitySpec()
         }
@@ -108,7 +108,7 @@ extension Parser {
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         let stringValue = self.parseSimpleString()
 
-        entry = .availabilityLabeledArgument(
+        entry = .init(
           RawAvailabilityLabeledArgumentSyntax(
             label: argumentLabel,
             unexpectedBeforeColon,
@@ -122,7 +122,7 @@ extension Parser {
         let argumentLabel = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         let version = self.parseVersionTuple()
-        entry = .availabilityLabeledArgument(
+        entry = .init(
           RawAvailabilityLabeledArgumentSyntax(
             label: argumentLabel,
             unexpectedBeforeColon,
@@ -135,7 +135,7 @@ extension Parser {
         let argumentLabel = self.eat(handle)
         if let colon = self.consume(if: .colon) {
           let version = self.parseVersionTuple()
-          entry = .availabilityLabeledArgument(
+          entry = .init(
             RawAvailabilityLabeledArgumentSyntax(
               label: argumentLabel,
               colon: colon,
@@ -144,19 +144,19 @@ extension Parser {
             )
           )
         } else {
-          entry = .token(argumentLabel)
+          entry = .init(argumentLabel)
         }
       case (.unavailable, let handle)?,
         (.noasync, let handle)?:
         let argument = self.eat(handle)
-        entry = .token(argument)
+        entry = .init(argument)
       case (.star, _)?:
         entry = self.parseAvailabilitySpec()
       case (.identifier, let handle)?:
         if self.peek(isAt: .comma) {
           // An argument like `_iOS13Aligned` that isn't followed by a version.
           let version = self.eat(handle)
-          entry = .token(version)
+          entry = .init(version)
         } else {
           entry = self.parseAvailabilitySpec()
         }
@@ -179,10 +179,10 @@ extension Parser {
   /// Parse an availability argument.
   mutating func parseAvailabilitySpec() -> RawAvailabilityArgumentSyntax.Argument {
     if let star = self.consumeIfContextualPunctuator("*") {
-      return .token(star)
+      return .init(star)
     }
 
-    return .availabilityVersionRestriction(self.parsePlatformVersion())
+    return .init(self.parsePlatformVersion())
   }
 
   /// Parse an availability macro.

--- a/Sources/SwiftParser/CollectionNodes+Parsable.swift
+++ b/Sources/SwiftParser/CollectionNodes+Parsable.swift
@@ -81,11 +81,11 @@ extension AccessorDeclListSyntax: SyntaxParseable {
 extension AttributeListSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
     return parse(from: &parser) { parser in
-      return RawSyntax(parser.parseAttributeList())
+      return parser.parseAttributeList()
     } makeMissing: { remainingTokens, arena in
       return RawAttributeSyntax(
         atSign: RawTokenSyntax(missing: .atSign, arena: arena),
-        attributeName: RawTypeSyntax(RawMissingTypeSyntax(arena: arena)),
+        attributeName: RawMissingTypeSyntax(arena: arena),
         leftParen: nil,
         arguments: nil,
         rightParen: nil,
@@ -99,10 +99,13 @@ extension CodeBlockItemListSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
     return parse(from: &parser) { parser in
       let node = parser.parseCodeBlockItemList(until: { _ in false })
-      return RawSyntax(node)
+      return node
     } makeMissing: { remainingTokens, arena in
-      let missingExpr = RawMissingExprSyntax(arena: arena)
-      return RawCodeBlockItemSyntax(item: .expr(RawExprSyntax(missingExpr)), semicolon: nil, arena: arena)
+      RawCodeBlockItemSyntax(
+        item: .init(RawMissingExprSyntax(arena: arena)),
+        semicolon: nil,
+        arena: arena
+      )
     }
   }
 }
@@ -110,7 +113,7 @@ extension CodeBlockItemListSyntax: SyntaxParseable {
 extension MemberBlockItemListSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
     return parse(from: &parser) { parser in
-      return RawSyntax(parser.parseMemberDeclList())
+      return parser.parseMemberDeclList()
     } makeMissing: { remainingTokens, arena in
       let missingDecl = RawMissingDeclSyntax(
         attributes: RawAttributeListSyntax(elements: [], arena: arena),
@@ -119,7 +122,7 @@ extension MemberBlockItemListSyntax: SyntaxParseable {
         RawUnexpectedNodesSyntax(remainingTokens, arena: arena),
         arena: arena
       )
-      return RawMemberBlockItemSyntax(decl: RawDeclSyntax(missingDecl), semicolon: nil, arena: arena)
+      return RawMemberBlockItemSyntax(decl: missingDecl, semicolon: nil, arena: arena)
     }
   }
 }

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -532,11 +532,11 @@ extension Parser {
           keepGoing = self.consume(if: .comma)
           elements.append(
             RawGenericRequirementSyntax(
-              requirement: .sameTypeRequirement(
+              requirement: .init(
                 RawSameTypeRequirementSyntax(
-                  leftType: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+                  leftType: RawMissingTypeSyntax(arena: self.arena),
                   equal: missingToken(.binaryOperator, text: "=="),
-                  rightType: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+                  rightType: RawMissingTypeSyntax(arena: self.arena),
                   arena: self.arena
                 )
               ),
@@ -629,7 +629,7 @@ extension Parser {
               rightParen = nil
             }
 
-            requirement = .layoutRequirement(
+            requirement = .init(
               RawLayoutRequirementSyntax(
                 type: firstType,
                 colon: colon,
@@ -647,7 +647,7 @@ extension Parser {
           } else {
             // Parse the protocol or composition.
             let secondType = self.parseType()
-            requirement = .conformanceRequirement(
+            requirement = .init(
               RawConformanceRequirementSyntax(
                 leftType: firstType,
                 colon: colon,
@@ -661,7 +661,7 @@ extension Parser {
           (.prefixOperator, let handle)?:
           let equal = self.eat(handle)
           let secondType = self.parseType()
-          requirement = .sameTypeRequirement(
+          requirement = .init(
             RawSameTypeRequirementSyntax(
               leftType: firstType,
               equal: equal,
@@ -670,11 +670,11 @@ extension Parser {
             )
           )
         case nil:
-          requirement = .sameTypeRequirement(
+          requirement = .init(
             RawSameTypeRequirementSyntax(
               leftType: firstType,
               equal: RawTokenSyntax(missing: .binaryOperator, text: "==", arena: self.arena),
-              rightType: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+              rightType: RawMissingTypeSyntax(arena: self.arena),
               arena: self.arena
             )
           )
@@ -722,12 +722,10 @@ extension Parser {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       let item = RawMemberBlockItemSyntax(
         remainingTokens,
-        decl: RawDeclSyntax(
-          RawMissingDeclSyntax(
-            attributes: self.emptyCollection(RawAttributeListSyntax.self),
-            modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
-            arena: self.arena
-          )
+        decl: RawMissingDeclSyntax(
+          attributes: self.emptyCollection(RawAttributeListSyntax.self),
+          modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
+          arena: self.arena
         ),
         semicolon: nil,
         arena: self.arena
@@ -1558,7 +1556,7 @@ extension Parser {
     let unexpectedBeforeEqual: RawUnexpectedNodesSyntax?
     let equal: RawTokenSyntax
     if let colon = self.consume(if: .colon) {
-      unexpectedBeforeEqual = RawUnexpectedNodesSyntax(elements: [RawSyntax(colon)], arena: self.arena)
+      unexpectedBeforeEqual = RawUnexpectedNodesSyntax([colon], arena: self.arena)
       equal = missingToken(.equal)
     } else {
       (unexpectedBeforeEqual, equal) = self.expect(.equal)
@@ -1844,7 +1842,7 @@ extension Parser {
             )
           }
           elements.append(
-            .precedenceGroupAssociativity(
+            .init(
               RawPrecedenceGroupAssociativitySyntax(
                 associativityLabel: associativity,
                 unexpectedBeforeColon,
@@ -1871,7 +1869,7 @@ extension Parser {
             unexpectedAfterFlag = nil
           }
           elements.append(
-            .precedenceGroupAssignment(
+            .init(
               RawPrecedenceGroupAssignmentSyntax(
                 assignmentLabel: assignmentKeyword,
                 unexpectedBeforeColon,
@@ -1906,7 +1904,7 @@ extension Parser {
             } while keepGoing != nil && self.hasProgressed(&namesProgress)
           }
           elements.append(
-            .precedenceGroupRelation(
+            .init(
               RawPrecedenceGroupRelationSyntax(
                 higherThanOrLowerThanLabel: level,
                 unexpectedBeforeColon,

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -75,7 +75,7 @@ extension Parser {
 
     // Parse #if
     let (unexpectedBeforePoundIf, poundIf) = self.expect(.poundIf)
-    let condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+    let condition = self.parseSequenceExpression(flavor: .poundIfDirective)
     let unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
 
     clauses.append(
@@ -102,7 +102,7 @@ extension Parser {
       switch match {
       case .poundElseif:
         (unexpectedBeforePound, pound) = self.eat(handle)
-        condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+        condition = self.parseSequenceExpression(flavor: .poundIfDirective)
         unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
       case .poundElse:
         (unexpectedBeforePound, pound) = self.eat(handle)
@@ -114,7 +114,7 @@ extension Parser {
             arena: self.arena
           )
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+          condition = self.parseSequenceExpression(flavor: .poundIfDirective)
         } else {
           condition = nil
         }
@@ -132,7 +132,7 @@ extension Parser {
             arena: self.arena
           )
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+          condition = self.parseSequenceExpression(flavor: .poundIfDirective)
           unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
         } else {
           break LOOP

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -33,7 +33,7 @@ extension Parser {
     }
     if let dollarIdent = self.consume(if: .dollarIdentifier) {
       return (
-        RawUnexpectedNodesSyntax(elements: [RawSyntax(dollarIdent)], arena: self.arena),
+        RawUnexpectedNodesSyntax([dollarIdent], arena: self.arena),
         self.missingToken(.identifier)
       )
     } else {

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -323,7 +323,7 @@ extension Parser {
     // If it is a Python style inheritance clause, then consume a right paren if there is one.
     if isPythonStyleInheritanceClause, let rightParen = self.consume(if: .rightParen) {
       unexpectedAfterInheritedTypeCollection = RawUnexpectedNodesSyntax(
-        elements: [RawSyntax(rightParen)],
+        [rightParen],
         arena: self.arena
       )
     } else {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -513,11 +513,11 @@ extension Parser {
   mutating func eat(_ handle: RecoveryConsumptionHandle) -> (RawUnexpectedNodesSyntax?, Token) {
     let unexpectedNodes: RawUnexpectedNodesSyntax?
     if handle.unexpectedTokens > 0 {
-      var unexpectedTokens = [RawSyntax]()
+      var unexpectedTokens = [RawTokenSyntax]()
       for _ in 0..<handle.unexpectedTokens {
-        unexpectedTokens.append(RawSyntax(self.consumeAnyTokenWithoutAdjustingNestingLevel()))
+        unexpectedTokens.append(self.consumeAnyTokenWithoutAdjustingNestingLevel())
       }
-      unexpectedNodes = RawUnexpectedNodesSyntax(elements: unexpectedTokens, arena: self.arena)
+      unexpectedNodes = RawUnexpectedNodesSyntax(unexpectedTokens, arena: self.arena)
     } else {
       unexpectedNodes = nil
     }
@@ -694,13 +694,13 @@ extension Parser {
     }
     if let unknown = self.consume(if: .unknown) {
       return (
-        RawUnexpectedNodesSyntax(elements: [RawSyntax(unknown)], arena: self.arena),
+        RawUnexpectedNodesSyntax([unknown], arena: self.arena),
         self.missingToken(.identifier)
       )
     }
     if let number = self.consume(if: .integerLiteral, .floatLiteral, .dollarIdentifier) {
       return (
-        RawUnexpectedNodesSyntax(elements: [RawSyntax(number)], arena: self.arena),
+        RawUnexpectedNodesSyntax([number], arena: self.arena),
         self.missingToken(.identifier)
       )
     } else if keywordRecovery,
@@ -709,7 +709,7 @@ extension Parser {
     {
       let keyword = self.consumeAnyToken()
       return (
-        RawUnexpectedNodesSyntax(elements: [RawSyntax(keyword)], arena: self.arena),
+        RawUnexpectedNodesSyntax([keyword], arena: self.arena),
         self.missingToken(.identifier)
       )
     }
@@ -880,7 +880,7 @@ extension Parser {
     // Invalid, extraneous whitespace. Have callers synthesize a missing
     // member if there's a newline after the period.
     return (
-      RawUnexpectedNodesSyntax(elements: [period.raw], arena: arena),
+      RawUnexpectedNodesSyntax([period], arena: arena),
       RawTokenSyntax(missing: .period, arena: arena),
       afterContainsAnyNewline
     )

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -94,7 +94,7 @@ extension Parser {
       )
     case (.lhs(.dollarIdentifier), let handle)?:
       let dollarIdent = self.eat(handle)
-      let unexpectedBeforeIdentifier = RawUnexpectedNodesSyntax(elements: [RawSyntax(dollarIdent)], arena: self.arena)
+      let unexpectedBeforeIdentifier = RawUnexpectedNodesSyntax([dollarIdent], arena: self.arena)
       return RawPatternSyntax(
         RawIdentifierPatternSyntax(
           unexpectedBeforeIdentifier,
@@ -164,7 +164,7 @@ extension Parser {
             remainingTokens,
             label: nil,
             colon: nil,
-            pattern: RawPatternSyntax(RawMissingPatternSyntax(arena: self.arena)),
+            pattern: RawMissingPatternSyntax(arena: self.arena),
             trailingComma: nil,
             arena: self.arena
           )
@@ -257,8 +257,7 @@ extension Parser {
       // binding patterns much earlier.
       return RawPatternSyntax(pat.pattern)
     }
-    let expr = RawExprSyntax(patternSyntax)
-    return RawPatternSyntax(RawExpressionPatternSyntax(expression: expr, arena: self.arena))
+    return RawPatternSyntax(RawExpressionPatternSyntax(expression: patternSyntax, arena: self.arena))
   }
 }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -58,7 +58,7 @@ extension Parser {
   mutating func parseStatement() -> RawStmtSyntax {
     // If this is a label on a loop/switch statement, consume it and pass it into
     // parsing logic below.
-    func label<S: RawStmtSyntaxNodeProtocol>(_ stmt: S, with label: Parser.StatementLabel?) -> RawStmtSyntax {
+    func label(_ stmt: some RawStmtSyntaxNodeProtocol, with label: Parser.StatementLabel?) -> RawStmtSyntax {
       guard let label = label else {
         return RawStmtSyntax(stmt)
       }
@@ -66,7 +66,7 @@ extension Parser {
         RawLabeledStmtSyntax(
           label: label.label,
           colon: label.colon,
-          statement: RawStmtSyntax(stmt),
+          statement: stmt,
           arena: self.arena
         )
       )
@@ -87,7 +87,7 @@ extension Parser {
       if self.experimentalFeatures.contains(.doExpressions) {
         let doExpr = self.parseDoExpression(doHandle: handle)
         let doStmt = RawExpressionStmtSyntax(
-          expression: RawExprSyntax(doExpr),
+          expression: doExpr,
           arena: self.arena
         )
         return label(doStmt, with: optLabel)
@@ -97,7 +97,7 @@ extension Parser {
     case (.if, let handle)?:
       let ifExpr = self.parseIfExpression(ifHandle: handle)
       let ifStmt = RawExpressionStmtSyntax(
-        expression: RawExprSyntax(ifExpr),
+        expression: ifExpr,
         arena: self.arena
       )
       return label(ifStmt, with: optLabel)
@@ -106,7 +106,7 @@ extension Parser {
     case (.switch, let handle)?:
       let switchExpr = self.parseSwitchExpression(switchHandle: handle)
       let switchStmt = RawExpressionStmtSyntax(
-        expression: RawExprSyntax(switchExpr),
+        expression: switchExpr,
         arena: self.arena
       )
       return label(switchStmt, with: optLabel)
@@ -129,8 +129,7 @@ extension Parser {
     case (.then, let handle)? where experimentalFeatures.contains(.thenStatements):
       return label(self.parseThenStatement(handle: handle), with: optLabel)
     case nil, (.then, _)?:
-      let missingStmt = RawStmtSyntax(RawMissingStmtSyntax(arena: self.arena))
-      return label(missingStmt, with: optLabel)
+      return label(RawMissingStmtSyntax(arena: self.arena), with: optLabel)
     }
   }
 }
@@ -295,7 +294,7 @@ extension Parser {
 
     switch kind {
     case let .optional(unexpectedBeforeBindingKeyword, bindingSpecifier, pattern):
-      return .optionalBinding(
+      return .init(
         RawOptionalBindingConditionSyntax(
           unexpectedBeforeBindingKeyword,
           bindingSpecifier: bindingSpecifier,
@@ -306,7 +305,7 @@ extension Parser {
         )
       )
     case let .pattern(caseKeyword, pattern):
-      return .matchingPattern(
+      return .init(
         RawMatchingPatternConditionSyntax(
           caseKeyword: caseKeyword,
           pattern: pattern,
@@ -314,7 +313,7 @@ extension Parser {
           initializer: initializer
             ?? RawInitializerClauseSyntax(
               equal: RawTokenSyntax(missing: .equal, arena: self.arena),
-              value: RawExprSyntax(RawMissingExprSyntax(arena: self.arena)),
+              value: RawMissingExprSyntax(arena: self.arena),
               arena: self.arena
             ),
           arena: self.arena
@@ -339,7 +338,7 @@ extension Parser {
     } else {
       unexpectedAfterRParen = nil
     }
-    return .availability(
+    return .init(
       RawAvailabilityConditionSyntax(
         availabilityKeyword: keyword,
         unexpectedBeforeLParen,
@@ -520,7 +519,7 @@ extension Parser {
       conditions = RawConditionElementListSyntax(
         elements: [
           RawConditionElementSyntax(
-            condition: .expression(RawExprSyntax(RawMissingExprSyntax(arena: self.arena))),
+            condition: .init(RawMissingExprSyntax(arena: self.arena)),
             trailingComma: nil,
             arena: self.arena
           )
@@ -761,7 +760,7 @@ extension Parser {
         exprList = RawYieldedExpressionListSyntax(elements: elementList, arena: self.arena)
       }
       let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
-      yieldedExpressions = .multiple(
+      yieldedExpressions = .init(
         RawYieldedExpressionsClauseSyntax(
           leftParen: lparen,
           elements: exprList,
@@ -771,7 +770,7 @@ extension Parser {
         )
       )
     } else {
-      yieldedExpressions = .single(self.parseExpression(flavor: .basic, pattern: .none))
+      yieldedExpressions = .init(self.parseExpression(flavor: .basic, pattern: .none))
     }
 
     return RawYieldStmtSyntax(

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -198,7 +198,7 @@ extension Parser {
           trailingTriviaPieces: lastMiddleSegment.content.trailingTriviaPieces.filter({ $0.isNewline }),
           arena: self.arena
         )
-        middleSegments[middleSegments.count - 1] = .stringSegment(
+        middleSegments[middleSegments.count - 1] = .init(
           RawStringSegmentSyntax(
             RawUnexpectedNodesSyntax(
               combining: lastMiddleSegment.unexpectedBeforeContent,
@@ -216,7 +216,7 @@ extension Parser {
         // Mark it as trivia.
         let content = self.reclassifyTrivia(in: lastMiddleSegment.content, trailing: newlineSuffix)
 
-        middleSegments[middleSegments.count - 1] = .stringSegment(
+        middleSegments[middleSegments.count - 1] = .init(
           RawStringSegmentSyntax(
             lastMiddleSegment.unexpectedBeforeContent,
             content: content,
@@ -543,7 +543,7 @@ extension Parser {
       guard currentToken.leadingTriviaText.isEmpty else { break }
 
       if let stringSegment = self.consume(if: .stringSegment, TokenSpec(.identifier, remapping: .stringSegment)) {
-        segments.append(.stringSegment(RawStringSegmentSyntax(content: stringSegment, arena: self.arena)))
+        segments.append(.init(RawStringSegmentSyntax(content: stringSegment, arena: self.arena)))
       } else if let backslash = self.consume(if: .backslash) {
         let (unexpectedBeforeDelimiter, delimiter) = self.parsePoundDelimiter(
           .rawStringPoundDelimiter,
@@ -587,7 +587,7 @@ extension Parser {
           self.lexemes.perform(stateTransition: .pop, currentToken: &self.currentToken)
         }
         segments.append(
-          .expressionSegment(
+          .init(
             RawExpressionSegmentSyntax(
               backslash: backslash,
               unexpectedBeforeDelimiter,

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -137,7 +137,7 @@ extension Parser {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawCodeBlockItemSyntax(
         remainingTokens,
-        item: .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena))),
+        item: .init(RawMissingExprSyntax(arena: self.arena)),
         semicolon: nil,
         arena: self.arena
       )
@@ -147,8 +147,8 @@ extension Parser {
       // Parse them and put them in their own CodeBlockItem but as an unexpected node.
       let switchCase = self.parseSwitchCase()
       return RawCodeBlockItemSyntax(
-        RawUnexpectedNodesSyntax(elements: [RawSyntax(switchCase)], arena: self.arena),
-        item: .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena))),
+        RawUnexpectedNodesSyntax([switchCase], arena: self.arena),
+        item: .init(RawMissingExprSyntax(arena: self.arena)),
         semicolon: nil,
         arena: self.arena
       )
@@ -237,21 +237,21 @@ extension Parser {
       } syntax: { parser, items in
         return .statements(RawCodeBlockItemListSyntax(elements: items, arena: parser.arena))
       }
-      return .decl(RawDeclSyntax(directive))
+      return .init(directive)
     } else if self.at(.poundSourceLocation) {
-      return .decl(RawDeclSyntax(self.parsePoundSourceLocationDirective()))
+      return .init(self.parsePoundSourceLocationDirective())
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl) {
-      return .decl(self.parseDeclaration())
+      return .init(self.parseDeclaration())
     } else if self.atStartOfStatement(preferExpr: false) {
       return self.parseStatementItem()
     } else if self.atStartOfExpression() {
-      return .expr(self.parseExpression(flavor: .basic, pattern: .none))
+      return .init(self.parseExpression(flavor: .basic, pattern: .none))
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl, allowRecovery: true) {
-      return .decl(self.parseDeclaration())
+      return .init(self.parseDeclaration())
     } else if self.atStartOfStatement(allowRecovery: true, preferExpr: false) {
       return self.parseStatementItem()
     } else {
-      return .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena)))
+      return .init(RawMissingExprSyntax(arena: self.arena))
     }
   }
 }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -520,7 +520,7 @@ extension Parser {
               secondName: nil,
               RawUnexpectedNodesSyntax(combining: misplacedSpecifiers, unexpectedBeforeColon, arena: self.arena),
               colon: nil,
-              type: RawTypeSyntax(RawIdentifierTypeSyntax(name: first, genericArgumentClause: nil, arena: self.arena)),
+              type: RawIdentifierTypeSyntax(name: first, genericArgumentClause: nil, arena: self.arena),
               ellipsis: nil,
               trailingComma: self.missingToken(.comma),
               arena: self.arena
@@ -575,7 +575,7 @@ extension Parser {
         RawArrayTypeSyntax(
           remaingingTokens,
           leftSquare: missingToken(.leftSquare),
-          element: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+          element: RawMissingTypeSyntax(arena: self.arena),
           rightSquare: missingToken(.rightSquare),
           arena: self.arena
         )
@@ -936,8 +936,7 @@ extension Parser {
     specifierHandle: TokenConsumptionHandle
   ) -> RawTypeSpecifierListSyntax.Element {
     let specifier = self.eat(specifierHandle)
-    let simpleSpecifier = RawSimpleTypeSpecifierSyntax(specifier: specifier, arena: arena)
-    return .simpleTypeSpecifier(simpleSpecifier)
+    return .init(RawSimpleTypeSpecifierSyntax(specifier: specifier, arena: arena))
   }
 
   mutating func parseTypeAttributeList(
@@ -961,7 +960,7 @@ extension Parser {
       }
     }
     specifiers += misplacedSpecifiers.map {
-      .simpleTypeSpecifier(
+      .init(
         RawSimpleTypeSpecifierSyntax(
           specifier: missingToken($0.tokenKind, text: $0.tokenText),
           arena: arena
@@ -1009,7 +1008,7 @@ extension Parser {
       // Known type attribute that doesn't take any arguments
       return parseAttributeWithoutArguments()
     case .differentiable:
-      return .attribute(self.parseDifferentiableAttribute())
+      return .init(self.parseDifferentiableAttribute())
 
     case .convention:
       return parseAttribute(argumentMode: .required) { parser in
@@ -1017,16 +1016,16 @@ extension Parser {
       }
     case ._opaqueReturnTypeOf:
       return parseAttribute(argumentMode: .required) { parser in
-        return .opaqueReturnTypeOfAttributeArguments(parser.parseOpaqueReturnTypeOfAttributeArguments())
+        return .init(parser.parseOpaqueReturnTypeOfAttributeArguments())
       }
     case .isolated:
       return parseAttribute(argumentMode: .required) { parser in
-        return .argumentList(parser.parseIsolatedAttributeArguments())
+        return .init(parser.parseIsolatedAttributeArguments())
       }
     case nil:  // Custom attribute
       return parseAttribute(argumentMode: .customAttribute) { parser in
         let arguments = parser.parseArgumentListElements(pattern: .none, allowTrailingComma: false)
-        return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
+        return .init(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }
 
     }

--- a/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
+++ b/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
@@ -370,13 +370,11 @@ fileprivate extension Parser {
       // The missing item is not necessary to be a declaration,
       // which is just a placeholder here
       return RawCodeBlockItemSyntax(
-        item: .decl(
-          RawDeclSyntax(
-            RawMissingDeclSyntax(
-              attributes: self.emptyCollection(RawAttributeListSyntax.self),
-              modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
-              arena: self.arena
-            )
+        item: .init(
+          RawMissingDeclSyntax(
+            attributes: self.emptyCollection(RawAttributeListSyntax.self),
+            modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
+            arena: self.arena
           )
         ),
         semicolon: nil,

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
@@ -42,6 +42,14 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawAccessorDeclListSyntax) {
+      self = .accessors(other)
+    }
+    
+    public init(_ other: RawCodeBlockItemListSyntax) {
+      self = .getter(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -667,7 +675,7 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -821,7 +829,7 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBeforeLeftSquare: RawUnexpectedNodesSyntax? = nil, 
       leftSquare: RawTokenSyntax, 
       _ unexpectedBetweenLeftSquareAndElement: RawUnexpectedNodesSyntax? = nil, 
-      element: RawTypeSyntax, 
+      element: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenElementAndRightSquare: RawUnexpectedNodesSyntax? = nil, 
       rightSquare: RawTokenSyntax, 
       _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil, 
@@ -971,13 +979,13 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndAsKeyword: RawUnexpectedNodesSyntax? = nil, 
       asKeyword: RawTokenSyntax, 
       _ unexpectedBetweenAsKeywordAndQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil, 
       questionOrExclamationMark: RawTokenSyntax?, 
       _ unexpectedBetweenQuestionOrExclamationMarkAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1252,6 +1260,14 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawAttributeSyntax) {
+      self = .attribute(other)
+    }
+    
+    public init(_ other: RawIfConfigDeclSyntax) {
+      self = .ifConfigDecl(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -1458,6 +1474,86 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawLabeledExprListSyntax) {
+      self = .argumentList(other)
+    }
+    
+    public init(_ other: RawTokenSyntax) {
+      self = .token(other)
+    }
+    
+    public init(_ other: RawStringLiteralExprSyntax) {
+      self = .string(other)
+    }
+    
+    public init(_ other: RawAvailabilityArgumentListSyntax) {
+      self = .availability(other)
+    }
+    
+    public init(_ other: RawSpecializeAttributeArgumentListSyntax) {
+      self = .specializeArguments(other)
+    }
+    
+    public init(_ other: RawObjCSelectorPieceListSyntax) {
+      self = .objCName(other)
+    }
+    
+    public init(_ other: RawImplementsAttributeArgumentsSyntax) {
+      self = .implementsArguments(other)
+    }
+    
+    public init(_ other: RawDifferentiableAttributeArgumentsSyntax) {
+      self = .differentiableArguments(other)
+    }
+    
+    public init(_ other: RawDerivativeAttributeArgumentsSyntax) {
+      self = .derivativeRegistrationArguments(other)
+    }
+    
+    public init(_ other: RawBackDeployedAttributeArgumentsSyntax) {
+      self = .backDeployedArguments(other)
+    }
+    
+    public init(_ other: RawConventionAttributeArgumentsSyntax) {
+      self = .conventionArguments(other)
+    }
+    
+    public init(_ other: RawConventionWitnessMethodAttributeArgumentsSyntax) {
+      self = .conventionWitnessMethodArguments(other)
+    }
+    
+    public init(_ other: RawOpaqueReturnTypeOfAttributeArgumentsSyntax) {
+      self = .opaqueReturnTypeOfAttributeArguments(other)
+    }
+    
+    public init(_ other: RawExposeAttributeArgumentsSyntax) {
+      self = .exposeAttributeArguments(other)
+    }
+    
+    public init(_ other: RawOriginallyDefinedInAttributeArgumentsSyntax) {
+      self = .originallyDefinedInArguments(other)
+    }
+    
+    public init(_ other: RawUnderscorePrivateAttributeArgumentsSyntax) {
+      self = .underscorePrivateAttributeArguments(other)
+    }
+    
+    public init(_ other: RawDynamicReplacementAttributeArgumentsSyntax) {
+      self = .dynamicReplacementArguments(other)
+    }
+    
+    public init(_ other: RawUnavailableFromAsyncAttributeArgumentsSyntax) {
+      self = .unavailableFromAsyncArguments(other)
+    }
+    
+    public init(_ other: RawEffectsAttributeArgumentListSyntax) {
+      self = .effectsArguments(other)
+    }
+    
+    public init(_ other: RawDocumentationAttributeArgumentListSyntax) {
+      self = .documentationArguments(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -1491,7 +1587,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeAtSign: RawUnexpectedNodesSyntax? = nil, 
       atSign: RawTokenSyntax, 
       _ unexpectedBetweenAtSignAndAttributeName: RawUnexpectedNodesSyntax? = nil, 
-      attributeName: RawTypeSyntax, 
+      attributeName: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenAttributeNameAndLeftParen: RawUnexpectedNodesSyntax? = nil, 
       leftParen: RawTokenSyntax?, 
       _ unexpectedBetweenLeftParenAndArguments: RawUnexpectedNodesSyntax? = nil, 
@@ -1599,7 +1695,7 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBetweenSpecifiersAndAttributes: RawUnexpectedNodesSyntax? = nil, 
       attributes: RawAttributeListSyntax, 
       _ unexpectedBetweenAttributesAndBaseType: RawUnexpectedNodesSyntax? = nil, 
-      baseType: RawTypeSyntax, 
+      baseType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterBaseType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1732,6 +1828,18 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
         return
       }
       return nil
+    }
+    
+    public init(_ other: RawTokenSyntax) {
+      self = .token(other)
+    }
+    
+    public init(_ other: RawPlatformVersionSyntax) {
+      self = .availabilityVersionRestriction(other)
+    }
+    
+    public init(_ other: RawAvailabilityLabeledArgumentSyntax) {
+      self = .availabilityLabeledArgument(other)
     }
   }
   
@@ -1927,6 +2035,14 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawSimpleStringLiteralExprSyntax) {
+      self = .string(other)
+    }
+    
+    public init(_ other: RawVersionTupleSyntax) {
+      self = .version(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -2042,7 +2158,7 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeAwaitKeyword: RawUnexpectedNodesSyntax? = nil, 
       awaitKeyword: RawTokenSyntax, 
       _ unexpectedBetweenAwaitKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2310,7 +2426,7 @@ public struct RawBorrowExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeBorrowKeyword: RawUnexpectedNodesSyntax? = nil, 
       borrowKeyword: RawTokenSyntax, 
       _ unexpectedBetweenBorrowKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesC.swift
@@ -1514,6 +1514,14 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawClosureShorthandParameterListSyntax) {
+      self = .simpleInput(other)
+    }
+    
+    public init(_ other: RawClosureParameterClauseSyntax) {
+      self = .parameterClause(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -1718,6 +1726,18 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
         return
       }
       return nil
+    }
+    
+    public init(_ other: some RawDeclSyntaxNodeProtocol) {
+      self = .decl(RawDeclSyntax(other))
+    }
+    
+    public init(_ other: some RawStmtSyntaxNodeProtocol) {
+      self = .stmt(RawStmtSyntax(other))
+    }
+    
+    public init(_ other: some RawExprSyntaxNodeProtocol) {
+      self = .expr(RawExprSyntax(other))
     }
   }
   
@@ -1952,7 +1972,7 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenTypeAndAmpersand: RawUnexpectedNodesSyntax? = nil, 
       ampersand: RawTokenSyntax?, 
       _ unexpectedAfterAmpersand: RawUnexpectedNodesSyntax? = nil, 
@@ -2143,6 +2163,22 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: some RawExprSyntaxNodeProtocol) {
+      self = .expression(RawExprSyntax(other))
+    }
+    
+    public init(_ other: RawAvailabilityConditionSyntax) {
+      self = .availability(other)
+    }
+    
+    public init(_ other: RawMatchingPatternConditionSyntax) {
+      self = .matchingPattern(other)
+    }
+    
+    public init(_ other: RawOptionalBindingConditionSyntax) {
+      self = .optionalBinding(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -2244,11 +2280,11 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeLeftType: RawUnexpectedNodesSyntax? = nil, 
-      leftType: RawTypeSyntax, 
+      leftType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenLeftTypeAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndRightType: RawUnexpectedNodesSyntax? = nil, 
-      rightType: RawTypeSyntax, 
+      rightType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterRightType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2328,7 +2364,7 @@ public struct RawConsumeExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeConsumeKeyword: RawUnexpectedNodesSyntax? = nil, 
       consumeKeyword: RawTokenSyntax, 
       _ unexpectedBetweenConsumeKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2656,7 +2692,7 @@ public struct RawCopyExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeCopyKeyword: RawUnexpectedNodesSyntax? = nil, 
       copyKeyword: RawTokenSyntax, 
       _ unexpectedBetweenCopyKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
@@ -797,7 +797,7 @@ public struct RawDerivativeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenOfLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndOriginalDeclName: RawUnexpectedNodesSyntax? = nil, 
-      originalDeclName: RawExprSyntax, 
+      originalDeclName: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenOriginalDeclNameAndPeriod: RawUnexpectedNodesSyntax? = nil, 
       period: RawTokenSyntax?, 
       _ unexpectedBetweenPeriodAndAccessorSpecifier: RawUnexpectedNodesSyntax? = nil, 
@@ -1093,11 +1093,11 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeKey: RawUnexpectedNodesSyntax? = nil, 
-      key: RawExprSyntax, 
+      key: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenKeyAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndValue: RawUnexpectedNodesSyntax? = nil, 
-      value: RawExprSyntax, 
+      value: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenValueAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -1185,6 +1185,14 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
         return
       }
       return nil
+    }
+    
+    public init(_ other: RawTokenSyntax) {
+      self = .colon(other)
+    }
+    
+    public init(_ other: RawDictionaryElementListSyntax) {
+      self = .elements(other)
     }
   }
   
@@ -1301,11 +1309,11 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBeforeLeftSquare: RawUnexpectedNodesSyntax? = nil, 
       leftSquare: RawTokenSyntax, 
       _ unexpectedBetweenLeftSquareAndKey: RawUnexpectedNodesSyntax? = nil, 
-      key: RawTypeSyntax, 
+      key: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenKeyAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndValue: RawUnexpectedNodesSyntax? = nil, 
-      value: RawTypeSyntax, 
+      value: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenValueAndRightSquare: RawUnexpectedNodesSyntax? = nil, 
       rightSquare: RawTokenSyntax, 
       _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil, 
@@ -1606,6 +1614,14 @@ public struct RawDifferentiabilityWithRespectToArgumentSyntax: RawSyntaxNodeProt
       }
       return nil
     }
+    
+    public init(_ other: RawDifferentiabilityArgumentSyntax) {
+      self = .argument(other)
+    }
+    
+    public init(_ other: RawDifferentiabilityArgumentsSyntax) {
+      self = .argumentList(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -1885,7 +1901,7 @@ public struct RawDiscardStmtSyntax: RawStmtSyntaxNodeProtocol {
       _ unexpectedBeforeDiscardKeyword: RawUnexpectedNodesSyntax? = nil, 
       discardKeyword: RawTokenSyntax, 
       _ unexpectedBetweenDiscardKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2180,6 +2196,14 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
         return
       }
       return nil
+    }
+    
+    public init(_ other: RawTokenSyntax) {
+      self = .token(other)
+    }
+    
+    public init(_ other: RawStringLiteralExprSyntax) {
+      self = .string(other)
     }
   }
   

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesEF.swift
@@ -614,7 +614,7 @@ public struct RawEnumCaseParameterSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenSecondNameAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax?, 
       _ unexpectedBetweenColonAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenTypeAndDefaultValue: RawUnexpectedNodesSyntax? = nil, 
       defaultValue: RawInitializerClauseSyntax?, 
       _ unexpectedBetweenDefaultValueAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -1049,7 +1049,7 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1213,7 +1213,7 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1277,7 +1277,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
       _ unexpectedBetweenModifiersAndExtensionKeyword: RawUnexpectedNodesSyntax? = nil, 
       extensionKeyword: RawTokenSyntax, 
       _ unexpectedBetweenExtensionKeywordAndExtendedType: RawUnexpectedNodesSyntax? = nil, 
-      extendedType: RawTypeSyntax, 
+      extendedType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenExtendedTypeAndInheritanceClause: RawUnexpectedNodesSyntax? = nil, 
       inheritanceClause: RawInheritanceClauseSyntax?, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
@@ -1525,13 +1525,13 @@ public struct RawForStmtSyntax: RawStmtSyntaxNodeProtocol {
       _ unexpectedBetweenAwaitKeywordAndCaseKeyword: RawUnexpectedNodesSyntax? = nil, 
       caseKeyword: RawTokenSyntax?, 
       _ unexpectedBetweenCaseKeywordAndPattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedBetweenPatternAndTypeAnnotation: RawUnexpectedNodesSyntax? = nil, 
       typeAnnotation: RawTypeAnnotationSyntax?, 
       _ unexpectedBetweenTypeAnnotationAndInKeyword: RawUnexpectedNodesSyntax? = nil, 
       inKeyword: RawTokenSyntax, 
       _ unexpectedBetweenInKeywordAndSequence: RawUnexpectedNodesSyntax? = nil, 
-      sequence: RawExprSyntax, 
+      sequence: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenSequenceAndWhereClause: RawUnexpectedNodesSyntax? = nil, 
       whereClause: RawWhereClauseSyntax?, 
       _ unexpectedBetweenWhereClauseAndBody: RawUnexpectedNodesSyntax? = nil, 
@@ -1683,7 +1683,7 @@ public struct RawForceUnwrapExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndExclamationMark: RawUnexpectedNodesSyntax? = nil, 
       exclamationMark: RawTokenSyntax, 
       _ unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? = nil, 
@@ -1753,7 +1753,7 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeCalledExpression: RawUnexpectedNodesSyntax? = nil, 
-      calledExpression: RawExprSyntax, 
+      calledExpression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenCalledExpressionAndLeftParen: RawUnexpectedNodesSyntax? = nil, 
       leftParen: RawTokenSyntax?, 
       _ unexpectedBetweenLeftParenAndArguments: RawUnexpectedNodesSyntax? = nil, 
@@ -2225,7 +2225,7 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenSecondNameAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenTypeAndEllipsis: RawUnexpectedNodesSyntax? = nil, 
       ellipsis: RawTokenSyntax?, 
       _ unexpectedBetweenEllipsisAndDefaultValue: RawUnexpectedNodesSyntax? = nil, 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesGHI.swift
@@ -175,7 +175,7 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeArgument: RawUnexpectedNodesSyntax? = nil, 
-      argument: RawTypeSyntax, 
+      argument: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenArgumentAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -563,6 +563,18 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawSameTypeRequirementSyntax) {
+      self = .sameTypeRequirement(other)
+    }
+    
+    public init(_ other: RawConformanceRequirementSyntax) {
+      self = .conformanceRequirement(other)
+    }
+    
+    public init(_ other: RawLayoutRequirementSyntax) {
+      self = .layoutRequirement(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -664,7 +676,7 @@ public struct RawGenericSpecializationExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil, 
       genericArgumentClause: RawGenericArgumentClauseSyntax, 
       _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil, 
@@ -1096,6 +1108,26 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawCodeBlockItemListSyntax) {
+      self = .statements(other)
+    }
+    
+    public init(_ other: RawSwitchCaseListSyntax) {
+      self = .switchCases(other)
+    }
+    
+    public init(_ other: RawMemberBlockItemListSyntax) {
+      self = .decls(other)
+    }
+    
+    public init(_ other: some RawExprSyntaxNodeProtocol) {
+      self = .postfixExpression(RawExprSyntax(other))
+    }
+    
+    public init(_ other: RawAttributeListSyntax) {
+      self = .attributes(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -1278,6 +1310,14 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawIfExprSyntax) {
+      self = .ifExpr(other)
+    }
+    
+    public init(_ other: RawCodeBlockSyntax) {
+      self = .codeBlock(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -1415,7 +1455,7 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenTypeAndComma: RawUnexpectedNodesSyntax? = nil, 
       comma: RawTokenSyntax, 
       _ unexpectedBetweenCommaAndDeclName: RawUnexpectedNodesSyntax? = nil, 
@@ -1497,7 +1537,7 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
   
   public init(
       _ unexpectedBeforeWrappedType: RawUnexpectedNodesSyntax? = nil, 
-      wrappedType: RawTypeSyntax, 
+      wrappedType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenWrappedTypeAndExclamationMark: RawUnexpectedNodesSyntax? = nil, 
       exclamationMark: RawTokenSyntax, 
       _ unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? = nil, 
@@ -1795,7 +1835,7 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeAmpersand: RawUnexpectedNodesSyntax? = nil, 
       ampersand: RawTokenSyntax, 
       _ unexpectedBetweenAmpersandAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1863,11 +1903,11 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeLeftOperand: RawUnexpectedNodesSyntax? = nil, 
-      leftOperand: RawExprSyntax, 
+      leftOperand: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenLeftOperandAndOperator: RawUnexpectedNodesSyntax? = nil, 
-      operator: RawExprSyntax, 
+      operator: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenOperatorAndRightOperand: RawUnexpectedNodesSyntax? = nil, 
-      rightOperand: RawExprSyntax, 
+      rightOperand: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterRightOperand: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2065,7 +2105,7 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenTypeAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -2137,7 +2177,7 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeEqual: RawUnexpectedNodesSyntax? = nil, 
       equal: RawTokenSyntax, 
       _ unexpectedBetweenEqualAndValue: RawUnexpectedNodesSyntax? = nil, 
-      value: RawExprSyntax, 
+      value: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2405,11 +2445,11 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndIsKeyword: RawUnexpectedNodesSyntax? = nil, 
       isKeyword: RawTokenSyntax, 
       _ unexpectedBetweenIsKeywordAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2489,7 +2529,7 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol {
       _ unexpectedBeforeIsKeyword: RawUnexpectedNodesSyntax? = nil, 
       isKeyword: RawTokenSyntax, 
       _ unexpectedBetweenIsKeywordAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
@@ -99,6 +99,18 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawKeyPathPropertyComponentSyntax) {
+      self = .property(other)
+    }
+    
+    public init(_ other: RawKeyPathSubscriptComponentSyntax) {
+      self = .subscript(other)
+    }
+    
+    public init(_ other: RawKeyPathOptionalComponentSyntax) {
+      self = .optional(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -546,7 +558,7 @@ public struct RawLabeledExprSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax?, 
       _ unexpectedBetweenColonAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -734,7 +746,7 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
       _ unexpectedBetweenLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndStatement: RawUnexpectedNodesSyntax? = nil, 
-      statement: RawStmtSyntax, 
+      statement: some RawStmtSyntaxNodeProtocol, 
       _ unexpectedAfterStatement: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -812,7 +824,7 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenTypeAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndLayoutSpecifier: RawUnexpectedNodesSyntax? = nil, 
@@ -1641,7 +1653,7 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeCaseKeyword: RawUnexpectedNodesSyntax? = nil, 
       caseKeyword: RawTokenSyntax, 
       _ unexpectedBetweenCaseKeywordAndPattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedBetweenPatternAndTypeAnnotation: RawUnexpectedNodesSyntax? = nil, 
       typeAnnotation: RawTypeAnnotationSyntax?, 
       _ unexpectedBetweenTypeAnnotationAndInitializer: RawUnexpectedNodesSyntax? = nil, 
@@ -1865,7 +1877,7 @@ public struct RawMemberBlockItemSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeDecl: RawUnexpectedNodesSyntax? = nil, 
-      decl: RawDeclSyntax, 
+      decl: some RawDeclSyntaxNodeProtocol, 
       _ unexpectedBetweenDeclAndSemicolon: RawUnexpectedNodesSyntax? = nil, 
       semicolon: RawTokenSyntax?, 
       _ unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? = nil, 
@@ -2017,7 +2029,7 @@ public struct RawMemberTypeSyntax: RawTypeSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeBaseType: RawUnexpectedNodesSyntax? = nil, 
-      baseType: RawTypeSyntax, 
+      baseType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenBaseTypeAndPeriod: RawUnexpectedNodesSyntax? = nil, 
       period: RawTokenSyntax, 
       _ unexpectedBetweenPeriodAndName: RawUnexpectedNodesSyntax? = nil, 
@@ -2111,7 +2123,7 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeBaseType: RawUnexpectedNodesSyntax? = nil, 
-      baseType: RawTypeSyntax, 
+      baseType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenBaseTypeAndPeriod: RawUnexpectedNodesSyntax? = nil, 
       period: RawTokenSyntax, 
       _ unexpectedBetweenPeriodAndMetatypeSpecifier: RawUnexpectedNodesSyntax? = nil, 
@@ -2699,7 +2711,7 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBeforeGenericParameterClause: RawUnexpectedNodesSyntax? = nil, 
       genericParameterClause: RawGenericParameterClauseSyntax, 
       _ unexpectedBetweenGenericParameterClauseAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesOP.swift
@@ -426,7 +426,7 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeBindingSpecifier: RawUnexpectedNodesSyntax? = nil, 
       bindingSpecifier: RawTokenSyntax, 
       _ unexpectedBetweenBindingSpecifierAndPattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedBetweenPatternAndTypeAnnotation: RawUnexpectedNodesSyntax? = nil, 
       typeAnnotation: RawTypeAnnotationSyntax?, 
       _ unexpectedBetweenTypeAnnotationAndInitializer: RawUnexpectedNodesSyntax? = nil, 
@@ -518,7 +518,7 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndQuestionMark: RawUnexpectedNodesSyntax? = nil, 
       questionMark: RawTokenSyntax, 
       _ unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? = nil, 
@@ -588,7 +588,7 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeWrappedType: RawUnexpectedNodesSyntax? = nil, 
-      wrappedType: RawTypeSyntax, 
+      wrappedType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenWrappedTypeAndQuestionMark: RawUnexpectedNodesSyntax? = nil, 
       questionMark: RawTokenSyntax, 
       _ unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? = nil, 
@@ -766,7 +766,7 @@ public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? = nil, 
       eachKeyword: RawTokenSyntax, 
       _ unexpectedBetweenEachKeywordAndPack: RawUnexpectedNodesSyntax? = nil, 
-      pack: RawExprSyntax, 
+      pack: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterPack: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -836,7 +836,7 @@ public struct RawPackElementTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? = nil, 
       eachKeyword: RawTokenSyntax, 
       _ unexpectedBetweenEachKeywordAndPack: RawUnexpectedNodesSyntax? = nil, 
-      pack: RawTypeSyntax, 
+      pack: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterPack: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -906,7 +906,7 @@ public struct RawPackExpansionExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeRepeatKeyword: RawUnexpectedNodesSyntax? = nil, 
       repeatKeyword: RawTokenSyntax, 
       _ unexpectedBetweenRepeatKeywordAndRepetitionPattern: RawUnexpectedNodesSyntax? = nil, 
-      repetitionPattern: RawExprSyntax, 
+      repetitionPattern: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterRepetitionPattern: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -976,7 +976,7 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBeforeRepeatKeyword: RawUnexpectedNodesSyntax? = nil, 
       repeatKeyword: RawTokenSyntax, 
       _ unexpectedBetweenRepeatKeywordAndRepetitionPattern: RawUnexpectedNodesSyntax? = nil, 
-      repetitionPattern: RawTypeSyntax, 
+      repetitionPattern: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterRepetitionPattern: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1094,7 +1094,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforePattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedBetweenPatternAndTypeAnnotation: RawUnexpectedNodesSyntax? = nil, 
       typeAnnotation: RawTypeAnnotationSyntax?, 
       _ unexpectedBetweenTypeAnnotationAndInitializer: RawUnexpectedNodesSyntax? = nil, 
@@ -1200,7 +1200,7 @@ public struct RawPatternExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforePattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedAfterPattern: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1557,7 +1557,7 @@ public struct RawPostfixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndOperator: RawUnexpectedNodesSyntax? = nil, 
       operator: RawTokenSyntax, 
       _ unexpectedAfterOperator: RawUnexpectedNodesSyntax? = nil, 
@@ -2021,6 +2021,18 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawPrecedenceGroupRelationSyntax) {
+      self = .precedenceGroupRelation(other)
+    }
+    
+    public init(_ other: RawPrecedenceGroupAssignmentSyntax) {
+      self = .precedenceGroupAssignment(other)
+    }
+    
+    public init(_ other: RawPrecedenceGroupAssociativitySyntax) {
+      self = .precedenceGroupAssociativity(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -2436,7 +2448,7 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeOperator: RawUnexpectedNodesSyntax? = nil, 
       operator: RawTokenSyntax, 
       _ unexpectedBetweenOperatorAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
@@ -158,7 +158,7 @@ public struct RawRepeatStmtSyntax: RawStmtSyntaxNodeProtocol {
       _ unexpectedBetweenBodyAndWhileKeyword: RawUnexpectedNodesSyntax? = nil, 
       whileKeyword: RawTokenSyntax, 
       _ unexpectedBetweenWhileKeywordAndCondition: RawUnexpectedNodesSyntax? = nil, 
-      condition: RawExprSyntax, 
+      condition: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterCondition: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -248,7 +248,7 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeArrow: RawUnexpectedNodesSyntax? = nil, 
       arrow: RawTokenSyntax, 
       _ unexpectedBetweenArrowAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -386,11 +386,11 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeLeftType: RawUnexpectedNodesSyntax? = nil, 
-      leftType: RawTypeSyntax, 
+      leftType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenLeftTypeAndEqual: RawUnexpectedNodesSyntax? = nil, 
       equal: RawTokenSyntax, 
       _ unexpectedBetweenEqualAndRightType: RawUnexpectedNodesSyntax? = nil, 
-      rightType: RawTypeSyntax, 
+      rightType: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterRightType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -718,7 +718,7 @@ public struct RawSomeOrAnyTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBeforeSomeOrAnySpecifier: RawUnexpectedNodesSyntax? = nil, 
       someOrAnySpecifier: RawTokenSyntax, 
       _ unexpectedBetweenSomeOrAnySpecifierAndConstraint: RawUnexpectedNodesSyntax? = nil, 
-      constraint: RawTypeSyntax, 
+      constraint: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterConstraint: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -880,6 +880,22 @@ public struct RawSpecializeAttributeArgumentListSyntax: RawSyntaxNodeProtocol {
         return
       }
       return nil
+    }
+    
+    public init(_ other: RawLabeledSpecializeArgumentSyntax) {
+      self = .labeledSpecializeArgument(other)
+    }
+    
+    public init(_ other: RawSpecializeAvailabilityArgumentSyntax) {
+      self = .specializeAvailabilityArgument(other)
+    }
+    
+    public init(_ other: RawSpecializeTargetFunctionArgumentSyntax) {
+      self = .specializeTargetFunctionArgument(other)
+    }
+    
+    public init(_ other: RawGenericWhereClauseSyntax) {
+      self = .genericWhereClause(other)
     }
   }
   
@@ -1294,6 +1310,14 @@ public struct RawStringLiteralSegmentListSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawStringSegmentSyntax) {
+      self = .stringSegment(other)
+    }
+    
+    public init(_ other: RawExpressionSegmentSyntax) {
+      self = .expressionSegment(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -1575,7 +1599,7 @@ public struct RawSubscriptCallExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeCalledExpression: RawUnexpectedNodesSyntax? = nil, 
-      calledExpression: RawExprSyntax, 
+      calledExpression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenCalledExpressionAndLeftSquare: RawUnexpectedNodesSyntax? = nil, 
       leftSquare: RawTokenSyntax, 
       _ unexpectedBetweenLeftSquareAndArguments: RawUnexpectedNodesSyntax? = nil, 
@@ -1895,7 +1919,7 @@ public struct RawSuppressedTypeSyntax: RawTypeSyntaxNodeProtocol {
       _ unexpectedBeforeWithoutTilde: RawUnexpectedNodesSyntax? = nil, 
       withoutTilde: RawTokenSyntax, 
       _ unexpectedBetweenWithoutTildeAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2013,7 +2037,7 @@ public struct RawSwitchCaseItemSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforePattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedBetweenPatternAndWhereClause: RawUnexpectedNodesSyntax? = nil, 
       whereClause: RawWhereClauseSyntax?, 
       _ unexpectedBetweenWhereClauseAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -2176,6 +2200,14 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawSwitchCaseSyntax) {
+      self = .switchCase(other)
+    }
+    
+    public init(_ other: RawIfConfigDeclSyntax) {
+      self = .ifConfigDecl(other)
+    }
   }
   
   @_spi(RawSyntax)
@@ -2255,6 +2287,14 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
         return
       }
       return nil
+    }
+    
+    public init(_ other: RawSwitchDefaultLabelSyntax) {
+      self = .default(other)
+    }
+    
+    public init(_ other: RawSwitchCaseLabelSyntax) {
+      self = .case(other)
     }
   }
   
@@ -2441,7 +2481,7 @@ public struct RawSwitchExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeSwitchKeyword: RawUnexpectedNodesSyntax? = nil, 
       switchKeyword: RawTokenSyntax, 
       _ unexpectedBetweenSwitchKeywordAndSubject: RawUnexpectedNodesSyntax? = nil, 
-      subject: RawExprSyntax, 
+      subject: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenSubjectAndLeftBrace: RawUnexpectedNodesSyntax? = nil, 
       leftBrace: RawTokenSyntax, 
       _ unexpectedBetweenLeftBraceAndCases: RawUnexpectedNodesSyntax? = nil, 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
@@ -46,15 +46,15 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeCondition: RawUnexpectedNodesSyntax? = nil, 
-      condition: RawExprSyntax, 
+      condition: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenConditionAndQuestionMark: RawUnexpectedNodesSyntax? = nil, 
       questionMark: RawTokenSyntax, 
       _ unexpectedBetweenQuestionMarkAndThenExpression: RawUnexpectedNodesSyntax? = nil, 
-      thenExpression: RawExprSyntax, 
+      thenExpression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenThenExpressionAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndElseExpression: RawUnexpectedNodesSyntax? = nil, 
-      elseExpression: RawExprSyntax, 
+      elseExpression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterElseExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -157,7 +157,7 @@ public struct RawThenStmtSyntax: RawStmtSyntaxNodeProtocol {
       _ unexpectedBeforeThenKeyword: RawUnexpectedNodesSyntax? = nil, 
       thenKeyword: RawTokenSyntax, 
       _ unexpectedBetweenThenKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -227,7 +227,7 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol {
       _ unexpectedBeforeThrowKeyword: RawUnexpectedNodesSyntax? = nil, 
       throwKeyword: RawTokenSyntax, 
       _ unexpectedBetweenThrowKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -393,7 +393,7 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil, 
       questionOrExclamationMark: RawTokenSyntax?, 
       _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -607,7 +607,7 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax?, 
       _ unexpectedBetweenColonAndPattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedBetweenPatternAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -837,7 +837,7 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenSecondNameAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax?, 
       _ unexpectedBetweenColonAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedBetweenTypeAndEllipsis: RawUnexpectedNodesSyntax? = nil, 
       ellipsis: RawTokenSyntax?, 
       _ unexpectedBetweenEllipsisAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -1173,7 +1173,7 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1311,7 +1311,7 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeType: RawUnexpectedNodesSyntax? = nil, 
-      type: RawTypeSyntax, 
+      type: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1371,7 +1371,7 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeEqual: RawUnexpectedNodesSyntax? = nil, 
       equal: RawTokenSyntax, 
       _ unexpectedBetweenEqualAndValue: RawUnexpectedNodesSyntax? = nil, 
-      value: RawTypeSyntax, 
+      value: some RawTypeSyntaxNodeProtocol, 
       _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -1437,6 +1437,14 @@ public struct RawTypeSpecifierListSyntax: RawSyntaxNodeProtocol {
         return
       }
       return nil
+    }
+    
+    public init(_ other: RawSimpleTypeSpecifierSyntax) {
+      self = .simpleTypeSpecifier(other)
+    }
+    
+    public init(_ other: RawLifetimeTypeSpecifierSyntax) {
+      self = .lifetimeTypeSpecifier(other)
     }
   }
   
@@ -1902,7 +1910,7 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
       _ unexpectedBeforeQuestionMark: RawUnexpectedNodesSyntax? = nil, 
       questionMark: RawTokenSyntax, 
       _ unexpectedBetweenQuestionMarkAndThenExpression: RawUnexpectedNodesSyntax? = nil, 
-      thenExpression: RawExprSyntax, 
+      thenExpression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenThenExpressionAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil, 
@@ -1984,7 +1992,7 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol {
       _ unexpectedBeforeBindingSpecifier: RawUnexpectedNodesSyntax? = nil, 
       bindingSpecifier: RawTokenSyntax, 
       _ unexpectedBetweenBindingSpecifierAndPattern: RawUnexpectedNodesSyntax? = nil, 
-      pattern: RawPatternSyntax, 
+      pattern: some RawPatternSyntaxNodeProtocol, 
       _ unexpectedAfterPattern: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2338,7 +2346,7 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBeforeWhereKeyword: RawUnexpectedNodesSyntax? = nil, 
       whereKeyword: RawTokenSyntax, 
       _ unexpectedBetweenWhereKeywordAndCondition: RawUnexpectedNodesSyntax? = nil, 
-      condition: RawExprSyntax, 
+      condition: some RawExprSyntaxNodeProtocol, 
       _ unexpectedAfterCondition: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -2545,6 +2553,14 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
       }
       return nil
     }
+    
+    public init(_ other: RawYieldedExpressionsClauseSyntax) {
+      self = .multiple(other)
+    }
+    
+    public init(_ other: some RawExprSyntaxNodeProtocol) {
+      self = .single(RawExprSyntax(other))
+    }
   }
   
   @_spi(RawSyntax)
@@ -2696,7 +2712,7 @@ public struct RawYieldedExpressionSyntax: RawSyntaxNodeProtocol {
   
   public init(
       _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
+      expression: some RawExprSyntaxNodeProtocol, 
       _ unexpectedBetweenExpressionAndComma: RawUnexpectedNodesSyntax? = nil, 
       comma: RawTokenSyntax?, 
       _ unexpectedAfterComma: RawUnexpectedNodesSyntax? = nil, 


### PR DESCRIPTION
This PR aims to improve developer ergonomics when using the designated initializers of raw syntax nodes. Simply put, it's through achieving feature parity with the non-raw side.

### Prefer generic types over type erasure types

Currently the designated initializer of `RawXXXSyntax` always uses type-erased types instead of generic types as parameter types, leading to much clunkiness.

```swift
public struct RawPatternExprSyntax: RawExprSyntaxNodeProtocol {
  public init(
    _ unexpectedBeforePattern: RawUnexpectedNodesSyntax? = nil, 
    pattern: RawPatternSyntax, // type erasure
    _ unexpectedAfterPattern: RawUnexpectedNodesSyntax? = nil, 
    arena: __shared SyntaxArena
  )
}

let pattern = RawIdentifierPatternSyntax(
  identifier: identifier,
  arena: self.arena
)
return RawExprSyntax(RawPatternExprSyntax(pattern: RawPatternSyntax(pattern), arena: self.arena))
```

The initializer body, however, only invokes `pattern.raw`, therefore we could just replace `pattern: RawPatternSyntax` with `pattern: some RawPatternSyntaxNodeProtocol` transparently,

```swift
public struct RawPatternExprSyntax: RawExprSyntaxNodeProtocol {
  public init(
    _ unexpectedBeforePattern: RawUnexpectedNodesSyntax? = nil, 
    pattern: some RawPatternSyntaxNodeProtocol, // generic type
    _ unexpectedAfterPattern: RawUnexpectedNodesSyntax? = nil, 
    arena: __shared SyntaxArena
  )
}

let pattern = RawIdentifierPatternSyntax(
  identifier: identifier,
  arena: self.arena
)
// clunky type-erasure removed
return RawExprSyntax(RawPatternExprSyntax(pattern: pattern, arena: self.arena))
```

Actually it's what `PatternExprSyntax.init` has been doing,
```swift
public init(
  leadingTrivia: Trivia? = nil,
  _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
  pattern: some PatternSyntaxProtocol,
  _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil,
  trailingTrivia: Trivia? = nil
)
```

### Generate convenience generic initializers for choices enum

e.g.
```swift
public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
  public enum Item: RawSyntaxNodeProtocol {
    case `decl`(RawDeclSyntax)
    case `stmt`(RawStmtSyntax)
    case `expr`(RawExprSyntax)

    public init(_ other: some RawDeclSyntaxNodeProtocol) {
      self = .decl(RawDeclSyntax(other))
    }
    
    public init(_ other: some RawStmtSyntaxNodeProtocol) {
      self = .stmt(RawStmtSyntax(other))
    }
    
    public init(_ other: some RawExprSyntaxNodeProtocol) {
      self = .expr(RawExprSyntax(other))
    }
```

So call sites might get rid of type erasure as follows,
```swift
// requires type erasure
.expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena)))

// supports generic type 
.init(RawMissingExprSyntax(arena: self.arena))
```

### Remove type erasure in call sites

This PR has removed unnecessary uses of type-erased types in many call sites thanks to the new initializers.