### PR TITLE
Braces following a variable declaration with no initializer clause are accessors

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1355,7 +1355,8 @@ extension Parser {
 
         let accessors: RawAccessorBlockSyntax?
         if (self.at(.leftBrace)
-          && (!self.currentToken.isAtStartOfLine || self.withLookahead({ $0.atStartOfGetSetAccessor() })))
+          && (initializer == nil || !self.currentToken.isAtStartOfLine
+            || self.withLookahead({ $0.atStartOfGetSetAccessor() })))
           || (inMemberDeclList && self.at(anyIn: AccessorDeclSyntax.AccessorSpecifierOptions.self) != nil
             && !self.at(.keyword(.`init`)))
         {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -2293,6 +2293,17 @@ final class DeclarationTests: ParserTestCase {
     )
   }
 
+  func testVariableGetSetNextLine() {
+    assertParse(
+      """
+      struct X {
+        var x: Int
+        { 17 }
+      }
+      """
+    )
+  }
+
   func testVariableFollowedByReferenceToSet() {
     assertParse(
       """


### PR DESCRIPTION
Fixes rdar://134877843, a regression introduced recently as part of the fix to https://github.com/swiftlang/swift/issues/76089.