### PR TITLE
Enable the `sendingArgsAndResults` experimental feature

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -18,7 +18,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case doExpressions
   case nonescapableTypes
   case trailingComma
-  case sendingArgsAndResults
 
   /// The name of the feature, which is used in the doc comment.
   public var featureName: String {
@@ -33,8 +32,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "NonEscableTypes"
     case .trailingComma:
       return "trailing comma"
-    case .sendingArgsAndResults:
-      return "SendingArgsAndResults"
     }
   }
 

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -687,10 +687,7 @@ public enum Keyword: CaseIterable {
     case .throws:
       return KeywordSpec("throws", isLexerClassified: true)
     case .sending:
-      return KeywordSpec(
-        "sending",
-        experimentalFeature: .sendingArgsAndResults
-      )
+      return KeywordSpec("sending")
     case .transpose:
       return KeywordSpec("transpose")
     case .true:

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -377,7 +377,7 @@ extension Parser.Lookahead {
         && !self.at(.keyword(._const))
         && !self.at(.keyword(.borrowing))
         && !self.at(.keyword(.consuming))
-        && !(experimentalFeatures.contains(.sendingArgsAndResults) && self.at(.keyword(.sending)))
+        && !self.at(.keyword(.sending))
       {
         return true
       }

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -38,7 +38,4 @@ extension Parser.ExperimentalFeatures {
   
   /// Whether to enable the parsing of trailing comma.
   public static let trailingComma = Self (rawValue: 1 << 4)
-  
-  /// Whether to enable the parsing of SendingArgsAndResults.
-  public static let sendingArgsAndResults = Self (rawValue: 1 << 5)
 }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -858,9 +858,6 @@ extension DeclModifierSyntax {
     case `static`
     case unowned
     case weak
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case sending
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -935,7 +932,7 @@ extension DeclModifierSyntax {
         self = .unowned
       case TokenSpec(.weak):
         self = .weak
-      case TokenSpec(.sending) where experimentalFeatures.contains(.sendingArgsAndResults):
+      case TokenSpec(.sending):
         self = .sending
       default:
         return nil
@@ -3379,9 +3376,6 @@ extension SimpleTypeSpecifierSyntax {
     case _const
     case borrowing
     case consuming
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case sending
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -3400,7 +3394,7 @@ extension SimpleTypeSpecifierSyntax {
         self = .borrowing
       case TokenSpec(.consuming):
         self = .consuming
-      case TokenSpec(.sending) where experimentalFeatures.contains(.sendingArgsAndResults):
+      case TokenSpec(.sending):
         self = .sending
       default:
         return nil

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -203,9 +203,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   #endif
   case scoped
   case `self`
-  #if compiler(>=5.8)
-  @_spi(ExperimentalLanguageFeatures)
-  #endif
   case sending
   case `Self`
   case Sendable

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3270,18 +3270,9 @@ final class DeclarationTests: ParserTestCase {
   }
 
   func testSendingTypeSpecifier() {
-    assertParse(
-      "func testVarDeclTupleElt() -> (sending String, String) {}",
-      experimentalFeatures: .sendingArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (sending String)) {}",
-      experimentalFeatures: .sendingArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (sending String, String)) {}",
-      experimentalFeatures: .sendingArgsAndResults
-    )
+    assertParse("func testVarDeclTupleElt() -> (sending String, String) {}")
+    assertParse("func testVarDeclTuple2(_ x: (sending String)) {}")
+    assertParse("func testVarDeclTuple2(_ x: (sending String, String)) {}")
   }
 
   func testMisplacedAttributeInVarDeclWithMultipleBindings() {

--- a/Tests/SwiftParserTest/SendingTest.swift
+++ b/Tests/SwiftParserTest/SendingTest.swift
@@ -19,8 +19,7 @@ final class SendingTests: ParserTestCase {
       """
       class Klass {}
       func transferMain(_ x: sending Klass) -> ()
-      """,
-      experimentalFeatures: .sendingArgsAndResults
+      """
     )
   }
 
@@ -29,8 +28,7 @@ final class SendingTests: ParserTestCase {
       """
       class Klass {}
       func transferMain(_ y: Klass, _ x: sending Klass, _ z: Klass) -> ()
-      """,
-      experimentalFeatures: .sendingArgsAndResults
+      """
     )
   }
 }


### PR DESCRIPTION
SE-0430 was accepted for Swift 6.0 but the experimental feature was not enabled with the proposal’s acceptance.