### PR TITLE
[SwiftIfConfig] Make ConfiguredRegions and a BuildConfiguration generally interchangeable

### DIFF
--- a/Sources/SwiftIfConfig/ActiveClauseEvaluator.swift
+++ b/Sources/SwiftIfConfig/ActiveClauseEvaluator.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+
+/// Captures sufficient information to determine the active clause for an `#if`
+/// either by querying existing configured regions or by evaluating the
+/// clause's conditions against a build configuration.
+enum ActiveClauseEvaluator {
+  case configuredRegions(ConfiguredRegions)
+  case configuration(any BuildConfiguration)
+
+  /// Previously-known diagnostics.
+  var priorDiagnostics: [Diagnostic] {
+    switch self {
+    case .configuredRegions(let configuredRegions):
+      return configuredRegions.diagnostics
+    case .configuration:
+      return []
+    }
+  }
+
+  /// Determine which clause of an `#if` declaration is active, if any.
+  ///
+  /// If this evaluation produced any diagnostics, they will be appended to
+  /// the diagnostics parameter.
+  func activeClause(
+    for node: IfConfigDeclSyntax,
+    diagnostics: inout [Diagnostic]
+  ) -> IfConfigClauseSyntax? {
+    switch self {
+    case .configuredRegions(let configuredRegions):
+      return configuredRegions.activeClause(for: node)
+    case .configuration(let configuration):
+      let (activeClause, localDiagnostics) = node.activeClause(in: configuration)
+      diagnostics.append(contentsOf: localDiagnostics)
+      return activeClause
+    }
+  }
+}

--- a/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
+++ b/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
@@ -24,14 +24,33 @@ extension SyntaxProtocol {
   /// removed.
   /// - Parameters:
   ///   - configuration: the configuration to apply.
+  /// - Returns: the syntax node with all inactive regions removed, along with
+  ///   an array containing any diagnostics produced along the way.
+  public func removingInactive(
+    in configuration: some BuildConfiguration
+  ) -> (result: Syntax, diagnostics: [Diagnostic]) {
+    return removingInactive(in: configuration, retainFeatureCheckIfConfigs: false)
+  }
+
+  /// Produce a copy of this syntax node that removes all syntax regions that
+  /// are inactive according to the given build configuration, leaving only
+  /// the code that is active within that build configuration.
+  ///
+  /// If there are errors in the conditions of any configuration
+  /// clauses, e.g., `#if FOO > 10`, then the condition will be
+  /// considered to have failed and the clauses's elements will be
+  /// removed.
+  /// - Parameters:
+  ///   - configuration: the configuration to apply.
   ///   - retainFeatureCheckIfConfigs: whether to retain `#if` blocks involving
   ///     compiler version checks (e.g., `compiler(>=6.0)`) and `$`-based
   ///     feature checks.
   /// - Returns: the syntax node with all inactive regions removed, along with
   ///   an array containing any diagnostics produced along the way.
+  @_spi(Compiler)
   public func removingInactive(
     in configuration: some BuildConfiguration,
-    retainFeatureCheckIfConfigs: Bool = false
+    retainFeatureCheckIfConfigs: Bool
   ) -> (result: Syntax, diagnostics: [Diagnostic]) {
     // First pass: Find all of the active clauses for the #ifs we need to
     // visit, along with any diagnostics produced along the way. This process

--- a/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
+++ b/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
@@ -382,12 +382,26 @@ extension IfConfigDeclSyntax {
 
 extension SyntaxProtocol {
   // Produce the source code for this syntax node with all of the comments
-  // removed. Each comment will be replaced with either a newline or a space,
-  // depending on whether the comment involved a newline.
+  // and #sourceLocations removed. Each comment will be replaced with either
+  // a newline or a space, depending on whether the comment involved a newline.
   @_spi(Compiler)
-  public var descriptionWithoutComments: String {
+  public var descriptionWithoutCommentsAndSourceLocations: String {
     var result = ""
+    var skipUntilRParen = false
     for token in tokens(viewMode: .sourceAccurate) {
+      // Skip #sourceLocation(...).
+      if token.tokenKind == .poundSourceLocation {
+        skipUntilRParen = true
+        continue
+      }
+
+      if skipUntilRParen {
+        if token.tokenKind == .rightParen {
+          skipUntilRParen = false
+        }
+        continue
+      }
+
       token.leadingTrivia.writeWithoutComments(to: &result)
       token.text.write(to: &result)
       token.trailingTrivia.writeWithoutComments(to: &result)

--- a/Sources/SwiftIfConfig/ActiveSyntaxVisitor.swift
+++ b/Sources/SwiftIfConfig/ActiveSyntaxVisitor.swift
@@ -46,9 +46,6 @@ open class ActiveSyntaxVisitor<Configuration: BuildConfiguration>: SyntaxVisitor
   /// The diagnostics accumulated during this walk of active syntax.
   public private(set) var diagnostics: [Diagnostic] = []
 
-  /// Whether we visited any "#if" clauses.
-  var visitedAnyIfClauses: Bool = false
-
   public init(viewMode: SyntaxTreeViewMode, configuration: Configuration) {
     self.configuration = configuration
     super.init(viewMode: viewMode)
@@ -59,8 +56,6 @@ open class ActiveSyntaxVisitor<Configuration: BuildConfiguration>: SyntaxVisitor
     // change one, please also change the other.
     let (activeClause, localDiagnostics) = node.activeClause(in: configuration)
     diagnostics.append(contentsOf: localDiagnostics)
-
-    visitedAnyIfClauses = true
 
     // If there is an active clause, visit it's children.
     if let activeClause, let elements = activeClause.elements {

--- a/Sources/SwiftIfConfig/ActiveSyntaxVisitor.swift
+++ b/Sources/SwiftIfConfig/ActiveSyntaxVisitor.swift
@@ -39,23 +39,30 @@ import SwiftSyntax
 /// All notes visited by this visitor will have the "active" state, i.e.,
 /// `node.isActive(in: configuration)` will have evaluated to `.active`.
 /// When errors occur, they will be recorded in the array of diagnostics.
-open class ActiveSyntaxVisitor<Configuration: BuildConfiguration>: SyntaxVisitor {
-  /// The build configuration, which will be queried for each relevant `#if`.
-  public let configuration: Configuration
+open class ActiveSyntaxVisitor: SyntaxVisitor {
+  /// The abstracted build configuration, which will be queried for each
+  /// relevant `#if`.
+  let activeClauses: ActiveClauseEvaluator
 
   /// The diagnostics accumulated during this walk of active syntax.
   public private(set) var diagnostics: [Diagnostic] = []
 
-  public init(viewMode: SyntaxTreeViewMode, configuration: Configuration) {
-    self.configuration = configuration
+  public init(viewMode: SyntaxTreeViewMode, configuration: some BuildConfiguration) {
+    self.activeClauses = .configuration(configuration)
+    self.diagnostics = activeClauses.priorDiagnostics
+    super.init(viewMode: viewMode)
+  }
+
+  public init(viewMode: SyntaxTreeViewMode, configuredRegions: ConfiguredRegions) {
+    self.activeClauses = .configuredRegions(configuredRegions)
+    self.diagnostics = activeClauses.priorDiagnostics
     super.init(viewMode: viewMode)
   }
 
   open override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
     // Note: there is a clone of this code in ActiveSyntaxAnyVisitor. If you
     // change one, please also change the other.
-    let (activeClause, localDiagnostics) = node.activeClause(in: configuration)
-    diagnostics.append(contentsOf: localDiagnostics)
+    let activeClause = activeClauses.activeClause(for: node, diagnostics: &diagnostics)
 
     // If there is an active clause, visit it's children.
     if let activeClause, let elements = activeClause.elements {
@@ -93,15 +100,23 @@ open class ActiveSyntaxVisitor<Configuration: BuildConfiguration>: SyntaxVisitor
 /// All notes visited by this visitor will have the "active" state, i.e.,
 /// `node.isActive(in: configuration)` will have evaluated to `.active`.
 /// When errors occur, they will be recorded in the array of diagnostics.
-open class ActiveSyntaxAnyVisitor<Configuration: BuildConfiguration>: SyntaxAnyVisitor {
-  /// The build configuration, which will be queried for each relevant `#if`.
-  public let configuration: Configuration
+open class ActiveSyntaxAnyVisitor: SyntaxAnyVisitor {
+  /// The abstracted build configuration, which will be queried for each
+  /// relevant `#if`.
+  let activeClauses: ActiveClauseEvaluator
 
   /// The diagnostics accumulated during this walk of active syntax.
   public private(set) var diagnostics: [Diagnostic] = []
 
-  public init(viewMode: SyntaxTreeViewMode, configuration: Configuration) {
-    self.configuration = configuration
+  public init(viewMode: SyntaxTreeViewMode, configuration: some BuildConfiguration) {
+    self.activeClauses = .configuration(configuration)
+    self.diagnostics = activeClauses.priorDiagnostics
+    super.init(viewMode: viewMode)
+  }
+
+  public init(viewMode: SyntaxTreeViewMode, configuredRegions: ConfiguredRegions) {
+    self.activeClauses = .configuredRegions(configuredRegions)
+    self.diagnostics = activeClauses.priorDiagnostics
     super.init(viewMode: viewMode)
   }
 
@@ -110,8 +125,7 @@ open class ActiveSyntaxAnyVisitor<Configuration: BuildConfiguration>: SyntaxAnyV
     // change one, please also change the other.
 
     // If there is an active clause, visit it's children.
-    let (activeClause, localDiagnostics) = node.activeClause(in: configuration)
-    diagnostics.append(contentsOf: localDiagnostics)
+    let activeClause = activeClauses.activeClause(for: node, diagnostics: &diagnostics)
 
     if let activeClause, let elements = activeClause.elements {
       walk(elements)

--- a/Sources/SwiftIfConfig/CMakeLists.txt
+++ b/Sources/SwiftIfConfig/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_syntax_library(SwiftIfConfig
+  ActiveClauseEvaluator.swift
   ActiveSyntaxVisitor.swift
   ActiveSyntaxRewriter.swift
   BuildConfiguration.swift

--- a/Sources/SwiftIfConfig/SwiftIfConfig.docc/SwiftIfConfig.md
+++ b/Sources/SwiftIfConfig/SwiftIfConfig.docc/SwiftIfConfig.md
@@ -29,4 +29,5 @@ The `SwiftIfConfig` library provides utilities to determine which syntax nodes a
 * <doc:ActiveSyntaxVisitor> and <doc:ActiveSyntaxAnyVisitor> are visitor types that only visit the syntax nodes that are included ("active") for a given build configuration, implicitly skipping any nodes within inactive `#if` clauses.
 * `SyntaxProtocol.removingInactive(in:)` produces a syntax node that removes all inactive regions (and their corresponding `IfConfigDeclSyntax` nodes) from the given syntax tree, returning a new tree that is free of `#if` conditions.
 * `IfConfigDeclSyntax.activeClause(in:)` determines which of the clauses of an `#if` is active for the given build configuration, returning the active clause.
-* `SyntaxProtocol.configuredRegions(in:)` produces a `ConfiguredRegions` value that can be used to efficiently test whether a given syntax node is in an active, inactive, or unparsed region (via `isActive`).
+* `SyntaxProtocol.configuredRegions(in:)` produces a `ConfiguredRegions` value that can be used to efficiently test whether a given syntax node is in an active, inactive, or unparsed region, remove inactive syntax, or determine the
+    active clause for a given `#if`. Use `ConfiguredRegions` for repeated queries.

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -300,12 +300,13 @@ public class VisitorTests: XCTestCase {
     )
   }
 
-  func testRemoveComments() {
+  func testRemoveCommentsAndSourceLocations() {
     let original: SourceFileSyntax = """
 
       /// This is a documentation comment
       func f() { }
 
+      #sourceLocation(file: "if-configs.swift", line: 200)
       /** Another documentation comment
           that is split across
           multiple lines */
@@ -318,12 +319,11 @@ public class VisitorTests: XCTestCase {
       """
 
     assertStringsEqualWithDiff(
-      original.descriptionWithoutComments,
+      original.descriptionWithoutCommentsAndSourceLocations,
       """
 
        
       func f() { }
-
 
 
       func g() { }

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -253,6 +253,52 @@ public class VisitorTests: XCTestCase {
         """
     )
   }
+
+  func testRemoveInactiveRetainingFeatureChecks() {
+    assertRemoveInactive(
+      """
+      public func hasIfCompilerCheck(_ x: () -> Bool = {
+      #if compiler(>=5.3)
+        return true
+      #else
+        return false
+      #endif
+
+      #if $Blah
+        return 0
+      #else
+        return 1
+      #endif
+
+      #if NOT_SET
+        return 3.14159
+      #else
+        return 2.71828
+      #endif
+        }) {
+      }
+      """,
+      configuration: linuxBuildConfig,
+      retainFeatureCheckIfConfigs: true,
+      expectedSource: """
+        public func hasIfCompilerCheck(_ x: () -> Bool = {
+        #if compiler(>=5.3)
+          return true
+        #else
+          return false
+        #endif
+
+        #if $Blah
+          return 0
+        #else
+          return 1
+        #endif
+          return 2.71828
+          }) {
+        }
+        """
+    )
+  }
 }
 
 /// Assert that applying the given build configuration to the source code
@@ -260,6 +306,7 @@ public class VisitorTests: XCTestCase {
 fileprivate func assertRemoveInactive(
   _ source: String,
   configuration: some BuildConfiguration,
+  retainFeatureCheckIfConfigs: Bool = false,
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   expectedSource: String,
   file: StaticString = #filePath,
@@ -268,7 +315,10 @@ fileprivate func assertRemoveInactive(
   var parser = Parser(source)
   let tree = SourceFileSyntax.parse(from: &parser)
 
-  let (treeWithoutInactive, actualDiagnostics) = tree.removingInactive(in: configuration)
+  let (treeWithoutInactive, actualDiagnostics) = tree.removingInactive(
+    in: configuration,
+    retainFeatureCheckIfConfigs: retainFeatureCheckIfConfigs
+  )
 
   // Check the resulting tree.
   assertStringsEqualWithDiff(

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-import SwiftIfConfig
+@_spi(Compiler) import SwiftIfConfig
 import SwiftParser
 import SwiftSyntax
 @_spi(XCTestFailureLocation) @_spi(Testing) import SwiftSyntaxMacrosGenericTestSupport
@@ -297,6 +297,42 @@ public class VisitorTests: XCTestCase {
           }) {
         }
         """
+    )
+  }
+
+  func testRemoveComments() {
+    let original: SourceFileSyntax = """
+
+      /// This is a documentation comment
+      func f() { }
+
+      /** Another documentation comment
+          that is split across
+          multiple lines */
+      func g() { }
+
+      func h() {
+        x +/*comment*/y
+        // foo
+      }
+      """
+
+    assertStringsEqualWithDiff(
+      original.descriptionWithoutComments,
+      """
+
+       
+      func f() { }
+
+
+
+      func g() { }
+
+      func h() {
+        x + y
+         
+      }
+      """
     )
   }
 }


### PR DESCRIPTION
Make the API surface area available for build configurations also available for configured regions. This allows clients that are going to provide repeated `#if`-related queries to produce configured regions once (for the whole syntax tree) and then perform more queries and traversals against it. Overall, this affects a few APIs:

* The `removingInactive(in:)` API is now available on `ConfiguredRegions` as well as on a syntax node (with build configuration). In both cases, it requires a single pass (whereas it was previously two-pass and evaluated `#if`s multiple times). This require a bit of a rework in how the recursion works in this operation.
* The `ActiveSyntax(Any)Visitor` visitor classes can be initialized with either `ConfiguredRegions` or `some BuildConfiguration`. These visitor classes are no longer generic, which makes them simpler to use.