### PR TITLE
Remove unnecessary operators.

### DIFF
--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -245,24 +245,6 @@ extension UInt8 {
 }
 
 /// Allows direct comparisons between UInt8 and double quoted literals.
-extension UInt8 {
-  /// Equality operator
-  @_transparent
-  static func == (i: Self, s: Unicode.Scalar) -> Bool {
-    return i == UInt8(ascii: s)
-  }
-  /// Inequality operator
-  @_transparent
-  static func != (i: Self, s: Unicode.Scalar) -> Bool {
-    return i != UInt8(ascii: s)
-  }
-  /// Used in switch statements
-  @_transparent
-  static func ~= (s: Unicode.Scalar, i: Self) -> Bool {
-    return i == UInt8(ascii: s)
-  }
-}
-
 extension UInt8? {
   /// Equality operator
   @_transparent


### PR DESCRIPTION
Hi @ahoppen, follow-up PR to https://github.com/swiftlang/swift-syntax/pull/2439 removing some operators that turn out to not be necessary as I just noticed they are implied by their optional counterparts. Does not seem to affect compile/runtime performance.