### PR TITLE
[6.0] Enable the `sendingArgsAndResults` experimental feature

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -697,10 +697,7 @@ public enum Keyword: CaseIterable {
     case .throws:
       return KeywordSpec("throws", isLexerClassified: true)
     case .sending:
-      return KeywordSpec(
-        "sending",
-        experimentalFeature: .sendingArgsAndResults
-      )
+      return KeywordSpec("sending")
     case .transpose:
       return KeywordSpec("transpose")
     case .true:

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -377,7 +377,7 @@ extension Parser.Lookahead {
         && !self.at(.keyword(.__owned))
         && !self.at(.keyword(.borrowing))
         && !self.at(.keyword(.consuming))
-        && !(experimentalFeatures.contains(.sendingArgsAndResults) && self.at(.keyword(.sending)))
+        && !self.at(.keyword(.sending))
         && !(experimentalFeatures.contains(.nonescapableTypes) && self.at(.keyword(._resultDependsOn)))
       {
         return true

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -810,9 +810,6 @@ extension DeclModifierSyntax {
     case `static`
     case unowned
     case weak
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case sending
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -889,7 +886,7 @@ extension DeclModifierSyntax {
         self = .unowned
       case TokenSpec(.weak):
         self = .weak
-      case TokenSpec(.sending) where experimentalFeatures.contains(.sendingArgsAndResults):
+      case TokenSpec(.sending):
         self = .sending
       default:
         return nil
@@ -3343,9 +3340,6 @@ extension SimpleTypeSpecifierSyntax {
     @_spi(ExperimentalLanguageFeatures)
     #endif
     case _resultDependsOn
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case sending
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -3366,7 +3360,7 @@ extension SimpleTypeSpecifierSyntax {
         self = .consuming
       case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonescapableTypes):
         self = ._resultDependsOn
-      case TokenSpec(.sending) where experimentalFeatures.contains(.sendingArgsAndResults):
+      case TokenSpec(.sending):
         self = .sending
       default:
         return nil

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -211,9 +211,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   #endif
   case scoped
   case `self`
-  #if compiler(>=5.8)
-  @_spi(ExperimentalLanguageFeatures)
-  #endif
   case sending
   case `Self`
   case Sendable

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3295,17 +3295,8 @@ final class DeclarationTests: ParserTestCase {
   }
 
   func testSendingTypeSpecifier() {
-    assertParse(
-      "func testVarDeclTupleElt() -> (sending String, String) {}",
-      experimentalFeatures: .sendingArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (sending String)) {}",
-      experimentalFeatures: .sendingArgsAndResults
-    )
-    assertParse(
-      "func testVarDeclTuple2(_ x: (sending String, String)) {}",
-      experimentalFeatures: .sendingArgsAndResults
-    )
+    assertParse("func testVarDeclTupleElt() -> (sending String, String) {}")
+    assertParse("func testVarDeclTuple2(_ x: (sending String)) {}")
+    assertParse("func testVarDeclTuple2(_ x: (sending String, String)) {}")
   }
 }

--- a/Tests/SwiftParserTest/SendingTest.swift
+++ b/Tests/SwiftParserTest/SendingTest.swift
@@ -19,8 +19,7 @@ final class SendingTests: ParserTestCase {
       """
       class Klass {}
       func transferMain(_ x: sending Klass) -> ()
-      """,
-      experimentalFeatures: .sendingArgsAndResults
+      """
     )
   }
 
@@ -29,8 +28,7 @@ final class SendingTests: ParserTestCase {
       """
       class Klass {}
       func transferMain(_ y: Klass, _ x: sending Klass, _ z: Klass) -> ()
-      """,
-      experimentalFeatures: .sendingArgsAndResults
+      """
     )
   }
 }


### PR DESCRIPTION
- **Explanation**: [SE-0430](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md) was accepted for Swift 6.0 but the corresponding experimental feature `sendingArgsAndResults` in swift-syntax was not enabled with the proposal’s acceptance. Because of this, SwiftParser cannot parse eg. `func whatever(_ foo: sending Foo)`
- **Scope**: Parsing of `sending` parameters in SwiftParser
- **Risk**: Fairly low, this is enabling a feature flag.
- **Testing**: Ran test suite
- **Issue**: https://github.com/swiftlang/swift-syntax/issues/2836 / rdar://135336930
- **Original PR**: https://github.com/swiftlang/swift-syntax/pull/2835
- **Reviewer**: @bnbarham @rintaro @hamishknight