### PR TITLE
Add a warning for TARGET_OS_* compilation conditions

### DIFF
--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -34,6 +34,7 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
   case ignoredTrailingComponents(version: VersionTuple, syntax: ExprSyntax)
   case integerLiteralCondition(syntax: ExprSyntax, replacement: Bool)
   case likelySimulatorPlatform(syntax: ExprSyntax)
+  case likelyTargetOS(syntax: ExprSyntax, replacement: ExprSyntax?)
   case endiannessDoesNotMatch(syntax: ExprSyntax, argument: String)
   case macabiIsMacCatalyst(syntax: ExprSyntax)
   case expectedModuleName(syntax: ExprSyntax)
@@ -88,6 +89,12 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
       return
         "platform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead"
 
+    case .likelyTargetOS(syntax: _, replacement: let replacement?):
+      return "'TARGET_OS_*' preprocessor macros are not available in Swift; use '\(replacement)' instead"
+
+    case .likelyTargetOS(syntax: _, replacement: nil):
+      return "'TARGET_OS_*' preprocessor macros are not available in Swift; use 'os(...)' conditionals instead"
+
     case .macabiIsMacCatalyst:
       return "'macabi' has been renamed to 'macCatalyst'"
 
@@ -122,6 +129,7 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
       .ignoredTrailingComponents(version: _, syntax: let syntax),
       .integerLiteralCondition(syntax: let syntax, replacement: _),
       .likelySimulatorPlatform(syntax: let syntax),
+      .likelyTargetOS(syntax: let syntax, replacement: _),
       .endiannessDoesNotMatch(syntax: let syntax, argument: _),
       .macabiIsMacCatalyst(syntax: let syntax),
       .expectedModuleName(syntax: let syntax),
@@ -145,7 +153,7 @@ extension IfConfigDiagnostic: DiagnosticMessage {
   var severity: SwiftDiagnostics.DiagnosticSeverity {
     switch self {
     case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents,
-      .likelySimulatorPlatform, .endiannessDoesNotMatch, .macabiIsMacCatalyst:
+      .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch, .macabiIsMacCatalyst:
       return .warning
     default: return .error
     }
@@ -188,6 +196,21 @@ extension IfConfigDiagnostic: DiagnosticMessage {
           ),
           oldNode: syntax,
           newNode: "targetEnvironment(simulator)" as ExprSyntax
+        )
+      )
+    }
+
+    // For the likely TARGET_OS_* condition we may have a Fix-It.
+    if case .likelyTargetOS(let syntax, let replacement?) = self {
+      return Diagnostic(
+        node: syntax,
+        message: self,
+        fixIt: .replace(
+          message: SimpleFixItMessage(
+            message: "replace with '\(replacement)'"
+          ),
+          oldNode: syntax,
+          newNode: replacement
         )
       )
     }

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -656,29 +656,23 @@ private func diagnoseLikelyTargetOSTest(
     return IfConfigDiagnostic.likelyTargetOS(syntax: ExprSyntax(reference), replacement: nil).asDiagnostic
   }
 
-  guard let (function, argument) = targetOSNameMap[osName] else { return nil }
-  let replacement = FunctionCallExprSyntax(callee: DeclReferenceExprSyntax(baseName: .identifier(function))) {
-    LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: .identifier(argument)))
-  }
+  guard let replacement = targetOSNameMap[osName] else { return nil }
 
-  return IfConfigDiagnostic.likelyTargetOS(
-    syntax: ExprSyntax(reference),
-    replacement: ExprSyntax(replacement)
-  ).asDiagnostic
+  return IfConfigDiagnostic.likelyTargetOS(syntax: ExprSyntax(reference), replacement: replacement).asDiagnostic
 }
 
 // TARGET_OS_* macros that don’t have a direct Swift equivalent
 private let unmappedTargetOSNames = ["WIN32", "UNIX", "MAC", "IPHONE", "EMBEDDED"]
-private let targetOSNameMap: [String: (function: String, argument: String)] = [
-  "WINDOWS": ("os", "Windows"),
-  "LINUX": ("os", "Linux"),
-  "OSX": ("os", "macOS"),
-  "IOS": ("os", "iOS"),
-  "MACCATALYST": ("targetEnvironment", "macCatalyst"),
-  "TV": ("os", "tvOS"),
-  "WATCH": ("os", "watchOS"),
-  "VISION": ("os", "visionOS"),
-  "SIMULATOR": ("targetEnvironment", "simulator"),
+private let targetOSNameMap: [String: ExprSyntax] = [
+  "WINDOWS": "os(Windows)",
+  "LINUX": "os(Linux)",
+  "OSX": "os(macOS)",
+  "IOS": "os(iOS)",
+  "MACCATALYST": "targetEnvironment(macCatalyst)",
+  "TV": "os(tvOS)",
+  "WATCH": "os(watchOS)",
+  "VISION": "os(visionOS)",
+  "SIMULATOR": "targetEnvironment(simulator)",
 ]
 
 extension IfConfigClauseSyntax {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -239,6 +239,71 @@ public class EvaluateTests: XCTestCase {
     )
   }
 
+  func testTargetOS() throws {
+    assertIfConfig("TARGET_OS_DISHWASHER", .inactive)
+
+    assertIfConfig(
+      "TARGET_OS_IOS",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'TARGET_OS_*' preprocessor macros are not available in Swift; use 'os(iOS)' instead",
+          line: 1,
+          column: 1,
+          severity: .warning,
+          fixIts: [
+            FixItSpec(message: "replace with 'os(iOS)'")
+          ]
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "TARGET_OS_OSX",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'TARGET_OS_*' preprocessor macros are not available in Swift; use 'os(macOS)' instead",
+          line: 1,
+          column: 1,
+          severity: .warning,
+          fixIts: [
+            FixItSpec(message: "replace with 'os(macOS)'")
+          ]
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "TARGET_OS_MACCATALYST",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'TARGET_OS_*' preprocessor macros are not available in Swift; use 'targetEnvironment(macCatalyst)' instead",
+          line: 1,
+          column: 1,
+          severity: .warning,
+          fixIts: [
+            FixItSpec(message: "replace with 'targetEnvironment(macCatalyst)'")
+          ]
+        )
+      ]
+    )
+
+    assertIfConfig(
+      "TARGET_OS_WIN32",
+      .inactive,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'TARGET_OS_*' preprocessor macros are not available in Swift; use 'os(...)' conditionals instead",
+          line: 1,
+          column: 1,
+          severity: .warning
+        )
+      ]
+    )
+  }
+
   func testVersions() throws {
     assertIfConfig("swift(>=5.5)", .active)
     assertIfConfig("swift(<6)", .active)

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -279,7 +279,8 @@ public class EvaluateTests: XCTestCase {
       .inactive,
       diagnostics: [
         DiagnosticSpec(
-          message: "'TARGET_OS_*' preprocessor macros are not available in Swift; use 'targetEnvironment(macCatalyst)' instead",
+          message:
+            "'TARGET_OS_*' preprocessor macros are not available in Swift; use 'targetEnvironment(macCatalyst)' instead",
           line: 1,
           column: 1,
           severity: .warning,


### PR DESCRIPTION
This helps people avoid silent mistakes when migrating from Objective-C:

```swift
#if TARGET_OS_IOS
//  ^ warning: 'TARGET_OS_*' preprocessor macros are not available in Swift; use 'os(iOS)' instead
//  ^ fix-it: replace with 'os(iOS)'
print("I will never be executed, even on iOS!")
#endif
```