### PR TITLE
SwiftIfConfig improvements to suit usage in the compiler

### DIFF
--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import SwiftSyntax
 
 /// Describes the ordering of a sequence of bytes that make up a word of
 /// storage for a particular architecture.
@@ -114,15 +115,15 @@ public protocol BuildConfiguration {
   /// information, which will translate into the `version` argument.
   ///
   /// - Parameters:
-  ///   - importPath: A nonempty sequence of identifiers describing the
-  ///     imported module, which was written in source as a dotted sequence,
-  ///     e.g., `UIKit.UIViewController` will be passed in as the import path
-  ///     array `["UIKit", "UIViewController"]`.
+  ///   - importPath: A nonempty sequence of (token, identifier) pairs
+  ///     describing the imported module, which was written in source as a
+  ///     dotted sequence, e.g., `UIKit.UIViewController` will be passed in as
+  ///     the import path array `[(token, "UIKit"), (token, "UIViewController")]`.
   ///   - version: The version restriction on the imported module. For the
   ///     normal `canImport(<import-path>)` syntax, this will always be
   ///     `CanImportVersion.unversioned`.
   /// - Returns: Whether the module can be imported.
-  func canImport(importPath: [String], version: CanImportVersion) throws -> Bool
+  func canImport(importPath: [(TokenSyntax, String)], version: CanImportVersion) throws -> Bool
 
   /// Determine whether the given name is the active target OS (e.g., Linux, iOS).
   ///

--- a/Sources/SwiftIfConfig/ConfiguredRegions.swift
+++ b/Sources/SwiftIfConfig/ConfiguredRegions.swift
@@ -51,7 +51,9 @@ public struct ConfiguredRegions {
         return currentState
       }
 
-      if node.position <= ifClause.endPosition {
+      let ifRegionStart =
+        ifClause.condition?.endPosition ?? ifClause.elements?._syntaxNode.position ?? ifClause.poundKeyword.endPosition
+      if node.position >= ifRegionStart && node.position <= ifClause.endPosition {
         currentState = state
       }
     }

--- a/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
+++ b/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
@@ -82,20 +82,10 @@ extension SyntaxProtocol {
   /// If you are querying whether many syntax nodes in a particular file are
   /// active, consider calling `configuredRegions(in:)` once and using
   /// this function. For occasional queries, use `isActive(in:)`.
+  @available(*, deprecated, message: "Please use ConfiguredRegions.isActive(_:)")
   public func isActive(
-    inConfiguredRegions regions: [(IfConfigClauseSyntax, IfConfigRegionState)]
+    inConfiguredRegions regions: ConfiguredRegions
   ) -> IfConfigRegionState {
-    var currentState: IfConfigRegionState = .active
-    for (ifClause, state) in regions {
-      if self.position < ifClause.position {
-        return currentState
-      }
-
-      if self.position <= ifClause.endPosition {
-        currentState = state
-      }
-    }
-
-    return currentState
+    regions.isActive(self)
   }
 }

--- a/Tests/SwiftIfConfigTest/ActiveRegionTests.swift
+++ b/Tests/SwiftIfConfigTest/ActiveRegionTests.swift
@@ -49,7 +49,7 @@ public class ActiveRegionTests: XCTestCase {
         "2️⃣": .active,
         "3️⃣": .inactive,
         "4️⃣": .unparsed,
-        "5️⃣": .inactive,
+        "5️⃣": .unparsed,
         "6️⃣": .active,
       ]
     )
@@ -77,7 +77,7 @@ public class ActiveRegionTests: XCTestCase {
         "2️⃣": .active,
         "3️⃣": .inactive,
         "4️⃣": .unparsed,
-        "5️⃣": .inactive,
+        "5️⃣": .unparsed,
         "6️⃣": .active,
       ]
     )
@@ -97,6 +97,25 @@ public class ActiveRegionTests: XCTestCase {
       states: [
         "0️⃣": .unparsed,
         "1️⃣": .active,
+      ]
+    )
+  }
+
+  func testActiveRegionUnparsed() throws {
+    try assertActiveCode(
+      """
+      #if false
+       #if compiler(>=4.1)
+       1️⃣let _: Int = 1
+       #else
+        // There should be no error here.
+        2️⃣foo bar
+       #endif
+      #endif
+      """,
+      states: [
+        "1️⃣": .unparsed,
+        "2️⃣": .unparsed,
       ]
     )
   }

--- a/Tests/SwiftIfConfigTest/ActiveRegionTests.swift
+++ b/Tests/SwiftIfConfigTest/ActiveRegionTests.swift
@@ -79,7 +79,9 @@ public class ActiveRegionTests: XCTestCase {
         "4️⃣": .unparsed,
         "5️⃣": .unparsed,
         "6️⃣": .active,
-      ]
+      ],
+      configuredRegionDescription:
+        "[[1:6 - 3:5] = active, [3:5 - 10:7] = inactive, [5:5 - 7:5] = unparsed, [7:5 - 9:5] = unparsed)]"
     )
   }
 
@@ -127,6 +129,7 @@ fileprivate func assertActiveCode(
   _ markedSource: String,
   configuration: some BuildConfiguration = TestingBuildConfiguration(),
   states: [String: IfConfigRegionState],
+  configuredRegionDescription: String? = nil,
   file: StaticString = #filePath,
   line: UInt = #line
 ) throws {
@@ -152,7 +155,7 @@ fileprivate func assertActiveCode(
     let (actualState, _) = token.isActive(in: configuration)
     XCTAssertEqual(actualState, expectedState, "isActive(in:) at marker \(marker)", file: file, line: line)
 
-    let actualViaRegions = token.isActive(inConfiguredRegions: configuredRegions)
+    let actualViaRegions = configuredRegions.isActive(token)
     XCTAssertEqual(
       actualViaRegions,
       expectedState,
@@ -160,5 +163,15 @@ fileprivate func assertActiveCode(
       file: file,
       line: line
     )
+
+    if let configuredRegionDescription {
+      XCTAssertEqual(
+        configuredRegions.debugDescription,
+        configuredRegionDescription,
+        "configured region descsription",
+        file: file,
+        line: line
+      )
+    }
   }
 }

--- a/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
+++ b/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
@@ -54,10 +54,10 @@ struct TestingBuildConfiguration: BuildConfiguration {
   }
 
   func canImport(
-    importPath: [String],
+    importPath: [(TokenSyntax, String)],
     version: CanImportVersion
   ) throws -> Bool {
-    guard let moduleName = importPath.first else {
+    guard let moduleName = importPath.first?.1 else {
       return false
     }
 


### PR DESCRIPTION
A couple more semantic tweaks and improvements to address the needs of the compiler:
* Rework the configured regions computation to better match the compiler with respect to inactive vs. unparsed
* Turn "configured regions" into a proper struct that also carries with it diagnostics and an `isActive` operation
* Reimplement `SyntaxProtocol.isActive(in:)` in terms of configured regions, and warn that it's slow
* Provide `TokenSyntax` nodes for the import path in `BuildConfiguration.canImport` because the compiler really needs location information