### PR TITLE
Parse @_specialize with a complete availability clause

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -730,7 +730,7 @@ extension Parser {
       case (.availability, let handle)?:
         let label = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
-        let availability = self.parseAvailabilitySpecList()
+        let availability = self.parseAvailabilityArgumentSpecList()
         let (unexpectedBeforeSemi, semi) = self.expect(.semicolon)
         elements.append(
           .specializeAvailabilityArgument(

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -143,6 +143,15 @@ final class AttributeTests: ParserTestCase {
     )
   }
 
+  func testSpecializeWithAvailability() {
+    assertParse(
+      """
+      @_specialize(exported: true, kind: full, availability: iOS, introduced: 15.4; where T == Swift.Int)
+      public func specializeWithAvailability<T>(_ t: T) { }
+      """
+    )
+  }
+
   func testObjCAttribute() {
     assertParse(
       """


### PR DESCRIPTION
`@_specialize` can also use the form of the availability clause that separates the platform name from the `introduced:` argument label. Parse this more general form.