### PR TITLE
Add support for parsing and emitting diagnostics for #if defined(...)

### DIFF
--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -313,6 +313,19 @@ func evaluateIfConfig(
         role: "pointer authentication scheme"
       )
 
+    case .defined:
+      guard let argExpr = call.arguments.singleUnlabeledExpression,
+        let arg = argExpr.simpleIdentifierExpr?.name
+      else {
+        return recordError(.unknownExpression(condition))
+      }
+      extraDiagnostics.append(
+        IfConfigDiagnostic.unexpectedDefined(syntax: condition, argument: arg).asDiagnostic
+      )
+      return checkConfiguration(at: condition) {
+        (active: try configuration.isCustomConditionSet(name: arg), syntaxErrorsAllowed: false)
+      }
+
     case ._endian:
       // Ensure that we have a single argument that is a simple identifier.
       guard let argExpr = call.arguments.singleUnlabeledExpression,

--- a/Sources/SwiftIfConfig/IfConfigFunctions.swift
+++ b/Sources/SwiftIfConfig/IfConfigFunctions.swift
@@ -57,6 +57,9 @@ enum IfConfigFunctions: String {
   /// via `_ptrauth(<name>)`.
   case _ptrauth
 
+  /// An unsupported function used by C preprocessor macros (e.g. `#if defined(FOO)`)
+  case defined
+
   /// Whether uses of this function consitutes a check that guards new syntax.
   /// When such a check fails, the compiler should not diagnose syntax errors
   /// within the covered block.
@@ -66,7 +69,7 @@ enum IfConfigFunctions: String {
       return true
 
     case .hasAttribute, .hasFeature, .canImport, .os, .arch, .targetEnvironment,
-      ._hasAtomicBitWidth, ._endian, ._pointerBitWidth, ._runtime, ._ptrauth:
+      ._hasAtomicBitWidth, ._endian, ._pointerBitWidth, ._runtime, ._ptrauth, .defined:
       return false
     }
   }

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -457,6 +457,69 @@ public class EvaluateTests: XCTestCase {
       .inactive
     )
   }
+
+  func testDefined() throws {
+    let message =
+      "compilation conditions in Swift are always boolean and do not need to be checked for existence with 'defined()'"
+
+    assertIfConfig(
+      "defined(FOO)",
+      .active,
+      configuration: TestingBuildConfiguration(customConditions: ["FOO"]),
+      diagnostics: [
+        DiagnosticSpec(
+          message: message,
+          line: 1,
+          column: 1,
+          severity: .error,
+          fixIts: [
+            FixItSpec(message: "remove 'defined()'")
+          ]
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "defined(FOO)",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: message,
+          line: 1,
+          column: 1,
+          severity: .error,
+          fixIts: [
+            FixItSpec(message: "remove 'defined()'")
+          ]
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "defined(FOO) || BAR || defined(BAZ)",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: message,
+          line: 1,
+          column: 1,
+          severity: .error,
+          fixIts: [
+            FixItSpec(message: "remove 'defined()'")
+          ]
+        ),
+        DiagnosticSpec(
+          message: message,
+          line: 1,
+          column: 24,
+          severity: .error,
+          fixIts: [
+            FixItSpec(message: "remove 'defined()'")
+          ]
+        ),
+      ]
+    )
+  }
 }
 
 /// Assert the results of evaluating the condition within an `#if` against the


### PR DESCRIPTION
SwiftIfConfig now supports parsing `defined(FOO)` and interpreting it as just `FOO` for the purposes of active/inactive evaluation. All uses of `defined()` will produce an error with a fix-it that removes the `defined()` call and replaces it with its argument.

This produces a much clearer error message than the current version of Swift. It also un-suppresses syntax errors from the contents of the `#if` block.

```swift
#if defined(FOO)
// before: error: Unexpected platform condition (expected 'os', 'arch', or 'swift')
// after:  error: compilation conditions in Swift are always boolean and do not need to be checked for existence with 'defined()'
//         fix-it: remove 'defined()'
```