### PR TITLE
Don't always treat a closure following a variable declaration as an accessor block

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1354,7 +1354,8 @@ extension Parser {
         }
 
         let accessors: RawAccessorBlockSyntax?
-        if self.at(.leftBrace)
+        if (self.at(.leftBrace)
+          && (!self.currentToken.isAtStartOfLine || self.withLookahead({ $0.atStartOfGetSetAccessor() })))
           || (inMemberDeclList && self.at(anyIn: AccessorDeclSyntax.AccessorSpecifierOptions.self) != nil
             && !self.at(.keyword(.`init`)))
         {

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -58,6 +58,18 @@ final class ExpressionTests: ParserTestCase {
       }
       """
     )
+
+    assertParse(
+      """
+      func f(x:[Void])
+      {
+        var y:[[Void]] = x.map { [$0] }
+        {
+          $0.reserveCapacity(1)
+        } (&y[0])
+      }
+      """
+    )
   }
 
   func testTrailingClosures() {


### PR DESCRIPTION
Introduce some lookahead to make sure we actually have something that looks like an accessor block when the `{` is on the next line, matching what the C++ parser does.

Fixes https://github.com/swiftlang/swift/issues/76089