### PR TITLE
Address more code-review comments on the SwiftIfConfig library

### DIFF
--- a/Sources/SwiftIfConfig/CMakeLists.txt
+++ b/Sources/SwiftIfConfig/CMakeLists.txt
@@ -13,7 +13,7 @@ add_swift_syntax_library(SwiftIfConfig
   ConfiguredRegions.swift
   IfConfigRegionState.swift
   IfConfigDecl+IfConfig.swift
-  IfConfigError.swift
+  IfConfigDiagnostic.swift
   IfConfigEvaluation.swift
   IfConfigFunctions.swift
   SyntaxLiteralUtils.swift

--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -60,10 +60,8 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
     case .emptyVersionComponent(syntax: _):
       return "found empty version component"
 
-    case .compilerVersionOutOfRange(value: _, upperLimit: let upperLimit, syntax: _):
-      // FIXME: This matches the C++ implementation, but it would be more useful to
-      // provide the actual value as-written and avoid the mathy [0, N] syntax.
-      return "compiler version component out of range: must be in [0, \(upperLimit)]"
+    case .compilerVersionOutOfRange(value: let value, upperLimit: let upperLimit, syntax: _):
+      return "compiler version component '\(value)' is not in the allowed range 0...\(upperLimit)"
 
     case .compilerVersionSecondComponentNotWildcard(syntax: _):
       return "the second version component is not used for comparison in legacy compiler versions"

--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -14,8 +14,11 @@ import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-/// Describes the kinds of errors that can occur when processing #if conditions.
-enum IfConfigError: Error, CustomStringConvertible {
+/// Describes the kinds of diagnostics that can occur when processing #if
+/// conditions. This is an Error-conforming type so we can throw errors when
+/// needed, but the cases themselves are a mix of warnings and errors when
+/// rendered as a diagnostic.
+enum IfConfigDiagnostic: Error, CustomStringConvertible {
   case unknownExpression(ExprSyntax)
   case unhandledFunction(name: String, syntax: ExprSyntax)
   case requiresUnlabeledArgument(name: String, role: String, syntax: ExprSyntax)
@@ -134,11 +137,11 @@ enum IfConfigError: Error, CustomStringConvertible {
   }
 }
 
-extension IfConfigError: DiagnosticMessage {
+extension IfConfigDiagnostic: DiagnosticMessage {
   var message: String { description }
 
   var diagnosticID: MessageID {
-    .init(domain: "SwiftIfConfig", id: "IfConfigError")
+    .init(domain: "SwiftIfConfig", id: "IfConfigDiagnostic")
   }
 
   var severity: SwiftDiagnostics.DiagnosticSeverity {

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -610,7 +610,7 @@ extension IfConfigClauseSyntax {
   /// Fold the operators within an #if condition, turning sequence expressions
   /// involving the various allowed operators (&&, ||, !) into well-structured
   /// binary operators.
-  public static func foldOperators(
+  static func foldOperators(
     _ condition: some ExprSyntaxProtocol
   ) -> (folded: ExprSyntax, diagnostics: [Diagnostic]) {
     var foldingDiagnostics: [Diagnostic] = []
@@ -635,7 +635,7 @@ extension IfConfigClauseSyntax {
   /// Determine whether the given expression, when used as the condition in
   /// an inactive `#if` clause, implies that syntax errors are permitted within
   /// that region.
-  public static func syntaxErrorsAllowed(
+  static func syntaxErrorsAllowed(
     _ condition: some ExprSyntaxProtocol
   ) -> (syntaxErrorsAllowed: Bool, diagnostics: [Diagnostic]) {
     let (foldedCondition, foldingDiagnostics) = IfConfigClauseSyntax.foldOperators(condition)

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -97,7 +97,7 @@ func evaluateIfConfig(
 
   // Declaration references are for custom compilation flags.
   if let identExpr = condition.as(DeclReferenceExprSyntax.self),
-    let ident = identExpr.simpleIdentifier
+    let ident = identExpr.simpleIdentifier?.name
   {
     // Evaluate the custom condition. If the build configuration cannot answer this query, fail.
     return checkConfiguration(at: identExpr) {
@@ -214,7 +214,7 @@ func evaluateIfConfig(
 
   // Call syntax is for operations.
   if let call = condition.as(FunctionCallExprSyntax.self),
-    let fnName = call.calledExpression.simpleIdentifierExpr,
+    let fnName = call.calledExpression.simpleIdentifierExpr?.name,
     let fn = IfConfigFunctions(rawValue: fnName)
   {
     /// Perform a check for an operation that takes a single identifier argument.
@@ -224,7 +224,7 @@ func evaluateIfConfig(
     ) -> (active: Bool, syntaxErrorsAllowed: Bool, diagnostics: [Diagnostic]) {
       // Ensure that we have a single argument that is a simple identifier.
       guard let argExpr = call.arguments.singleUnlabeledExpression,
-        var arg = argExpr.simpleIdentifierExpr
+        var arg = argExpr.simpleIdentifierExpr?.name
       else {
         return recordError(
           .requiresUnlabeledArgument(name: fnName, role: role, syntax: ExprSyntax(call))
@@ -316,7 +316,7 @@ func evaluateIfConfig(
     case ._endian:
       // Ensure that we have a single argument that is a simple identifier.
       guard let argExpr = call.arguments.singleUnlabeledExpression,
-        let arg = argExpr.simpleIdentifierExpr
+        let arg = argExpr.simpleIdentifierExpr?.name
       else {
         return recordError(
           .requiresUnlabeledArgument(
@@ -352,7 +352,7 @@ func evaluateIfConfig(
       // Ensure that we have a single argument that is a simple identifier, which
       // is an underscore followed by an integer.
       guard let argExpr = call.arguments.singleUnlabeledExpression,
-        let arg = argExpr.simpleIdentifierExpr,
+        let arg = argExpr.simpleIdentifierExpr?.name,
         let argFirst = arg.first,
         argFirst == "_",
         let expectedBitWidth = Int(arg.dropFirst())
@@ -530,14 +530,14 @@ private func extractImportPath(_ expression: some ExprSyntaxProtocol) throws -> 
   // Member access.
   if let memberAccess = expression.as(MemberAccessExprSyntax.self),
     let base = memberAccess.base,
-    let memberName = memberAccess.declName.simpleIdentifier
+    let memberName = memberAccess.declName.simpleIdentifier?.name
   {
     return try extractImportPath(base) + [memberName]
   }
 
   // Declaration reference.
   if let declRef = expression.as(DeclReferenceExprSyntax.self),
-    let name = declRef.simpleIdentifier
+    let name = declRef.simpleIdentifier?.name
   {
     return [name]
   }
@@ -574,11 +574,11 @@ private func isConditionDisjunction(
   // If we have a call to this function, check whether the argument is one of
   // the acceptable values.
   if let call = condition.as(FunctionCallExprSyntax.self),
-    let fnName = call.calledExpression.simpleIdentifierExpr,
+    let fnName = call.calledExpression.simpleIdentifierExpr?.name,
     let callFn = IfConfigFunctions(rawValue: fnName),
     callFn == function,
     let argExpr = call.arguments.singleUnlabeledExpression,
-    let arg = argExpr.simpleIdentifierExpr
+    let arg = argExpr.simpleIdentifierExpr?.name
   {
     return values.contains(arg)
   }
@@ -705,7 +705,7 @@ extension ExprSyntaxProtocol {
 
     // Call syntax is for operations.
     if let call = self.as(FunctionCallExprSyntax.self),
-      let fnName = call.calledExpression.simpleIdentifierExpr,
+      let fnName = call.calledExpression.simpleIdentifierExpr?.name,
       let fn = IfConfigFunctions(rawValue: fnName)
     {
       return fn.syntaxErrorsAllowed

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -49,7 +49,7 @@ func evaluateIfConfig(
   /// Record an if-config evaluation error before returning it. Use this for
   /// every 'throw' site in this evaluation.
   func recordError(
-    _ error: IfConfigError
+    _ error: IfConfigDiagnostic
   ) -> (active: Bool, syntaxErrorsAllowed: Bool, diagnostics: [Diagnostic]) {
     return recordError(error, at: error.syntax)
   }
@@ -87,7 +87,7 @@ func evaluateIfConfig(
       active: result,
       syntaxErrorsAllowed: false,
       diagnostics: [
-        IfConfigError.integerLiteralCondition(
+        IfConfigDiagnostic.integerLiteralCondition(
           syntax: condition,
           replacement: result
         ).asDiagnostic
@@ -234,7 +234,7 @@ func evaluateIfConfig(
       // The historical "macabi" environment has been renamed to "macCatalyst".
       if role == "environment" && arg == "macabi" {
         extraDiagnostics.append(
-          IfConfigError.macabiIsMacCatalyst(syntax: argExpr)
+          IfConfigDiagnostic.macabiIsMacCatalyst(syntax: argExpr)
             .asDiagnostic
         )
 
@@ -335,7 +335,7 @@ func evaluateIfConfig(
       } else {
         // Complain about unknown endianness
         extraDiagnostics.append(
-          IfConfigError.endiannessDoesNotMatch(syntax: argExpr, argument: arg)
+          IfConfigDiagnostic.endiannessDoesNotMatch(syntax: argExpr, argument: arg)
             .asDiagnostic
         )
 
@@ -466,7 +466,7 @@ func evaluateIfConfig(
 
           // Warn that we did this.
           extraDiagnostics.append(
-            IfConfigError.ignoredTrailingComponents(
+            IfConfigDiagnostic.ignoredTrailingComponents(
               version: versionTuple,
               syntax: secondArg.expression
             ).asDiagnostic
@@ -542,7 +542,7 @@ private func extractImportPath(_ expression: some ExprSyntaxProtocol) throws -> 
     return [name]
   }
 
-  throw IfConfigError.expectedModuleName(syntax: ExprSyntax(expression))
+  throw IfConfigDiagnostic.expectedModuleName(syntax: ExprSyntax(expression))
 }
 
 /// Determine whether the given condition only involves disjunctions that
@@ -624,7 +624,7 @@ private func diagnoseLikelySimulatorEnvironmentTest(
     return nil
   }
 
-  return IfConfigError.likelySimulatorPlatform(syntax: ExprSyntax(binOp)).asDiagnostic
+  return IfConfigDiagnostic.likelySimulatorPlatform(syntax: ExprSyntax(binOp)).asDiagnostic
 }
 
 extension IfConfigClauseSyntax {
@@ -643,7 +643,7 @@ extension IfConfigClauseSyntax {
       {
 
         foldingDiagnostics.append(
-          IfConfigError.badInfixOperator(syntax: ExprSyntax(binOp)).asDiagnostic
+          IfConfigDiagnostic.badInfixOperator(syntax: ExprSyntax(binOp)).asDiagnostic
         )
         return
       }

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -146,9 +146,9 @@ func evaluateIfConfig(
       outermostCondition: false
     )
 
-    // Short-circuit evaluation if we know the answer. We still recurse into
-    // the right-hand side, but with a dummy configuration that won't have
-    // side effects, so we only get validation-related errors.
+    // Determine whether we already know the result. We might short-circuit the
+    // evaluation, depending on whether we need to produce validation
+    // diagnostics for the right-hand side.
     let shortCircuitResult: Bool?
     switch (lhsActive, op.operator.text) {
     case (true, "||"): shortCircuitResult = true
@@ -157,8 +157,8 @@ func evaluateIfConfig(
     }
 
     // If we are supposed to short-circuit and the left-hand side of this
-    // operator with inactive &&, stop now: we shouldn't evaluate the right-
-    // hand side at all.
+    // operator permits syntax errors when it fails, stop now: we shouldn't
+    // process the right-hand side at all.
     if let isActive = shortCircuitResult, lhsSyntaxErrorsAllowed {
       return (
         active: isActive,
@@ -167,7 +167,9 @@ func evaluateIfConfig(
       )
     }
 
-    // Evaluate the right-hand side.
+    // Process the right-hand side. If we already know the answer, then
+    // avoid performing any build configuration queries that might cause
+    // side effects.
     let rhsActive: Bool
     let rhsSyntaxErrorsAllowed: Bool
     let rhsDiagnostics: [Diagnostic]

--- a/Sources/SwiftIfConfig/SyntaxLiteralUtils.swift
+++ b/Sources/SwiftIfConfig/SyntaxLiteralUtils.swift
@@ -35,7 +35,7 @@ extension LabeledExprListSyntax {
 
 extension ExprSyntax {
   /// Whether this is a simple identifier expression and, if so, what the identifier string is.
-  var simpleIdentifierExpr: String? {
+  var simpleIdentifierExpr: Identifier? {
     guard let identExpr = self.as(DeclReferenceExprSyntax.self) else {
       return nil
     }
@@ -47,12 +47,11 @@ extension ExprSyntax {
 extension DeclReferenceExprSyntax {
   /// If this declaration reference is a simple identifier, return that
   /// string.
-  var simpleIdentifier: String? {
+  var simpleIdentifier: Identifier? {
     guard argumentNames == nil else {
       return nil
     }
 
-    /// FIXME: Make this an Identifier so we handle escaping properly.
-    return baseName.text
+    return baseName.identifier
   }
 }

--- a/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
+++ b/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
@@ -58,7 +58,7 @@ extension VersionTuple {
     func recordComponent(_ value: Int) throws {
       let limit = components.isEmpty ? 9223371 : 999
       if value < 0 || value > limit {
-        throw IfConfigError.compilerVersionOutOfRange(value: value, upperLimit: limit, syntax: versionSyntax)
+        throw IfConfigDiagnostic.compilerVersionOutOfRange(value: value, upperLimit: limit, syntax: versionSyntax)
       }
 
       components.append(value)
@@ -68,14 +68,14 @@ extension VersionTuple {
     for (index, componentString) in componentStrings.enumerated() {
       // Check ahead of time for empty version components
       if componentString.isEmpty {
-        throw IfConfigError.emptyVersionComponent(syntax: versionSyntax)
+        throw IfConfigDiagnostic.emptyVersionComponent(syntax: versionSyntax)
       }
 
       // The second component is always "*", and is never used for comparison.
       if index == 1 {
         if componentString != "*" {
           extraDiagnostics.append(
-            IfConfigError.compilerVersionSecondComponentNotWildcard(syntax: versionSyntax).asDiagnostic
+            IfConfigDiagnostic.compilerVersionSecondComponentNotWildcard(syntax: versionSyntax).asDiagnostic
           )
         }
         try recordComponent(0)
@@ -84,7 +84,7 @@ extension VersionTuple {
 
       // Every other component must be an integer value.
       guard let component = Int(componentString) else {
-        throw IfConfigError.invalidVersionOperand(name: "_compiler_version", syntax: versionSyntax)
+        throw IfConfigDiagnostic.invalidVersionOperand(name: "_compiler_version", syntax: versionSyntax)
       }
 
       try recordComponent(component)
@@ -92,7 +92,7 @@ extension VersionTuple {
 
     // Only allowed to specify up to 5 version components.
     if components.count > 5 {
-      throw IfConfigError.compilerVersionTooManyComponents(syntax: versionSyntax)
+      throw IfConfigDiagnostic.compilerVersionTooManyComponents(syntax: versionSyntax)
     }
 
     // In the beginning, '_compiler_version(string-literal)' was designed for a

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -323,6 +323,19 @@ public class EvaluateTests: XCTestCase {
         )
       ]
     )
+
+    assertIfConfig(
+      #"_compiler_version("5009.*.1000")"#,
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "compiler version component '1000' is not in the allowed range 0...999",
+          line: 1,
+          column: 20,
+          severity: .error
+        )
+      ]
+    )
   }
 
   func testCanImport() throws {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -71,7 +71,7 @@ public class EvaluateTests: XCTestCase {
   }
 
   func testCustomConfigs() throws {
-    let buildConfig = TestingBuildConfiguration(customConditions: ["DEBUG", "ASSERTS"])
+    let buildConfig = TestingBuildConfiguration(customConditions: ["DEBUG", "ASSERTS", "try"])
 
     assertIfConfig("DEBUG", .active, configuration: buildConfig)
     assertIfConfig("NODEBUG", .inactive, configuration: buildConfig)
@@ -80,6 +80,8 @@ public class EvaluateTests: XCTestCase {
     assertIfConfig("DEBUG && ASSERTS", .active, configuration: buildConfig)
     assertIfConfig("DEBUG && nope", .inactive, configuration: buildConfig)
     assertIfConfig("nope && DEBUG", .inactive, configuration: buildConfig)
+    assertIfConfig("`try`", .active, configuration: buildConfig)
+    assertIfConfig("`return`", .inactive, configuration: buildConfig)
     assertIfConfig(
       "nope && 3.14159",
       .unparsed,


### PR DESCRIPTION
A number of small cleanups to the implementation of `SwiftIfConfig` that came up in code review:
* Make `foldOperators` and `syntaxErrorsAllowed` internal; we don't want them as part of the public API just now.
* Improve comments about short-circuit evaluation, which has some... interesting... semantics to match the compiler.
* Eliminate the `outermostCondition` parameter for the core `#if` evaluation operation.
* Rename `IfConfigError` -> `IfConfigDiagnostic`.
* Handle back-ticked identifiers properly.
* Improve a diagnostic for compiler version number parsing.

SwiftIfConfig is now FIXME-free