### PR TITLE
[SwiftLexicalLookup] Remove some import Foundation

### DIFF
--- a/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
+++ b/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 @_spi(Experimental) public struct LookupConfig {
   /// Specifies behavior of file scope.
   @_spi(Experimental) public var fileScopeHandling: FileScopeHandlingConfig

--- a/Sources/SwiftLexicalLookup/SimpleLookupQueries.swift
+++ b/Sources/SwiftLexicalLookup/SimpleLookupQueries.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftSyntax
 
 extension SyntaxProtocol {


### PR DESCRIPTION
The `import Foundation` seems to not be needed in these two files. Remove them.