### PR TITLE
Add `buildFinalResult` to `CodeBlockItemListBuilder` to ensure newline between expressions

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
+++ b/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
@@ -40,6 +40,18 @@ extension CodeBlockItemListBuilder {
   public static func buildExpression(_ expression: some Sequence<DeclSyntaxProtocol>) -> Component {
     buildExpression(expression.map { CodeBlockItemSyntax(item: .decl(DeclSyntax($0))) })
   }
+
+  public static func buildFinalResult(_ component: Component) -> CodeBlockItemListSyntax {
+    .init(
+      component.enumerated().map { (index, expression) in
+        if index > component.startIndex, !expression.leadingTrivia.contains(where: \.isNewline) {
+          return expression.with(\.leadingTrivia, .newline.merging(expression.leadingTrivia))
+        } else {
+          return expression
+        }
+      }
+    )
+  }
 }
 
 extension ConditionElementListBuilder {

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -528,5 +528,15 @@ public func collapse<Node: SyntaxProtocol>(
     break
   }
 
-  return expansions.joined(separator: separator)
+  // Join the expansions ensuring `separator` between them.
+  var collapsed = ""
+  for expansion in expansions {
+    if collapsed.isEmpty || expansion.hasPrefix(separator) {
+      collapsed.append(expansion)
+    } else {
+      collapsed.append(separator + expansion)
+    }
+  }
+
+  return collapsed
 }

--- a/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
@@ -75,4 +75,31 @@ final class CollectionNodeFlatteningTests: XCTestCase {
       """
     )
   }
+
+  func test_FlattenCodeBlockItemListWithCodeBlockInterpolated() {
+    let block = CodeBlockItemListSyntax {
+      "let a = 1"
+      "let b = 2"
+      "let c = 3"
+    }
+
+    let buildable = CodeBlockItemListSyntax {
+      "let one = object.methodOne()"
+      "let two = object.methodTwo()"
+      "let three = {\(block)}()"
+    }
+
+    assertBuildResult(
+      buildable,
+      """
+      let one = object.methodOne()
+      let two = object.methodTwo()
+      let three = {
+          let a = 1
+          let b = 2
+          let c = 3
+      }()
+      """
+    )
+  }
 }


### PR DESCRIPTION
This ensures that the following usage of `CodeBlockItemListBuilder` produces a valid block where expressions are separated by newlines:

```swift
CodeBlockItemListSyntax {
    "let a = 1"
    "let b = 2"
    "let c = 3"
}
```
Something similar it's already done for comma separated lists [here](https://github.com/swiftlang/swift-syntax/blob/8740e1555d3202ec65bb6ccc2721a87ec450a7e3/Sources/SwiftSyntaxBuilder/ListBuilder.swift#L108-L116).

I've also modified the `collapse` function to avoid adding unnecessary separators to a macro expansion. This change is important because if someone uses `CodeBlockItemListBuilder` as in [testDontAddIndentationWhenCollapsingBody](https://github.com/swiftlang/swift-syntax/blob/c2c798059a3787694d1fd22668d55d09d725c101/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift#L159C8-L159C48), they might be surprised by unexpected empty lines if `collapse` adds separator unconditionally.

```swift
func f() {
#sourceLocation(file: "test.swift", line: 3)

        let x: Int = 1

#sourceLocation()
}
```
