### PR TITLE
Implementation of the compiler's "extract inlinable text"

### DIFF
--- a/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
+++ b/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
@@ -382,12 +382,26 @@ extension IfConfigDeclSyntax {
 
 extension SyntaxProtocol {
   // Produce the source code for this syntax node with all of the comments
-  // removed. Each comment will be replaced with either a newline or a space,
-  // depending on whether the comment involved a newline.
+  // and #sourceLocations removed. Each comment will be replaced with either
+  // a newline or a space, depending on whether the comment involved a newline.
   @_spi(Compiler)
-  public var descriptionWithoutComments: String {
+  public var descriptionWithoutCommentsAndSourceLocations: String {
     var result = ""
+    var skipUntilRParen = false
     for token in tokens(viewMode: .sourceAccurate) {
+      // Skip #sourceLocation(...).
+      if token.tokenKind == .poundSourceLocation {
+        skipUntilRParen = true
+        continue
+      }
+
+      if skipUntilRParen {
+        if token.tokenKind == .rightParen {
+          skipUntilRParen = false
+        }
+        continue
+      }
+
       token.leadingTrivia.writeWithoutComments(to: &result)
       token.text.write(to: &result)
       token.trailingTrivia.writeWithoutComments(to: &result)

--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import SwiftSyntax
 
 /// Describes the ordering of a sequence of bytes that make up a word of

--- a/Sources/SwiftIfConfig/SwiftIfConfig.docc/SwiftIfConfig.md
+++ b/Sources/SwiftIfConfig/SwiftIfConfig.docc/SwiftIfConfig.md
@@ -29,8 +29,4 @@ The `SwiftIfConfig` library provides utilities to determine which syntax nodes a
 * <doc:ActiveSyntaxVisitor> and <doc:ActiveSyntaxAnyVisitor> are visitor types that only visit the syntax nodes that are included ("active") for a given build configuration, implicitly skipping any nodes within inactive `#if` clauses.
 * `SyntaxProtocol.removingInactive(in:)` produces a syntax node that removes all inactive regions (and their corresponding `IfConfigDeclSyntax` nodes) from the given syntax tree, returning a new tree that is free of `#if` conditions.
 * `IfConfigDeclSyntax.activeClause(in:)` determines which of the clauses of an `#if` is active for the given build configuration, returning the active clause.
-* `SyntaxProtocol.isActive(in:)` determines whether the given syntax node is active for the given build configuration. The result is one of "active"
-    (the node is included in the program), "inactive" (the node is not included
-    in the program), or "unparsed" (the node is not included in the program and
-    is also allowed to have syntax errors).
-* `SyntaxProtocol.configuredRegions(in:)` produces an array describing the various regions in which a configuration has an effect, indicating active, inactive, and unparsed regions in the source tree. The array can be used as an input to `SyntaxProtocol.isActive(inConfiguredRegions:)` to determine whether a given syntax node is active.
+* `SyntaxProtocol.configuredRegions(in:)` produces a `ConfiguredRegions` value that can be used to efficiently test whether a given syntax node is in an active, inactive, or unparsed region (via `isActive`).

--- a/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
+++ b/Sources/SwiftIfConfig/SyntaxProtocol+IfConfig.swift
@@ -47,17 +47,4 @@ extension SyntaxProtocol {
     let configuredRegions = root.configuredRegions(in: configuration)
     return (configuredRegions.isActive(self), configuredRegions.diagnostics)
   }
-
-  /// Determine whether the given syntax node is active given a set of
-  /// configured regions as produced by `configuredRegions(in:)`.
-  ///
-  /// If you are querying whether many syntax nodes in a particular file are
-  /// active, consider calling `configuredRegions(in:)` once and using
-  /// this function. For occasional queries, use `isActive(in:)`.
-  @available(*, deprecated, message: "Please use ConfiguredRegions.isActive(_:)")
-  public func isActive(
-    inConfiguredRegions regions: ConfiguredRegions
-  ) -> IfConfigRegionState {
-    regions.isActive(self)
-  }
 }

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -300,12 +300,13 @@ public class VisitorTests: XCTestCase {
     )
   }
 
-  func testRemoveComments() {
+  func testRemoveCommentsAndSourceLocations() {
     let original: SourceFileSyntax = """
 
       /// This is a documentation comment
       func f() { }
 
+      #sourceLocation(file: "if-configs.swift", line: 200)
       /** Another documentation comment
           that is split across
           multiple lines */
@@ -318,12 +319,11 @@ public class VisitorTests: XCTestCase {
       """
 
     assertStringsEqualWithDiff(
-      original.descriptionWithoutComments,
+      original.descriptionWithoutCommentsAndSourceLocations,
       """
 
        
       func f() { }
-
 
 
       func g() { }

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -253,6 +253,52 @@ public class VisitorTests: XCTestCase {
         """
     )
   }
+
+  func testRemoveInactiveRetainingFeatureChecks() {
+    assertRemoveInactive(
+      """
+      public func hasIfCompilerCheck(_ x: () -> Bool = {
+      #if compiler(>=5.3)
+        return true
+      #else
+        return false
+      #endif
+
+      #if $Blah
+        return 0
+      #else
+        return 1
+      #endif
+
+      #if NOT_SET
+        return 3.14159
+      #else
+        return 2.71828
+      #endif
+        }) {
+      }
+      """,
+      configuration: linuxBuildConfig,
+      retainFeatureCheckIfConfigs: true,
+      expectedSource: """
+        public func hasIfCompilerCheck(_ x: () -> Bool = {
+        #if compiler(>=5.3)
+          return true
+        #else
+          return false
+        #endif
+
+        #if $Blah
+          return 0
+        #else
+          return 1
+        #endif
+          return 2.71828
+          }) {
+        }
+        """
+    )
+  }
 }
 
 /// Assert that applying the given build configuration to the source code
@@ -260,6 +306,7 @@ public class VisitorTests: XCTestCase {
 fileprivate func assertRemoveInactive(
   _ source: String,
   configuration: some BuildConfiguration,
+  retainFeatureCheckIfConfigs: Bool = false,
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   expectedSource: String,
   file: StaticString = #filePath,
@@ -268,7 +315,10 @@ fileprivate func assertRemoveInactive(
   var parser = Parser(source)
   let tree = SourceFileSyntax.parse(from: &parser)
 
-  let (treeWithoutInactive, actualDiagnostics) = tree.removingInactive(in: configuration)
+  let (treeWithoutInactive, actualDiagnostics) = tree.removingInactive(
+    in: configuration,
+    retainFeatureCheckIfConfigs: retainFeatureCheckIfConfigs
+  )
 
   // Check the resulting tree.
   assertStringsEqualWithDiff(

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-import SwiftIfConfig
+@_spi(Compiler) import SwiftIfConfig
 import SwiftParser
 import SwiftSyntax
 @_spi(XCTestFailureLocation) @_spi(Testing) import SwiftSyntaxMacrosGenericTestSupport
@@ -297,6 +297,42 @@ public class VisitorTests: XCTestCase {
           }) {
         }
         """
+    )
+  }
+
+  func testRemoveComments() {
+    let original: SourceFileSyntax = """
+
+      /// This is a documentation comment
+      func f() { }
+
+      /** Another documentation comment
+          that is split across
+          multiple lines */
+      func g() { }
+
+      func h() {
+        x +/*comment*/y
+        // foo
+      }
+      """
+
+    assertStringsEqualWithDiff(
+      original.descriptionWithoutComments,
+      """
+
+       
+      func f() { }
+
+
+
+      func g() { }
+
+      func h() {
+        x + y
+         
+      }
+      """
     )
   }
 }


### PR DESCRIPTION
The compiler has an operation to extract "inlinable" text for use in Swift interface generation. The operation removes all "inactive" code (per a build configuration) that doesn't involve the compiler version or feature checks, as well as stripping comments and `#sourceLocation`. 

Provide those APIs here based on swift-syntax. 