### PR TITLE
[SwiftParser] Improve developer ergonomics for type erasure with `RawXXX<Kind>Syntax`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -388,6 +388,11 @@ public enum SyntaxNodeKind: String, CaseIterable {
     return "Raw\(syntaxType)"
   }
 
+  /// The name of this node at the `RawSyntax` level as an variable name.
+  public var rawTypeAsVarName: TypeSyntax {
+    "raw\(syntaxType)"
+  }
+
   /// For base nodes, the name of the corresponding raw protocol to which all the
   /// concrete raw nodes that have this base kind, conform.
   public var rawProtocolType: TypeSyntax {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
@@ -65,14 +65,12 @@ let layoutNodesParsableFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           // The missing item is not necessary to be a declaration,
           // which is just a placeholder here
           return RawCodeBlockItemSyntax(
-            item: .decl(
-              RawDeclSyntax(
-                RawMissingDeclSyntax(
-                  attributes: self.emptyCollection(RawAttributeListSyntax.self),
-                  modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
-                  arena: self.arena
-                )
-              )
+            item: .decl(              
+              RawMissingDeclSyntax(
+                attributes: self.emptyCollection(RawAttributeListSyntax.self),
+                modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
+                arena: self.arena
+              ).rawDeclSyntax
             ),
             semicolon: nil,
             arena: self.arena

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -361,9 +361,8 @@ extension Parser {
           unexpectedBeforeAtSign,
           atSign: atSign,
           unexpectedBeforeAttributeName,
-          attributeName: RawTypeSyntax(
-            RawIdentifierTypeSyntax(name: attributeName, genericArgumentClause: nil, arena: self.arena)
-          ),
+          attributeName: RawIdentifierTypeSyntax(name: attributeName, genericArgumentClause: nil, arena: self.arena)
+            .rawTypeSyntax,
           leftParen: nil,
           arguments: nil,
           rightParen: nil,
@@ -394,14 +393,12 @@ extension RawLabeledExprSyntax {
     self.init(
       label: nil,
       colon: nil,
-      expression: RawExprSyntax(
-        RawDeclReferenceExprSyntax(
-          unexpectedBeforeIdentifier,
-          baseName: identifier,
-          argumentNames: nil,
-          arena: arena
-        )
-      ),
+      expression: RawDeclReferenceExprSyntax(
+        unexpectedBeforeIdentifier,
+        baseName: identifier,
+        argumentNames: nil,
+        arena: arena
+      ).rawExprSyntax,
       unexpectedBetweenIdentifierAndTrailingComma,
       trailingComma: trailingComma,
       arena: arena
@@ -448,9 +445,8 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSign: atSign,
       unexpectedBeforeDifferentiable,
-      attributeName: RawTypeSyntax(
-        RawIdentifierTypeSyntax(name: differentiable, genericArgumentClause: nil, arena: self.arena)
-      ),
+      attributeName: RawIdentifierTypeSyntax(name: differentiable, genericArgumentClause: nil, arena: self.arena)
+        .rawTypeSyntax,
       unexpectedBeforeLeftParen,
       leftParen: leftParen,
       arguments: .differentiableArguments(argument),
@@ -592,9 +588,8 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSign: atSign,
       unexpectedBeforeDerivative,
-      attributeName: RawTypeSyntax(
-        RawIdentifierTypeSyntax(name: derivative, genericArgumentClause: nil, arena: self.arena)
-      ),
+      attributeName: RawIdentifierTypeSyntax(name: derivative, genericArgumentClause: nil, arena: self.arena)
+        .rawTypeSyntax,
       unexpectedBeforeLeftParen,
       leftParen: leftParen,
       arguments: .derivativeRegistrationArguments(argument),
@@ -616,9 +611,8 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSign: atSign,
       unexpectedBeforeTranspose,
-      attributeName: RawTypeSyntax(
-        RawIdentifierTypeSyntax(name: transpose, genericArgumentClause: nil, arena: self.arena)
-      ),
+      attributeName: RawIdentifierTypeSyntax(name: transpose, genericArgumentClause: nil, arena: self.arena)
+        .rawTypeSyntax,
       unexpectedBeforeLeftParen,
       leftParen: leftParen,
       arguments: .derivativeRegistrationArguments(argument),

--- a/Sources/SwiftParser/CollectionNodes+Parsable.swift
+++ b/Sources/SwiftParser/CollectionNodes+Parsable.swift
@@ -85,7 +85,7 @@ extension AttributeListSyntax: SyntaxParseable {
     } makeMissing: { remainingTokens, arena in
       return RawAttributeSyntax(
         atSign: RawTokenSyntax(missing: .atSign, arena: arena),
-        attributeName: RawTypeSyntax(RawMissingTypeSyntax(arena: arena)),
+        attributeName: RawMissingTypeSyntax(arena: arena).rawTypeSyntax,
         leftParen: nil,
         arguments: nil,
         rightParen: nil,
@@ -102,7 +102,7 @@ extension CodeBlockItemListSyntax: SyntaxParseable {
       return RawSyntax(node)
     } makeMissing: { remainingTokens, arena in
       let missingExpr = RawMissingExprSyntax(arena: arena)
-      return RawCodeBlockItemSyntax(item: .expr(RawExprSyntax(missingExpr)), semicolon: nil, arena: arena)
+      return RawCodeBlockItemSyntax(item: .expr(missingExpr.rawExprSyntax), semicolon: nil, arena: arena)
     }
   }
 }
@@ -119,7 +119,7 @@ extension MemberBlockItemListSyntax: SyntaxParseable {
         RawUnexpectedNodesSyntax(remainingTokens, arena: arena),
         arena: arena
       )
-      return RawMemberBlockItemSyntax(decl: RawDeclSyntax(missingDecl), semicolon: nil, arena: arena)
+      return RawMemberBlockItemSyntax(decl: missingDecl.rawDeclSyntax, semicolon: nil, arena: arena)
     }
   }
 }

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -200,7 +200,7 @@ extension Parser {
       } syntax: { parser, elements in
         return .decls(RawMemberBlockItemListSyntax(elements: elements, arena: parser.arena))
       }
-      return RawDeclSyntax(directive)
+      return directive.rawDeclSyntax
     }
 
     let attrs = DeclAttributes(
@@ -227,53 +227,48 @@ extension Parser {
 
     switch recoveryResult {
     case (.lhs(.import), let handle)?:
-      return RawDeclSyntax(self.parseImportDeclaration(attrs, handle))
+      return self.parseImportDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.class), let handle)?:
-      return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawClassDeclSyntax.self, attrs: attrs, introucerHandle: handle)
-      )
+      return self.parseNominalTypeDeclaration(for: RawClassDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        .rawDeclSyntax
     case (.lhs(.enum), let handle)?:
-      return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawEnumDeclSyntax.self, attrs: attrs, introucerHandle: handle)
-      )
+      return self.parseNominalTypeDeclaration(for: RawEnumDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        .rawDeclSyntax
     case (.lhs(.case), let handle)?:
-      return RawDeclSyntax(self.parseEnumCaseDeclaration(attrs, handle))
+      return self.parseEnumCaseDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.struct), let handle)?:
-      return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawStructDeclSyntax.self, attrs: attrs, introucerHandle: handle)
-      )
+      return self.parseNominalTypeDeclaration(for: RawStructDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        .rawDeclSyntax
     case (.lhs(.protocol), let handle)?:
-      return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawProtocolDeclSyntax.self, attrs: attrs, introucerHandle: handle)
-      )
+      return self.parseNominalTypeDeclaration(for: RawProtocolDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        .rawDeclSyntax
     case (.lhs(.associatedtype), let handle)?:
-      return RawDeclSyntax(self.parseAssociatedTypeDeclaration(attrs, handle))
+      return self.parseAssociatedTypeDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.typealias), let handle)?:
-      return RawDeclSyntax(self.parseTypealiasDeclaration(attrs, handle))
+      return self.parseTypealiasDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.extension), let handle)?:
-      return RawDeclSyntax(self.parseExtensionDeclaration(attrs, handle))
+      return self.parseExtensionDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.func), let handle)?:
-      return RawDeclSyntax(self.parseFuncDeclaration(attrs, handle))
+      return self.parseFuncDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.subscript), let handle)?:
-      return RawDeclSyntax(self.parseSubscriptDeclaration(attrs, handle))
+      return self.parseSubscriptDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.`init`), let handle)?:
-      return RawDeclSyntax(self.parseInitializerDeclaration(attrs, handle))
+      return self.parseInitializerDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.deinit), let handle)?:
-      return RawDeclSyntax(self.parseDeinitializerDeclaration(attrs, handle))
+      return self.parseDeinitializerDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.operator), let handle)?:
-      return RawDeclSyntax(self.parseOperatorDeclaration(attrs, handle))
+      return self.parseOperatorDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.precedencegroup), let handle)?:
-      return RawDeclSyntax(self.parsePrecedenceGroupDeclaration(attrs, handle))
+      return self.parsePrecedenceGroupDeclaration(attrs, handle).rawDeclSyntax
     case (.lhs(.actor), let handle)?:
-      return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawActorDeclSyntax.self, attrs: attrs, introucerHandle: handle)
-      )
+      return self.parseNominalTypeDeclaration(for: RawActorDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        .rawDeclSyntax
     case (.lhs(.macro), let handle)?:
-      return RawDeclSyntax(self.parseMacroDeclaration(attrs: attrs, introducerHandle: handle))
+      return self.parseMacroDeclaration(attrs: attrs, introducerHandle: handle).rawDeclSyntax
     case (.lhs(.pound), let handle)?:
-      return RawDeclSyntax(self.parseMacroExpansionDeclaration(attrs, handle))
+      return self.parseMacroExpansionDeclaration(attrs, handle).rawDeclSyntax
     case (.rhs, let handle)?:
-      return RawDeclSyntax(self.parseBindingDeclaration(attrs, handle, inMemberDeclList: inMemberDeclList))
+      return self.parseBindingDeclaration(attrs, handle, inMemberDeclList: inMemberDeclList).rawDeclSyntax
     case nil:
       break
     }
@@ -283,32 +278,28 @@ extension Parser {
       let isProbablyTupleDecl = self.at(.leftParen) && self.peek(isAt: .identifier, .wildcard)
 
       if isProbablyVarDecl || isProbablyTupleDecl {
-        return RawDeclSyntax(self.parseBindingDeclaration(attrs, .missing(.keyword(.var))))
+        return self.parseBindingDeclaration(attrs, .missing(.keyword(.var))).rawDeclSyntax
       }
 
       if self.currentToken.isEditorPlaceholder {
         let placeholder = self.parseAnyIdentifier()
-        return RawDeclSyntax(
-          RawMissingDeclSyntax(
-            attributes: attrs.attributes,
-            modifiers: attrs.modifiers,
-            placeholder: placeholder,
-            arena: self.arena
-          )
-        )
+        return RawMissingDeclSyntax(
+          attributes: attrs.attributes,
+          modifiers: attrs.modifiers,
+          placeholder: placeholder,
+          arena: self.arena
+        ).rawDeclSyntax
       }
 
       if atFunctionDeclarationWithoutFuncKeyword() {
-        return RawDeclSyntax(self.parseFuncDeclaration(attrs, .missing(.keyword(.func))))
+        return self.parseFuncDeclaration(attrs, .missing(.keyword(.func))).rawDeclSyntax
       }
     }
-    return RawDeclSyntax(
-      RawMissingDeclSyntax(
-        attributes: attrs.attributes,
-        modifiers: attrs.modifiers,
-        arena: self.arena
-      )
-    )
+    return RawMissingDeclSyntax(
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      arena: self.arena
+    ).rawDeclSyntax
   }
 
   /// Returns `true` if it looks like the parser is positioned at a function declaration that’s missing the `func` keyword.
@@ -462,16 +453,15 @@ extension Parser {
             inherited = self.parseType()
           } else if let classKeyword = self.consume(if: .keyword(.class)) {
             unexpectedBeforeInherited = RawUnexpectedNodesSyntax([classKeyword], arena: self.arena)
-            inherited = RawTypeSyntax(
+            inherited =
               RawIdentifierTypeSyntax(
                 name: missingToken(.identifier, text: "AnyObject"),
                 genericArgumentClause: nil,
                 arena: self.arena
-              )
-            )
+              ).rawTypeSyntax
           } else {
             unexpectedBeforeInherited = nil
-            inherited = RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena))
+            inherited = RawMissingTypeSyntax(arena: self.arena).rawTypeSyntax
           }
         } else {
           unexpectedBeforeInherited = nil
@@ -534,9 +524,9 @@ extension Parser {
             RawGenericRequirementSyntax(
               requirement: .sameTypeRequirement(
                 RawSameTypeRequirementSyntax(
-                  leftType: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+                  leftType: RawMissingTypeSyntax(arena: self.arena).rawTypeSyntax,
                   equal: missingToken(.binaryOperator, text: "=="),
-                  rightType: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+                  rightType: RawMissingTypeSyntax(arena: self.arena).rawTypeSyntax,
                   arena: self.arena
                 )
               ),
@@ -674,7 +664,7 @@ extension Parser {
             RawSameTypeRequirementSyntax(
               leftType: firstType,
               equal: RawTokenSyntax(missing: .binaryOperator, text: "==", arena: self.arena),
-              rightType: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+              rightType: RawMissingTypeSyntax(arena: self.arena).rawTypeSyntax,
               arena: self.arena
             )
           )
@@ -722,13 +712,11 @@ extension Parser {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       let item = RawMemberBlockItemSyntax(
         remainingTokens,
-        decl: RawDeclSyntax(
-          RawMissingDeclSyntax(
-            attributes: self.emptyCollection(RawAttributeListSyntax.self),
-            modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
-            arena: self.arena
-          )
-        ),
+        decl: RawMissingDeclSyntax(
+          attributes: self.emptyCollection(RawAttributeListSyntax.self),
+          modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
+          arena: self.arena
+        ).rawDeclSyntax,
         semicolon: nil,
         arena: self.arena
       )
@@ -737,7 +725,7 @@ extension Parser {
 
     let decl: RawDeclSyntax
     if self.at(.poundSourceLocation) {
-      decl = RawDeclSyntax(self.parsePoundSourceLocationDirective())
+      decl = self.parsePoundSourceLocationDirective().rawDeclSyntax
     } else {
       decl = self.parseDeclaration(inMemberDeclList: true)
     }
@@ -1291,14 +1279,13 @@ extension Parser {
         if let equal = self.consume(if: .equal) {
           var value = self.parseExpression(flavor: .basic, pattern: .none)
           if hasTryBeforeIntroducer && !value.is(RawTryExprSyntax.self) {
-            value = RawExprSyntax(
+            value =
               RawTryExprSyntax(
                 tryKeyword: missingToken(.try),
                 questionOrExclamationMark: nil,
                 expression: value,
                 arena: self.arena
-              )
-            )
+              ).rawExprSyntax
           }
           initializer = RawInitializerClauseSyntax(
             equal: equal,
@@ -1313,13 +1300,11 @@ extension Parser {
           // annotation and form an initializer clause from it instead.
           typeAnnotation = nil
           let initExpr = parsePostfixExpressionSuffix(
-            RawExprSyntax(
-              RawTypeExprSyntax(
-                type: typeAnnotationUnwrapped.type,
-                typeAnnotation?.unexpectedAfterType,
-                arena: self.arena
-              )
-            ),
+            RawTypeExprSyntax(
+              type: typeAnnotationUnwrapped.type,
+              typeAnnotation?.unexpectedAfterType,
+              arena: self.arena
+            ).rawExprSyntax,
             flavor: .basic,
             pattern: .none
           )

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -75,7 +75,7 @@ extension Parser {
 
     // Parse #if
     let (unexpectedBeforePoundIf, poundIf) = self.expect(.poundIf)
-    let condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+    let condition = self.parseSequenceExpression(flavor: .poundIfDirective)
     let unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
 
     clauses.append(
@@ -102,7 +102,7 @@ extension Parser {
       switch match {
       case .poundElseif:
         (unexpectedBeforePound, pound) = self.eat(handle)
-        condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+        condition = self.parseSequenceExpression(flavor: .poundIfDirective)
         unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
       case .poundElse:
         (unexpectedBeforePound, pound) = self.eat(handle)
@@ -114,7 +114,7 @@ extension Parser {
             arena: self.arena
           )
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+          condition = self.parseSequenceExpression(flavor: .poundIfDirective)
         } else {
           condition = nil
         }
@@ -132,7 +132,7 @@ extension Parser {
             arena: self.arena
           )
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
+          condition = self.parseSequenceExpression(flavor: .poundIfDirective)
           unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
         } else {
           break LOOP

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -160,7 +160,7 @@ extension Parser {
     let period: RawTokenSyntax?
 
     if self.lookahead().canParseBaseTypeForQualifiedDeclName() {
-      type = RawExprSyntax(RawTypeExprSyntax(type: self.parseQualifiedTypeIdentifier(), arena: self.arena))
+      type = RawTypeExprSyntax(type: self.parseQualifiedTypeIdentifier(), arena: self.arena).rawExprSyntax
       period = self.expectWithoutRecovery(prefix: ".", as: .period)
     } else {
       type = nil
@@ -173,22 +173,20 @@ extension Parser {
       .operators,
     ])
     if let period = period {
-      return RawExprSyntax(
-        RawMemberAccessExprSyntax(
-          base: type,
-          period: period,
-          declName: declName,
-          arena: self.arena
-        )
-      )
+      return RawMemberAccessExprSyntax(
+        base: type,
+        period: period,
+        declName: declName,
+        arena: self.arena
+      ).rawExprSyntax
     } else {
-      return RawExprSyntax(declName)
+      return declName.rawExprSyntax
     }
   }
 
   mutating func parseQualifiedTypeIdentifier() -> RawTypeSyntax {
     if self.at(.keyword(.Any)) {
-      return RawTypeSyntax(self.parseAnyType())
+      return self.parseAnyType().rawTypeSyntax
     }
 
     let (unexpectedBeforeName, name) = self.expect(anyIn: IdentifierTypeSyntax.NameOptions.self, default: .identifier)
@@ -199,14 +197,12 @@ extension Parser {
       generics = nil
     }
 
-    var result = RawTypeSyntax(
-      RawIdentifierTypeSyntax(
-        unexpectedBeforeName,
-        name: name,
-        genericArgumentClause: generics,
-        arena: self.arena
-      )
-    )
+    var result = RawIdentifierTypeSyntax(
+      unexpectedBeforeName,
+      name: name,
+      genericArgumentClause: generics,
+      arena: self.arena
+    ).rawTypeSyntax
 
     // If qualified name base type cannot be parsed from the current
     // point (i.e. the next type identifier is not followed by a '.'),
@@ -234,7 +230,7 @@ extension Parser {
       } else {
         generics = nil
       }
-      result = RawTypeSyntax(
+      result =
         RawMemberTypeSyntax(
           baseType: result,
           period: keepGoing!,
@@ -242,8 +238,7 @@ extension Parser {
           name: name,
           genericArgumentClause: generics,
           arena: self.arena
-        )
-      )
+        ).rawTypeSyntax
 
       // If qualified name base type cannot be parsed from the current
       // point (i.e. the next type identifier is not followed by a '.'),

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -297,12 +297,11 @@ extension Parser {
       repeat {
         let type: RawTypeSyntax
         if let classKeyword = self.consume(if: .keyword(.class)) {
-          type = RawTypeSyntax(
+          type =
             RawClassRestrictionTypeSyntax(
               classKeyword: classKeyword,
               arena: self.arena
-            )
-          )
+            ).rawTypeSyntax
         } else {
           type = self.parseType()
         }

--- a/Sources/SwiftParser/Parameters.swift
+++ b/Sources/SwiftParser/Parameters.swift
@@ -107,13 +107,12 @@ extension Parser {
       secondName.tokenText.isStartingWithUppercase
     {
       // Synthesize the secondName parameter as a type node.
-      type = RawTypeSyntax(
+      type =
         RawIdentifierTypeSyntax(
           name: secondName,
           genericArgumentClause: nil,
           arena: self.arena
-        )
-      )
+        ).rawTypeSyntax
       names = ParameterNames(
         unexpectedBeforeFirstName: names.unexpectedBeforeFirstName,
         firstName: names.firstName,
@@ -176,7 +175,7 @@ extension Parser {
     } else if colon != nil {
       // mark the type as missing if the preceding colon is present
       // e.g. (:) or (_:)
-      type = RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena))
+      type = RawMissingTypeSyntax(arena: self.arena).rawTypeSyntax
     } else {
       type = nil
     }
@@ -216,7 +215,7 @@ extension Parser {
       if colon!.isMissing {
         // If there was no colon, don't try to parse a type either so we are not
         // skipping over unrelated tokens trying to find a type during recvoery.
-        type = RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena))
+        type = RawMissingTypeSyntax(arena: self.arena).rawTypeSyntax
       } else {
         type = self.parseType(misplacedSpecifiers: misplacedSpecifiers)
       }

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -54,69 +54,57 @@ extension Parser {
       let lparen = self.eat(handle)
       let elements = self.parsePatternTupleElements()
       let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
-      return RawPatternSyntax(
-        RawTuplePatternSyntax(
-          leftParen: lparen,
-          elements: elements,
-          unexpectedBeforeRParen,
-          rightParen: rparen,
-          arena: self.arena
-        )
-      )
+      return RawTuplePatternSyntax(
+        leftParen: lparen,
+        elements: elements,
+        unexpectedBeforeRParen,
+        rightParen: rparen,
+        arena: self.arena
+      ).rawPatternSyntax
     case (.lhs(.wildcard), let handle)?:
       let wildcard = self.eat(handle)
-      return RawPatternSyntax(
-        RawWildcardPatternSyntax(
-          wildcard: wildcard,
-          arena: self.arena
-        )
-      )
+      return RawWildcardPatternSyntax(
+        wildcard: wildcard,
+        arena: self.arena
+      ).rawPatternSyntax
     case (.rhs(let introducer), let handle)?
     where self.withLookahead { $0.shouldParsePatternBinding(introducer: introducer) }:
       let bindingSpecifier = self.eat(handle)
       let value = self.parsePattern()
-      return RawPatternSyntax(
-        RawValueBindingPatternSyntax(
-          bindingSpecifier: bindingSpecifier,
-          pattern: value,
-          arena: self.arena
-        )
-      )
+      return RawValueBindingPatternSyntax(
+        bindingSpecifier: bindingSpecifier,
+        pattern: value,
+        arena: self.arena
+      ).rawPatternSyntax
     case (.lhs(.identifier), let handle)?,
       // If we shouldn't contextually parse a pattern binding introducer (because the previous pattern match guard failed), then parse it as an identifier.
       (.rhs(_), let handle)?:
       let identifier = self.eat(handle)
-      return RawPatternSyntax(
-        RawIdentifierPatternSyntax(
-          identifier: identifier,
-          arena: self.arena
-        )
-      )
+      return RawIdentifierPatternSyntax(
+        identifier: identifier,
+        arena: self.arena
+      ).rawPatternSyntax
     case (.lhs(.dollarIdentifier), let handle)?:
       let dollarIdent = self.eat(handle)
       let unexpectedBeforeIdentifier = RawUnexpectedNodesSyntax(elements: [RawSyntax(dollarIdent)], arena: self.arena)
-      return RawPatternSyntax(
-        RawIdentifierPatternSyntax(
-          unexpectedBeforeIdentifier,
-          identifier: missingToken(.identifier),
-          arena: self.arena
-        )
-      )
+      return RawIdentifierPatternSyntax(
+        unexpectedBeforeIdentifier,
+        identifier: missingToken(.identifier),
+        arena: self.arena
+      ).rawPatternSyntax
     case nil:
       break
     }
     if self.currentToken.isLexerClassifiedKeyword, !self.atStartOfLine {
       // Recover if a keyword was used instead of an identifier
       let keyword = self.consumeAnyToken()
-      return RawPatternSyntax(
-        RawIdentifierPatternSyntax(
-          RawUnexpectedNodesSyntax([keyword], arena: self.arena),
-          identifier: missingToken(.identifier),
-          arena: self.arena
-        )
-      )
+      return RawIdentifierPatternSyntax(
+        RawUnexpectedNodesSyntax([keyword], arena: self.arena),
+        identifier: missingToken(.identifier),
+        arena: self.arena
+      ).rawPatternSyntax
     } else {
-      return RawPatternSyntax(RawMissingPatternSyntax(arena: self.arena))
+      return RawMissingPatternSyntax(arena: self.arena).rawPatternSyntax
     }
   }
 
@@ -164,7 +152,7 @@ extension Parser {
             remainingTokens,
             label: nil,
             colon: nil,
-            pattern: RawPatternSyntax(RawMissingPatternSyntax(arena: self.arena)),
+            pattern: RawMissingPatternSyntax(arena: self.arena).rawPatternSyntax,
             trailingComma: nil,
             arena: self.arena
           )
@@ -222,24 +210,20 @@ extension Parser {
     case (.lhs(.is), let handle)?:
       let isKeyword = self.eat(handle)
       let type = self.parseType()
-      return RawPatternSyntax(
-        RawIsTypePatternSyntax(
-          isKeyword: isKeyword,
-          type: type,
-          arena: self.arena
-        )
-      )
+      return RawIsTypePatternSyntax(
+        isKeyword: isKeyword,
+        type: type,
+        arena: self.arena
+      ).rawPatternSyntax
     case (.rhs(let introducer), let handle)?
     where self.withLookahead { $0.shouldParsePatternBinding(introducer: introducer) }:
       let bindingSpecifier = self.eat(handle)
       let value = self.parseMatchingPattern(context: .bindingIntroducer)
-      return RawPatternSyntax(
-        RawValueBindingPatternSyntax(
-          bindingSpecifier: bindingSpecifier,
-          pattern: value,
-          arena: self.arena
-        )
-      )
+      return RawValueBindingPatternSyntax(
+        bindingSpecifier: bindingSpecifier,
+        pattern: value,
+        arena: self.arena
+      ).rawPatternSyntax
     case (.rhs(_), _)?,
       nil:
       break
@@ -255,10 +239,9 @@ extension Parser {
       //
       // FIXME: This is pretty gross. Let's find a way to disambiguate let
       // binding patterns much earlier.
-      return RawPatternSyntax(pat.pattern)
+      return pat.pattern
     }
-    let expr = RawExprSyntax(patternSyntax)
-    return RawPatternSyntax(RawExpressionPatternSyntax(expression: expr, arena: self.arena))
+    return RawExpressionPatternSyntax(expression: patternSyntax, arena: self.arena).rawPatternSyntax
   }
 }
 

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -137,7 +137,7 @@ extension Parser {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawCodeBlockItemSyntax(
         remainingTokens,
-        item: .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena))),
+        item: .expr(RawMissingExprSyntax(arena: self.arena).rawExprSyntax),
         semicolon: nil,
         arena: self.arena
       )
@@ -147,8 +147,8 @@ extension Parser {
       // Parse them and put them in their own CodeBlockItem but as an unexpected node.
       let switchCase = self.parseSwitchCase()
       return RawCodeBlockItemSyntax(
-        RawUnexpectedNodesSyntax(elements: [RawSyntax(switchCase)], arena: self.arena),
-        item: .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena))),
+        RawUnexpectedNodesSyntax(elements: [RawSyntax(switchCase.raw)], arena: self.arena),
+        item: .expr(RawMissingExprSyntax(arena: self.arena).rawExprSyntax),
         semicolon: nil,
         arena: self.arena
       )
@@ -192,16 +192,14 @@ extension Parser {
         let (op, rhs) = parseUnresolvedAsExpr(
           handle: .init(spec: .keyword(.as))
         )
-        let sequence = RawExprSyntax(
-          RawSequenceExprSyntax(
-            elements: RawExprListSyntax(
-              elements: [expr, op, rhs],
-              arena: self.arena
-            ),
+        let sequence = RawSequenceExprSyntax(
+          elements: RawExprListSyntax(
+            elements: [expr, op, rhs],
             arena: self.arena
-          )
+          ),
+          arena: self.arena
         )
-        return .expr(sequence)
+        return .expr(sequence.rawExprSyntax)
       }
     }
     return .stmt(stmt)
@@ -237,9 +235,9 @@ extension Parser {
       } syntax: { parser, items in
         return .statements(RawCodeBlockItemListSyntax(elements: items, arena: parser.arena))
       }
-      return .decl(RawDeclSyntax(directive))
+      return .decl(directive.rawDeclSyntax)
     } else if self.at(.poundSourceLocation) {
-      return .decl(RawDeclSyntax(self.parsePoundSourceLocationDirective()))
+      return .decl(self.parsePoundSourceLocationDirective().rawDeclSyntax)
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl) {
       return .decl(self.parseDeclaration())
     } else if self.atStartOfStatement(preferExpr: false) {
@@ -251,7 +249,7 @@ extension Parser {
     } else if self.atStartOfStatement(allowRecovery: true, preferExpr: false) {
       return self.parseStatementItem()
     } else {
-      return .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena)))
+      return .expr(RawMissingExprSyntax(arena: self.arena).rawExprSyntax)
     }
   }
 }

--- a/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
+++ b/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
@@ -371,13 +371,11 @@ fileprivate extension Parser {
       // which is just a placeholder here
       return RawCodeBlockItemSyntax(
         item: .decl(
-          RawDeclSyntax(
-            RawMissingDeclSyntax(
-              attributes: self.emptyCollection(RawAttributeListSyntax.self),
-              modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
-              arena: self.arena
-            )
-          )
+          RawMissingDeclSyntax(
+            attributes: self.emptyCollection(RawAttributeListSyntax.self),
+            modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
+            arena: self.arena
+          ).rawDeclSyntax
         ),
         semicolon: nil,
         arena: self.arena

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
@@ -13,7 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax)
-public protocol RawDeclSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
+public protocol RawDeclSyntaxNodeProtocol: RawSyntaxNodeProtocol {
+  /// Type erased raw decl syntax.
+  var rawDeclSyntax: RawDeclSyntax {
+    get
+  }
+}
+
+@_spi(RawSyntax)
+public extension RawDeclSyntaxNodeProtocol {
+  @inline(__always)
+  var rawDeclSyntax: RawDeclSyntax {
+    RawDeclSyntax(self)
+  }
+}
 
 @_spi(RawSyntax)
 public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol {
@@ -525,6 +538,12 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
   
   public init(_ other: some RawDeclSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
+  }
+  
+  /// Optimization if this witness is a base type other than `RawSyntax` and `RawSyntaxCollection`.
+  @inline(__always)
+  public var rawDeclSyntax: RawDeclSyntax {
+    self
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesEF.swift
@@ -13,7 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax)
-public protocol RawExprSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
+public protocol RawExprSyntaxNodeProtocol: RawSyntaxNodeProtocol {
+  /// Type erased raw expr syntax.
+  var rawExprSyntax: RawExprSyntax {
+    get
+  }
+}
+
+@_spi(RawSyntax)
+public extension RawExprSyntaxNodeProtocol {
+  @inline(__always)
+  var rawExprSyntax: RawExprSyntax {
+    RawExprSyntax(self)
+  }
+}
 
 @_spi(RawSyntax)
 public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
@@ -1015,6 +1028,12 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol {
   
   public init(_ other: some RawExprSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
+  }
+  
+  /// Optimization if this witness is a base type other than `RawSyntax` and `RawSyntaxCollection`.
+  @inline(__always)
+  public var rawExprSyntax: RawExprSyntax {
+    self
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesOP.swift
@@ -13,7 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax)
-public protocol RawPatternSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
+public protocol RawPatternSyntaxNodeProtocol: RawSyntaxNodeProtocol {
+  /// Type erased raw pattern syntax.
+  var rawPatternSyntax: RawPatternSyntax {
+    get
+  }
+}
+
+@_spi(RawSyntax)
+public extension RawPatternSyntaxNodeProtocol {
+  @inline(__always)
+  var rawPatternSyntax: RawPatternSyntax {
+    RawPatternSyntax(self)
+  }
+}
 
 @_spi(RawSyntax)
 public struct RawObjCSelectorPieceListSyntax: RawSyntaxNodeProtocol {
@@ -1263,6 +1276,12 @@ public struct RawPatternSyntax: RawPatternSyntaxNodeProtocol {
   
   public init(_ other: some RawPatternSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
+  }
+  
+  /// Optimization if this witness is a base type other than `RawSyntax` and `RawSyntaxCollection`.
+  @inline(__always)
+  public var rawPatternSyntax: RawPatternSyntax {
+    self
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
@@ -13,7 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax)
-public protocol RawStmtSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
+public protocol RawStmtSyntaxNodeProtocol: RawSyntaxNodeProtocol {
+  /// Type erased raw stmt syntax.
+  var rawStmtSyntax: RawStmtSyntax {
+    get
+  }
+}
+
+@_spi(RawSyntax)
+public extension RawStmtSyntaxNodeProtocol {
+  @inline(__always)
+  var rawStmtSyntax: RawStmtSyntax {
+    RawStmtSyntax(self)
+  }
+}
 
 @_spi(RawSyntax)
 public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol {
@@ -1155,6 +1168,12 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
   
   public init(_ other: some RawStmtSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
+  }
+  
+  /// Optimization if this witness is a base type other than `RawSyntax` and `RawSyntaxCollection`.
+  @inline(__always)
+  public var rawStmtSyntax: RawStmtSyntax {
+    self
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
@@ -13,7 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax)
-public protocol RawTypeSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
+public protocol RawTypeSyntaxNodeProtocol: RawSyntaxNodeProtocol {
+  /// Type erased raw type syntax.
+  var rawTypeSyntax: RawTypeSyntax {
+    get
+  }
+}
+
+@_spi(RawSyntax)
+public extension RawTypeSyntaxNodeProtocol {
+  @inline(__always)
+  var rawTypeSyntax: RawTypeSyntax {
+    RawTypeSyntax(self)
+  }
+}
 
 @_spi(RawSyntax)
 public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
@@ -1524,6 +1537,12 @@ public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol {
   
   public init(_ other: some RawTypeSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
+  }
+  
+  /// Optimization if this witness is a base type other than `RawSyntax` and `RawSyntaxCollection`.
+  @inline(__always)
+  public var rawTypeSyntax: RawTypeSyntax {
+    self
   }
 }
 


### PR DESCRIPTION
### Overview

This PR aims to improve developer ergonomics when performing type erasure with `RawXXX<Kind>Syntax` nodes. In short, a convenience property `raw<Kind>Expr` will be added to all conforming types of `Raw<Kind>SyntaxNodeProtocol` where `<Kind>` is one of `Decl`, `Expr`, `Stmt` or `Pattern`.

For example, 
```swift
public protocol RawDeclSyntaxNodeProtocol: RawSyntaxNodeProtocol {
  var rawDeclSyntax: RawDeclSyntax {
    get
  }
}

public extension RawDeclSyntaxNodeProtocol {
  @inline(__always)
  var rawDeclSyntax: RawDeclSyntax {
    RawDeclSyntax(self)
  }
}
```

Instead of wrapping a subtype with the constructor of its type-erased base type,
```swift
RawDeclSyntax(RawMissingDeclSyntax(arena: arena))
```
we may now use the convenience property `rawDeclSyntax`.
```swift
RawMissingDeclSyntax(arena: arena).rawDeclSyntax
```

### Rationale

This PR seems to be at odds with the established idiom of directly wrapping a subtype with the constructor of its type-erased base type for upcasting. Despite this, I'd like to argue with the following points,

#### Existing usage of `.raw`
In the codebase, it's not uncommon to see `.raw` be used instead of `RawSyntax.init` when it comes to type-erasure even outside generated code. 

#### Readability
Maybe it's only my preference, but I'd contend that the current idiom has somewhat increased the noise-to-information ratio as `RawExprSyntax` shouldn't be the focus here but it definitely has caught my attention (or distraction one might consider?),
```swift
RawExprSyntax(
  RawTryExprSyntax(
    tryKeyword: tryKeyword,
    questionOrExclamationMark: mark,
    expression: expression,
    arena: self.arena
  )
)
```
Arguably the following usage would better emphasize `RawTryExprSyntax` than the one above,
```swift
RawTryExprSyntax(
  tryKeyword: tryKeyword,
  questionOrExclamationMark: mark,
  expression: expression,
  arena: self.arena
).rawExprSyntax
```
In highly nested code, the use of `.rawExprSyntax` would also help control nesting levels.

#### Composability
Appending/trimming `.rawExprSyntax` would be easier than wrapping/unwrapping a `RawExprSyntax(...)` when one would like to opt in/out of type erasure. I'd also argue that `someOptionalExpr.map(\.rawExprSyntax)` would be less unwieldy than `someOptionalExpr.map(RawExprSyntax.init)`.

### Performance Regression
By always inlining the convenience properties, there has been no observable performance regression in terms of instruction count after the change. The binary size of `swift-parser-cli` has increased by a tiny margin, possibly due to the new protocol requirements.

### Alternative Approaches
In a prior PR, I'd replaced the occurrences of `Raw<Kind>Syntax` with `some Raw<Kind>SyntaxNodeProtocol` in function signatures and got rid of the use of type erasure in most call sites. This had resulted in a performance regression of ~0.1% increase in instruction count.