### PR TITLE
Increase tools version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 
 import Foundation
 import PackageDescription


### PR DESCRIPTION
The changes introduced by #2742 in SyntaxRewriter require at least Swift 5.8.