### PR TITLE
[SwiftLexicalLookup] Add ASTScope related fixes and lookInMembers result kind.

### DIFF
--- a/Sources/SwiftLexicalLookup/CMakeLists.txt
+++ b/Sources/SwiftLexicalLookup/CMakeLists.txt
@@ -15,6 +15,7 @@ add_swift_syntax_library(SwiftLexicalLookup
   Configurations/FileScopeHandlingConfig.swift
   Configurations/LookupConfig.swift
   
+  Scopes/CanInterleaveResultsLaterScopeSyntax.swift
   Scopes/FunctionScopeSyntax.swift
   Scopes/GenericParameterScopeSyntax.swift
   Scopes/IntroducingToSequentialParentScopeSyntax.swift

--- a/Sources/SwiftLexicalLookup/CMakeLists.txt
+++ b/Sources/SwiftLexicalLookup/CMakeLists.txt
@@ -17,10 +17,11 @@ add_swift_syntax_library(SwiftLexicalLookup
   
   Scopes/GenericParameterScopeSyntax.swift
   Scopes/IntroducingToSequentialParentScopeSyntax.swift
+  Scopes/LookInMembersScopeSyntax.swift
+  Scopes/NominalTypeDeclSyntax.swift
   Scopes/ScopeImplementations.swift
   Scopes/ScopeSyntax.swift
   Scopes/SequentialScopeSyntax.swift
-  Scopes/TypeScopeSyntax.swift
   Scopes/WithGenericParametersScopeSyntax.swift
 )
 

--- a/Sources/SwiftLexicalLookup/CMakeLists.txt
+++ b/Sources/SwiftLexicalLookup/CMakeLists.txt
@@ -15,6 +15,7 @@ add_swift_syntax_library(SwiftLexicalLookup
   Configurations/FileScopeHandlingConfig.swift
   Configurations/LookupConfig.swift
   
+  Scopes/FunctionScopeSyntax.swift
   Scopes/GenericParameterScopeSyntax.swift
   Scopes/IntroducingToSequentialParentScopeSyntax.swift
   Scopes/LookInMembersScopeSyntax.swift

--- a/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
+++ b/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
@@ -14,8 +14,43 @@
   /// Specifies behavior of file scope.
   @_spi(Experimental) public var fileScopeHandling: FileScopeHandlingConfig
   /// Specifies whether lookup should finish in the closest sequential scope.
+  ///
+  /// ### Example
+  /// ```swift
+  /// class X {
+  ///   let a = 42
+  ///
+  ///   func (a: Int) {
+  ///     let a = 123
+  ///
+  ///     a // <-- lookup here
+  ///   }
+  /// }
+  /// ```
+  /// When looking up at the specified position with `finishInSequentialScope`
+  /// set to `false`, lookup will return declaration from inside function body,
+  /// function parameter and the `a` declaration from `class X` member block.
+  /// If `finishInSequentialScope` would be set to `false`, the only name
+  /// returned by lookup would be the `a` declaration from inside function body.
   @_spi(Experimental) public var finishInSequentialScope: Bool
   /// Specifies whether to include results generated in file and member block scopes.
+  ///
+  /// ### Example
+  /// ```swift
+  /// class X {
+  ///   let a = 42
+  ///
+  ///   func (a: Int) {
+  ///     let a = 123
+  ///
+  ///     a // <-- lookup here
+  ///   }
+  /// }
+  /// ```
+  /// When looking up at the specified position with `includeMembers`
+  /// set to `true`, lookup will return declaration from inside function body,
+  /// function parameter and the `a` declaration from `class X` member block.
+  /// If `includeMembers` would be set to `false`, the latter name would be omitted.
   @_spi(Experimental) public var includeMembers: Bool
 
   /// Creates a new lookup configuration.

--- a/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
+++ b/Sources/SwiftLexicalLookup/Configurations/LookupConfig.swift
@@ -13,14 +13,26 @@
 @_spi(Experimental) public struct LookupConfig {
   /// Specifies behavior of file scope.
   @_spi(Experimental) public var fileScopeHandling: FileScopeHandlingConfig
+  /// Specifies whether lookup should finish in the closest sequential scope.
+  @_spi(Experimental) public var finishInSequentialScope: Bool
+  /// Specifies whether to include results generated in file and member block scopes.
+  @_spi(Experimental) public var includeMembers: Bool
 
   /// Creates a new lookup configuration.
   ///
   /// - `fileScopeHandling` - specifies behavior of file scope.
   ///   `memberBlockUpToLastDecl` by default.
+  /// - `finishInSequentialScope` - specifies whether lookup should finish
+  ///   in the closest sequential scope. `false` by default.
+  /// - `includeMembers` - specifies whether to include results generated
+  ///   in file and member block scopes. `true` by default.
   @_spi(Experimental) public init(
-    fileScopeHandling: FileScopeHandlingConfig = .memberBlockUpToLastDecl
+    fileScopeHandling: FileScopeHandlingConfig = .memberBlockUpToLastDecl,
+    finishInSequentialScope: Bool = false,
+    includeMembers: Bool = true
   ) {
     self.fileScopeHandling = fileScopeHandling
+    self.finishInSequentialScope = finishInSequentialScope
+    self.includeMembers = includeMembers
   }
 }

--- a/Sources/SwiftLexicalLookup/LookupName.swift
+++ b/Sources/SwiftLexicalLookup/LookupName.swift
@@ -16,8 +16,8 @@ import SwiftSyntax
 @_spi(Experimental) public enum ImplicitDecl {
   /// `self` keyword representing object instance.
   /// Could be associated with type declaration, extension,
-  /// or closure captures.
-  case `self`(DeclSyntaxProtocol)
+  /// or closure captures. Introduced at function edge.
+  case `self`(FunctionDeclSyntax)
   /// `Self` keyword representing object type.
   /// Could be associated with type declaration or extension.
   case `Self`(DeclSyntaxProtocol)
@@ -135,6 +135,35 @@ import SwiftSyntax
     }
   }
 
+  /// Position of this name.
+  /// 
+  /// For some syntax nodes, their position doesn't reflect
+  /// the position at which a particular name was introduced at.
+  /// Such cases are function parameters (as they can
+  /// contain two identifiers) and function declarations (where name
+  /// is precided by access modifiers and `func` keyword).
+  @_spi(Experimental) public var position: AbsolutePosition {
+    switch self {
+    case .identifier(let syntax, _):
+      switch Syntax(syntax).as(SyntaxEnum.self) {
+      case .functionParameter(let functionParameter):
+        return functionParameter.secondName?.positionAfterSkippingLeadingTrivia
+          ?? functionParameter.firstName.positionAfterSkippingLeadingTrivia
+      default:
+        return syntax.position
+      }
+    case .declaration(let syntax):
+      return syntax.name.position
+    case .implicit(let implicitName):
+      switch implicitName {
+      case .self(let functionDecl):
+        return functionDecl.name.position
+      default:
+        return implicitName.syntax.position
+      }
+    }
+  }
+
   /// Point, after which the name is available in scope.
   /// If set to `nil`, the name is available at any point in scope.
   var accessibleAfter: AbsolutePosition? {
@@ -224,5 +253,28 @@ import SwiftSyntax
     accessibleAfter: AbsolutePosition? = nil
   ) -> [LookupName] {
     [.declaration(namedDecl)]
+  }
+
+  /// Debug description of this lookup name.
+  @_spi(Experimental) public var debugDescription: String {
+    let sourceLocationConverter = SourceLocationConverter(fileName: "", tree: syntax.root)
+    let location = sourceLocationConverter.location(for: position)
+    let strName = (identifier != nil ? identifier!.name : "NO-NAME") + " at: \(location.line):\(location.column)"
+
+    switch self {
+    case .identifier:
+      let str = "identifier: \(strName)"
+
+      if let accessibleAfter {
+        let location = sourceLocationConverter.location(for: accessibleAfter)
+        return str + " after: \(location.line):\(location.column)"
+      } else {
+        return str
+      }
+    case .declaration:
+      return "declaration: \(strName)"
+    case .implicit:
+      return "implicit: \(strName)"
+    }
   }
 }

--- a/Sources/SwiftLexicalLookup/LookupName.swift
+++ b/Sources/SwiftLexicalLookup/LookupName.swift
@@ -154,8 +154,20 @@ import SwiftSyntax
         switch Syntax(declSyntax).as(SyntaxEnum.self) {
         case .functionDecl(let functionDecl):
           return functionDecl.name.position
+        case .initializerDecl(let initializerDecl):
+          return initializerDecl.initKeyword.positionAfterSkippingLeadingTrivia
         case .subscriptDecl(let subscriptDecl):
           return subscriptDecl.accessorBlock?.position ?? subscriptDecl.endPosition
+        case .variableDecl(let variableDecl):
+          return variableDecl.bindings.first?.accessorBlock?.positionAfterSkippingLeadingTrivia
+            ?? variableDecl.endPosition
+        default:
+          return declSyntax.positionAfterSkippingLeadingTrivia
+        }
+      case .Self(let declSyntax):
+        switch Syntax(declSyntax).as(SyntaxEnum.self) {
+        case .protocolDecl(let protocolDecl):
+          return protocolDecl.name.positionAfterSkippingLeadingTrivia
         default:
           return declSyntax.positionAfterSkippingLeadingTrivia
         }
@@ -226,6 +238,8 @@ import SwiftSyntax
       return functionCallExpr.arguments.flatMap { argument in
         getNames(from: argument.expression, accessibleAfter: accessibleAfter)
       }
+    case .optionalChainingExpr(let optionalChainingExpr):
+      return getNames(from: optionalChainingExpr.expression, accessibleAfter: accessibleAfter)
     default:
       if let namedDecl = Syntax(syntax).asProtocol(SyntaxProtocol.self) as? NamedDeclSyntax {
         return handle(namedDecl: namedDecl, accessibleAfter: accessibleAfter)

--- a/Sources/SwiftLexicalLookup/LookupName.swift
+++ b/Sources/SwiftLexicalLookup/LookupName.swift
@@ -20,7 +20,7 @@ import SwiftSyntax
   case `self`(DeclSyntaxProtocol)
   /// `Self` keyword representing object type.
   /// Could be associated with type declaration or extension.
-  case `Self`(ProtocolDeclSyntax)
+  case `Self`(DeclSyntaxProtocol)
   /// `error` value caught by a `catch`
   /// block that does not specify a catch pattern.
   case error(CatchClauseSyntax)
@@ -147,27 +147,33 @@ import SwiftSyntax
     case .identifier(let syntax, _):
       return syntax.identifier.positionAfterSkippingLeadingTrivia
     case .declaration(let syntax):
-      return syntax.name.position
+      return syntax.name.positionAfterSkippingLeadingTrivia
     case .implicit(let implicitName):
       switch implicitName {
       case .self(let declSyntax):
         switch Syntax(declSyntax).as(SyntaxEnum.self) {
         case .functionDecl(let functionDecl):
-          return functionDecl.name.position
+          return functionDecl.name.positionAfterSkippingLeadingTrivia
         case .initializerDecl(let initializerDecl):
           return initializerDecl.initKeyword.positionAfterSkippingLeadingTrivia
         case .subscriptDecl(let subscriptDecl):
-          return subscriptDecl.accessorBlock?.position ?? subscriptDecl.endPosition
+          return subscriptDecl.accessorBlock?.positionAfterSkippingLeadingTrivia
+            ?? subscriptDecl.endPositionBeforeTrailingTrivia
         case .variableDecl(let variableDecl):
           return variableDecl.bindings.first?.accessorBlock?.positionAfterSkippingLeadingTrivia
             ?? variableDecl.endPosition
         default:
           return declSyntax.positionAfterSkippingLeadingTrivia
         }
-      case .Self(let protocolDecl):
-        return protocolDecl.name.positionAfterSkippingLeadingTrivia
+      case .Self(let declSyntax):
+        switch Syntax(declSyntax).as(SyntaxEnum.self) {
+        case .protocolDecl(let protocolDecl):
+          return protocolDecl.name.positionAfterSkippingLeadingTrivia
+        default:
+          return declSyntax.positionAfterSkippingLeadingTrivia
+        }
       case .error(let catchClause):
-        return catchClause.body.position
+        return catchClause.body.positionAfterSkippingLeadingTrivia
       default:
         return implicitName.syntax.positionAfterSkippingLeadingTrivia
       }

--- a/Sources/SwiftLexicalLookup/LookupName.swift
+++ b/Sources/SwiftLexicalLookup/LookupName.swift
@@ -20,7 +20,7 @@ import SwiftSyntax
   case `self`(DeclSyntaxProtocol)
   /// `Self` keyword representing object type.
   /// Could be associated with type declaration or extension.
-  case `Self`(DeclSyntaxProtocol)
+  case `Self`(ProtocolDeclSyntax)
   /// `error` value caught by a `catch`
   /// block that does not specify a catch pattern.
   case error(CatchClauseSyntax)
@@ -164,13 +164,8 @@ import SwiftSyntax
         default:
           return declSyntax.positionAfterSkippingLeadingTrivia
         }
-      case .Self(let declSyntax):
-        switch Syntax(declSyntax).as(SyntaxEnum.self) {
-        case .protocolDecl(let protocolDecl):
-          return protocolDecl.name.positionAfterSkippingLeadingTrivia
-        default:
-          return declSyntax.positionAfterSkippingLeadingTrivia
-        }
+      case .Self(let protocolDecl):
+        return protocolDecl.name.positionAfterSkippingLeadingTrivia
       case .error(let catchClause):
         return catchClause.body.position
       default:
@@ -271,7 +266,7 @@ import SwiftSyntax
   @_spi(Experimental) public var debugDescription: String {
     let sourceLocationConverter = SourceLocationConverter(fileName: "", tree: syntax.root)
     let location = sourceLocationConverter.location(for: position)
-    let strName = (identifier != nil ? identifier!.name : "NO-NAME") + " at: \(location.line):\(location.column)"
+    let strName = (identifier?.name ?? "NO-NAME") + " at: \(location.line):\(location.column)"
 
     switch self {
     case .identifier:

--- a/Sources/SwiftLexicalLookup/LookupResult.swift
+++ b/Sources/SwiftLexicalLookup/LookupResult.swift
@@ -18,14 +18,18 @@ import SwiftSyntax
   case fromScope(ScopeSyntax, withNames: [LookupName])
   /// File scope and names that matched lookup.
   case fromFileScope(SourceFileSyntax, withNames: [LookupName])
+  /// Indicates where to perform member lookup.
+  case lookInMembers(LookInMembersScopeSyntax)
 
   /// Associated scope.
-  @_spi(Experimental) public var scope: ScopeSyntax? {
+  @_spi(Experimental) public var scope: ScopeSyntax {
     switch self {
     case .fromScope(let scopeSyntax, _):
       return scopeSyntax
     case .fromFileScope(let fileScopeSyntax, _):
       return fileScopeSyntax
+    case .lookInMembers(let lookInMemb):
+      return lookInMemb
     }
   }
 
@@ -34,6 +38,8 @@ import SwiftSyntax
     switch self {
     case .fromScope(_, let names), .fromFileScope(_, let names):
       return names
+    case .lookInMembers(_):
+      return []
     }
   }
 
@@ -45,5 +51,55 @@ import SwiftSyntax
     default:
       return .fromScope(scope, withNames: names)
     }
+  }
+
+  /// Debug description of this lookup name.
+  @_spi(Experimental) public var debugDescription: String {
+    var description =
+      resultKindDebugName + ": " + scope.scopeDebugDescription
+
+    switch self {
+    case .lookInMembers:
+      break
+    default:
+      if !names.isEmpty {
+        description += "\n"
+      }
+    }
+
+    for (index, name) in names.enumerated() {
+      if index + 1 == names.count {
+        description += "`-" + name.debugDescription
+      } else {
+        description += "|-" + name.debugDescription + "\n"
+      }
+    }
+
+    return description
+  }
+
+  /// Debug name of this result kind.
+  private var resultKindDebugName: String {
+    switch self {
+    case .fromScope:
+      return "fromScope"
+    case .fromFileScope:
+      return "fromFileScope"
+    case .lookInMembers:
+      return "lookInMembers"
+    }
+  }
+}
+
+@_spi(Experimental) extension [LookupResult] {
+  /// Debug description this array of lookup results.
+  @_spi(Experimental) public var debugDescription: String {
+    var str: String = ""
+
+    for (index, result) in self.enumerated() {
+      str += result.debugDescription + (index + 1 == self.count ? "" : "\n")
+    }
+
+    return str
   }
 }

--- a/Sources/SwiftLexicalLookup/LookupResult.swift
+++ b/Sources/SwiftLexicalLookup/LookupResult.swift
@@ -94,12 +94,6 @@ import SwiftSyntax
 @_spi(Experimental) extension [LookupResult] {
   /// Debug description this array of lookup results.
   @_spi(Experimental) public var debugDescription: String {
-    var str: String = ""
-
-    for (index, result) in self.enumerated() {
-      str += result.debugDescription + (index + 1 == self.count ? "" : "\n")
-    }
-
-    return str
+    return self.map(\.debugDescription).joined(separator: "\n")
   }
 }

--- a/Sources/SwiftLexicalLookup/Scopes/CanInterleaveResultsLaterScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/CanInterleaveResultsLaterScopeSyntax.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+protocol CanInterleaveResultsLaterScopeSyntax: ScopeSyntax {
+  func lookupWithInterleavedResults(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig,
+    resultsToInterleave: [LookupResult]
+  ) -> [LookupResult]
+}

--- a/Sources/SwiftLexicalLookup/Scopes/CanInterleaveResultsLaterScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/CanInterleaveResultsLaterScopeSyntax.swift
@@ -13,6 +13,9 @@
 import SwiftSyntax
 
 protocol CanInterleaveResultsLaterScopeSyntax: ScopeSyntax {
+  /// Perform lookup in this scope and later introduce results
+  /// passed as `resultsToInterleave`.
+  /// The exact behavior depends on a specific scope.
   func lookupWithInterleavedResults(
     _ identifier: Identifier?,
     at lookUpPosition: AbsolutePosition,

--- a/Sources/SwiftLexicalLookup/Scopes/FunctionScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/FunctionScopeSyntax.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+protocol FunctionScopeSyntax: DeclSyntaxProtocol, WithGenericParametersScopeSyntax {
+  var signature: FunctionSignatureSyntax { get }
+}
+
+extension FunctionScopeSyntax {
+  /// Function parameters introduced by this function's signature.
+  @_spi(Experimental) public var introducedNames: [LookupName] {
+    signature.parameterClause.parameters.flatMap { parameter in
+      LookupName.getNames(from: parameter)
+    } + (parentScope?.is(MemberBlockSyntax.self) ?? false ? [.implicit(.self(self))] : [])
+  }
+
+  /// Lookup results from this function scope.
+  /// Routes to generic parameter clause scope if exists.
+  @_spi(Experimental) public func lookup(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    var thisScopeResults: [LookupResult] = []
+
+    if !signature.range.contains(lookUpPosition) {
+      thisScopeResults = defaultLookupImplementation(
+        identifier,
+        at: position,
+        with: config,
+        propagateToParent: false
+      )
+    }
+
+    return thisScopeResults
+      + lookupThroughGenericParameterScope(
+        identifier,
+        at: lookUpPosition,
+        with: config
+      )
+  }
+}

--- a/Sources/SwiftLexicalLookup/Scopes/GenericParameterScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/GenericParameterScopeSyntax.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 /// futher lookup to its `WithGenericParametersScopeSyntax`
 /// parent scope's parent scope (i.e. on return, bypasses names
 /// introduced by its parent).
-@_spi(Experimental) public protocol GenericParameterScopeSyntax: ScopeSyntax {}
+protocol GenericParameterScopeSyntax: ScopeSyntax {}
 
 @_spi(Experimental) extension GenericParameterScopeSyntax {
   /// Returns names matching lookup and bypasses
@@ -83,7 +83,7 @@ import SwiftSyntax
     if let parentScope = Syntax(parentScope).asProtocol(SyntaxProtocol.self)
       as? WithGenericParametersScopeSyntax
     {
-      return parentScope.lookupInParent(identifier, at: lookUpPosition, with: config)
+      return parentScope.returningLookupFromGenericParameterScope(identifier, at: lookUpPosition, with: config)
     } else {
       return lookupInParent(identifier, at: lookUpPosition, with: config)
     }

--- a/Sources/SwiftLexicalLookup/Scopes/LookInMembersScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/LookInMembersScopeSyntax.swift
@@ -12,14 +12,7 @@
 
 import SwiftSyntax
 
-@_spi(Experimental) public protocol TypeScopeSyntax: ScopeSyntax, DeclSyntaxProtocol {}
-
-extension TypeScopeSyntax {
-  @_spi(Experimental) public var implicitInstanceAndTypeNames: [LookupName] {
-    [.implicit(.self(self)), .implicit(.Self(self))]
-  }
-
-  @_spi(Experimental) public var introducedNames: [LookupName] {
-    implicitInstanceAndTypeNames
-  }
+@_spi(Experimental) public protocol LookInMembersScopeSyntax: ScopeSyntax {
+  /// Position used for member lookup.
+  var lookupMembersPosition: AbsolutePosition { get }
 }

--- a/Sources/SwiftLexicalLookup/Scopes/NominalTypeDeclSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/NominalTypeDeclSyntax.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+protocol NominalTypeDeclSyntax: LookInMembersScopeSyntax, NamedDeclSyntax, WithGenericParametersScopeSyntax {
+  var inheritanceClause: InheritanceClauseSyntax? { get }
+}
+
+extension NominalTypeDeclSyntax {
+  @_spi(Experimental) public var lookupMembersPosition: AbsolutePosition {
+    name.position
+  }
+
+  /// Nominal type doesn't introduce any names by itself.
+  @_spi(Experimental) public var introducedNames: [LookupName] {
+    []
+  }
+
+  /// Function used by generic parameter clause
+  /// scope on return from it's lookup.
+  func returningLookupFromGenericParameterScope(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    if let inheritanceClause, inheritanceClause.range.contains(lookUpPosition) {
+      return lookupInParent(identifier, at: lookUpPosition, with: config)
+    } else {
+      return [.lookInMembers(self)] + lookupInParent(identifier, at: lookUpPosition, with: config)
+    }
+  }
+}

--- a/Sources/SwiftLexicalLookup/Scopes/NominalTypeDeclSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/NominalTypeDeclSyntax.swift
@@ -13,6 +13,7 @@
 import SwiftSyntax
 
 protocol NominalTypeDeclSyntax: LookInMembersScopeSyntax, NamedDeclSyntax, WithGenericParametersScopeSyntax {
+  var genericParameterClause: GenericParameterClauseSyntax? { get }
   var inheritanceClause: InheritanceClauseSyntax? { get }
 }
 
@@ -34,6 +35,10 @@ extension NominalTypeDeclSyntax {
     with config: LookupConfig
   ) -> [LookupResult] {
     if let inheritanceClause, inheritanceClause.range.contains(lookUpPosition) {
+      return lookupInParent(identifier, at: lookUpPosition, with: config)
+    } else if let genericParameterClause, genericParameterClause.range.contains(lookUpPosition) {
+      return lookupInParent(identifier, at: lookUpPosition, with: config)
+    } else if name.range.contains(lookUpPosition) {
       return lookupInParent(identifier, at: lookUpPosition, with: config)
     } else {
       return [.lookInMembers(self)] + lookupInParent(identifier, at: lookUpPosition, with: config)

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
@@ -671,8 +671,7 @@ import SwiftSyntax
       )
     }
 
-    let lookInMembers: [LookupResult] =
-      inheritanceClause?.range.contains(lookUpPosition) ?? false ? [] : [.lookInMembers(self)]
+    let lookInMembers: [LookupResult] = memberBlock.range.contains(lookUpPosition) ? [.lookInMembers(self)] : []
 
     return results
       + defaultLookupImplementation(

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
@@ -21,6 +21,13 @@ import SwiftSyntax
       return self.parent?.scope
     }
   }
+
+  /// This node's line and column separated by `:`.
+  var debugLineWithColumnDescription: String {
+    let location = SourceLocationConverter(fileName: "", tree: root).location(for: position)
+
+    return "\(location.line):\(location.column)"
+  }
 }
 
 @_spi(Experimental) extension SourceFileSyntax: SequentialScopeSyntax {
@@ -28,6 +35,10 @@ import SwiftSyntax
   /// according to the default strategy: `memberBlockUpToLastDecl`.
   @_spi(Experimental) public var introducedNames: [LookupName] {
     introducedNames(using: .memberBlockUpToLastDecl)
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "FileScope"
   }
 
   /// All names introduced in the file scope
@@ -101,6 +112,8 @@ import SwiftSyntax
     at lookUpPosition: AbsolutePosition,
     with config: LookupConfig
   ) -> [LookupResult] {
+    guard config.includeMembers else { return [] }
+
     switch config.fileScopeHandling {
     case .memberBlock:
       let names = introducedNames(using: .memberBlock)
@@ -151,6 +164,10 @@ import SwiftSyntax
     }
   }
 
+  @_spi(Experimental) public var scopeDebugName: String {
+    "CodeBlockScope"
+  }
+
   @_spi(Experimental) public func lookup(
     _ identifier: Identifier?,
     at lookUpPosition: AbsolutePosition,
@@ -170,21 +187,15 @@ import SwiftSyntax
   @_spi(Experimental) public var introducedNames: [LookupName] {
     LookupName.getNames(from: pattern)
   }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "ForStmtScope"
+  }
 }
 
-@_spi(Experimental) extension ClosureExprSyntax: ScopeSyntax {
-  /// All names introduced by the closure signature.
-  /// Could be closure captures or (shorthand) parameters.
-  ///
-  /// ### Example
-  /// ```swift
-  /// let x = { [weak self, a] b, _ in
-  ///   // <--
-  /// }
-  /// ```
-  /// During lookup, names available at the marked place are:
-  /// `self`, a, b.
-  @_spi(Experimental) public var introducedNames: [LookupName] {
+@_spi(Experimental) extension ClosureExprSyntax: SequentialScopeSyntax {
+  /// Names introduced in this closure's signature.
+  var introducedNamesInSignature: [LookupName] {
     let captureNames =
       signature?.capture?.items.flatMap { element in
         LookupName.getNames(from: element)
@@ -203,6 +214,54 @@ import SwiftSyntax
 
     return captureNames + parameterNames
   }
+
+  /// Names introduced sequentially in body.
+  var introducedNamesInBody: [LookupName] {
+    statements.flatMap { codeBlockItem in
+      LookupName.getNames(from: codeBlockItem.item, accessibleAfter: codeBlockItem.endPosition)
+    }
+  }
+
+  @_spi(Experimental) public var introducedNames: [LookupName] {
+    introducedNamesInSignature + introducedNamesInBody
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "ClosureExprScope"
+  }
+
+  /// All names introduced by the closure signature and its body.
+  /// Could be closure captures, (shorthand) parameters or
+  /// sequential results from the body.
+  ///
+  /// ### Example
+  /// ```swift
+  /// let x = { [weak self, a] b, _ in
+  ///   let c = 42
+  ///   // <--
+  ///   let d = 42
+  /// }
+  /// ```
+  /// During lookup, names available at the marked place are:
+  /// `self`, `a`, `b` and `c`.
+  @_spi(Experimental) public func lookup(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    let filteredSignatureNames = introducedNamesInSignature.filter { name in
+      checkIdentifier(identifier, refersTo: name, at: lookUpPosition)
+    }
+
+    return sequentialLookup(
+      in: statements,
+      identifier,
+      at: lookUpPosition,
+      with: config,
+      propagateToParent: false
+    ) + (filteredSignatureNames.isEmpty ? [] : [.fromScope(self, withNames: filteredSignatureNames)])
+      + (config.finishInSequentialScope ? [] : lookupInParent(identifier, at: lookUpPosition, with: config))
+  }
 }
 
 @_spi(Experimental) extension WhileStmtSyntax: ScopeSyntax {
@@ -211,6 +270,10 @@ import SwiftSyntax
     conditions.flatMap { element in
       LookupName.getNames(from: element.condition)
     }
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "WhileStmtScope"
   }
 }
 
@@ -253,9 +316,13 @@ import SwiftSyntax
 
   /// Names introduced by the `if` optional binding conditions.
   @_spi(Experimental) public var introducedNames: [LookupName] {
-    conditions.flatMap { element in
+    conditions.reversed().flatMap { element in
       LookupName.getNames(from: element.condition, accessibleAfter: element.endPosition)
     }
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "IfExprScope"
   }
 
   /// Returns names matching lookup.
@@ -291,6 +358,24 @@ import SwiftSyntax
     }
   }
 
+  @_spi(Experimental) public var scopeDebugName: String {
+    "MemberBlockScope"
+  }
+
+  /// Lookup results from this member block scope.
+  /// Bypasses names from this scope if `includeMembers` set to `false`.
+  @_spi(Experimental) public func lookup(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    if config.includeMembers {
+      return defaultLookupImplementation(identifier, at: lookUpPosition, with: config)
+    } else {
+      return lookupInParent(identifier, at: lookUpPosition, with: config)
+    }
+  }
+
   /// Creates a result from associated type declarations
   /// made by it's members.
   func lookupAssociatedTypeDeclarations(
@@ -312,13 +397,17 @@ import SwiftSyntax
 
 @_spi(Experimental) extension GuardStmtSyntax: IntroducingToSequentialParentScopeSyntax {
   var namesIntroducedToSequentialParent: [LookupName] {
-    conditions.flatMap { element in
+    conditions.reversed().flatMap { element in
       LookupName.getNames(from: element.condition, accessibleAfter: element.endPosition)
     }
   }
 
   @_spi(Experimental) public var introducedNames: [LookupName] {
     []
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "GuardStmtScope"
   }
 
   /// Returns results matching lookup that should be
@@ -348,11 +437,51 @@ import SwiftSyntax
   }
 }
 
-@_spi(Experimental) extension ActorDeclSyntax: TypeScopeSyntax, WithGenericParametersScopeSyntax {}
-@_spi(Experimental) extension ClassDeclSyntax: TypeScopeSyntax, WithGenericParametersScopeSyntax {}
-@_spi(Experimental) extension StructDeclSyntax: TypeScopeSyntax, WithGenericParametersScopeSyntax {}
-@_spi(Experimental) extension EnumDeclSyntax: TypeScopeSyntax, WithGenericParametersScopeSyntax {}
-@_spi(Experimental) extension ExtensionDeclSyntax: TypeScopeSyntax {}
+@_spi(Experimental) extension ActorDeclSyntax: NominalTypeDeclSyntax {
+  @_spi(Experimental) public var scopeDebugName: String {
+    "ActorDeclScope"
+  }
+}
+@_spi(Experimental) extension ClassDeclSyntax: NominalTypeDeclSyntax {
+  @_spi(Experimental) public var scopeDebugName: String {
+    "ClassDeclScope"
+  }
+}
+@_spi(Experimental) extension StructDeclSyntax: NominalTypeDeclSyntax {
+  @_spi(Experimental) public var scopeDebugName: String {
+    "StructDeclScope"
+  }
+}
+@_spi(Experimental) extension EnumDeclSyntax: NominalTypeDeclSyntax {
+  @_spi(Experimental) public var scopeDebugName: String {
+    "EnumDeclScope"
+  }
+}
+@_spi(Experimental) extension ExtensionDeclSyntax: LookInMembersScopeSyntax {
+  @_spi(Experimental) public var lookupMembersPosition: AbsolutePosition {
+    extendedType.position
+  }
+
+  @_spi(Experimental) public var introducedNames: [LookupName] {
+    []
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "ExtensionDeclScope"
+  }
+
+  @_spi(Experimental) public func lookup(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    if memberBlock.range.contains(lookUpPosition) {
+      return [.lookInMembers(self)] + defaultLookupImplementation(identifier, at: lookUpPosition, with: config)
+    } else {
+      return defaultLookupImplementation(identifier, at: lookUpPosition, with: config)
+    }
+  }
+}
 
 @_spi(Experimental) extension AccessorDeclSyntax: ScopeSyntax {
   /// Implicit and/or explicit names introduced within the accessor.
@@ -370,12 +499,20 @@ import SwiftSyntax
       }
     }
   }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "AccessorDeclScope"
+  }
 }
 
 @_spi(Experimental) extension CatchClauseSyntax: ScopeSyntax {
   /// Implicit `error` when there are no catch items.
   @_spi(Experimental) public var introducedNames: [LookupName] {
     return catchItems.isEmpty ? [.implicit(.error(self))] : []
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "CatchClauseScope"
   }
 }
 
@@ -386,12 +523,20 @@ import SwiftSyntax
       LookupName.getNames(from: child.pattern)
     } ?? []
   }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "SwitchCaseScope"
+  }
 }
 
 @_spi(Experimental) extension ProtocolDeclSyntax: ScopeSyntax {
   /// Protocol declarations don't introduce names by themselves.
   @_spi(Experimental) public var introducedNames: [LookupName] {
     []
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "ProtocolDeclScope"
   }
 
   /// For the lookup initiated from inside primary
@@ -437,8 +582,12 @@ import SwiftSyntax
   /// Generic parameter names introduced by this clause.
   @_spi(Experimental) public var introducedNames: [LookupName] {
     parameters.children(viewMode: .fixedUp).flatMap { child in
-      LookupName.getNames(from: child, accessibleAfter: child.endPosition)
+      LookupName.getNames(from: child)
     }
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "GenericParameterClauseScope"
   }
 }
 
@@ -447,7 +596,37 @@ import SwiftSyntax
   @_spi(Experimental) public var introducedNames: [LookupName] {
     signature.parameterClause.parameters.flatMap { parameter in
       LookupName.getNames(from: parameter)
+    } + (parentScope?.is(MemberBlockSyntax.self) ?? false ? [.implicit(.self(self))] : [])
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "FunctionDeclScope"
+  }
+
+  /// Lookup results from this function scope.
+  /// Routes to generic parameter clause scope if exists.
+  @_spi(Experimental) public func lookup(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    var thisScopeResults: [LookupResult] = []
+
+    if !signature.range.contains(lookUpPosition) {
+      thisScopeResults = defaultLookupImplementation(
+        identifier,
+        at: position,
+        with: config,
+        propagateToParent: false
+      )
     }
+
+    return thisScopeResults
+      + lookupThroughGenericParameterScope(
+        identifier,
+        at: lookUpPosition,
+        with: config
+      )
   }
 }
 
@@ -458,11 +637,19 @@ import SwiftSyntax
       LookupName.getNames(from: parameter)
     }
   }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "SubscriptDeclScope"
+  }
 }
 
 @_spi(Experimental) extension TypeAliasDeclSyntax: WithGenericParametersScopeSyntax {
   /// Type alias doesn't introduce any names to it's children.
   @_spi(Experimental) public var introducedNames: [LookupName] {
     []
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "TypeAliasDeclScope"
   }
 }

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeSyntax.swift
@@ -56,6 +56,8 @@ extension SyntaxProtocol {
   var parentScope: ScopeSyntax? { get }
   /// Names found in this scope. Ordered from first to last introduced.
   var introducedNames: [LookupName] { get }
+  /// Debug description of this scope.
+  var scopeDebugName: String { get }
   /// Finds all declarations `identifier` refers to. `syntax` specifies the node lookup was triggered with.
   /// If `identifier` set to `nil`, returns all available names at the given node.
   func lookup(
@@ -116,5 +118,10 @@ extension SyntaxProtocol {
     at lookUpPosition: AbsolutePosition
   ) -> Bool {
     introducedName.isAccessible(at: lookUpPosition) && (identifier == nil || introducedName.identifier == identifier!)
+  }
+
+  /// Debug description of this scope.
+  @_spi(Experimental) public var scopeDebugDescription: String {
+    scopeDebugName + " " + debugLineWithColumnDescription
   }
 }

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeSyntax.swift
@@ -87,13 +87,14 @@ extension SyntaxProtocol {
   /// refers to and is accessible at given syntax node then passes lookup to the parent.
   /// If `identifier` set to `nil`, returns all available names at the given node.
   func defaultLookupImplementation(
+    in names: [LookupName]? = nil,
     _ identifier: Identifier?,
     at lookUpPosition: AbsolutePosition,
     with config: LookupConfig,
     propagateToParent: Bool = true
   ) -> [LookupResult] {
     let filteredNames =
-      introducedNames
+      (names ?? introducedNames)
       .filter { introducedName in
         checkIdentifier(identifier, refersTo: introducedName, at: lookUpPosition)
       }

--- a/Sources/SwiftLexicalLookup/Scopes/WithGenericParametersScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/WithGenericParametersScopeSyntax.swift
@@ -12,8 +12,14 @@
 
 import SwiftSyntax
 
-@_spi(Experimental) public protocol WithGenericParametersScopeSyntax: ScopeSyntax {
+protocol WithGenericParametersScopeSyntax: ScopeSyntax {
   var genericParameterClause: GenericParameterClauseSyntax? { get }
+
+  func returningLookupFromGenericParameterScope(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult]
 }
 
 @_spi(Experimental) extension WithGenericParametersScopeSyntax {
@@ -67,7 +73,7 @@ import SwiftSyntax
   /// function declaration scope and then to generic parameter
   /// scope (`WithGenericParametersScopeSyntax`)
   /// with this method (instead of using standard `lookupInParent`).
-  private func lookupThroughGenericParameterScope(
+  func lookupThroughGenericParameterScope(
     _ identifier: Identifier?,
     at lookUpPosition: AbsolutePosition,
     with config: LookupConfig
@@ -75,7 +81,15 @@ import SwiftSyntax
     if let genericParameterClause {
       return genericParameterClause.lookup(identifier, at: lookUpPosition, with: config)
     } else {
-      return lookupInParent(identifier, at: lookUpPosition, with: config)
+      return returningLookupFromGenericParameterScope(identifier, at: lookUpPosition, with: config)
     }
+  }
+
+  func returningLookupFromGenericParameterScope(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    lookupInParent(identifier, at: lookUpPosition, with: config)
   }
 }

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -633,7 +633,7 @@ final class testNameLookup: XCTestCase {
     )
   }
 
-  func testGuardOnFileScope() {
+  func testGuardOnFileScope() {  // TODO: Fix this according to ASTScope (ommiting class a)
     assertLexicalNameLookup(
       source: """
         let 1️⃣a = 0
@@ -902,7 +902,7 @@ final class testNameLookup: XCTestCase {
     )
   }
 
-  func testSwitchExpression() {
+  func testSwitchExpression() {  // TODO: For some reason ASTScope doesn't introduce any results besides first function call expr.
     assertLexicalNameLookup(
       source: """
         switch {
@@ -973,20 +973,16 @@ final class testNameLookup: XCTestCase {
         """,
       references: [
         "2️⃣": [
-          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
-          .lookInMembers(ClassDeclSyntax.self),
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"])
         ],
         "3️⃣": [
-          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
-          .lookInMembers(ClassDeclSyntax.self),
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"])
         ],
         "5️⃣": [
-          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["7️⃣"]),
-          .lookInMembers(ClassDeclSyntax.self),
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["7️⃣"])
         ],
         "6️⃣": [
-          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"]),
-          .lookInMembers(ClassDeclSyntax.self),
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"])
         ],
       ],
       expectedResultTypes: .all(GenericParameterSyntax.self)
@@ -1070,7 +1066,7 @@ final class testNameLookup: XCTestCase {
     )
   }
 
-  func testSubscript() {
+  func testSubscript() {  // TODO: Fix behavior of self keyword in subscript with accessors.
     assertLexicalNameLookup(
       source: """
         class X {

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -660,7 +660,7 @@ final class testNameLookup: XCTestCase {
   func testImplicitSelf() {
     assertLexicalNameLookup(
       source: """
-        extension a {
+        7️⃣extension a {
           struct b {
             2️⃣func foo() {
               let x: 3️⃣Self = 4️⃣self
@@ -675,6 +675,7 @@ final class testNameLookup: XCTestCase {
       references: [
         "3️⃣": [
           .lookInMembers(StructDeclSyntax.self),
+          .fromScope(ExtensionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.Self("7️⃣"))]),
           .lookInMembers(ExtensionDeclSyntax.self),
         ],
         "4️⃣": [
@@ -683,7 +684,8 @@ final class testNameLookup: XCTestCase {
           .lookInMembers(ExtensionDeclSyntax.self),
         ],
         "5️⃣": [
-          .lookInMembers(ExtensionDeclSyntax.self)
+          .fromScope(ExtensionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.Self("7️⃣"))]),
+          .lookInMembers(ExtensionDeclSyntax.self),
         ],
         "6️⃣": [
           .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -1005,10 +1005,12 @@ final class testNameLookup: XCTestCase {
       references: [
         "1️⃣": [
           .fromScope(MemberBlockSyntax.self, expectedNames: ["3️⃣"]),
+          .lookInMembers(ProtocolDeclSyntax.self),
           .fromFileScope(expectedNames: ["0️⃣"]),
         ],
         "2️⃣": [
-          .fromScope(MemberBlockSyntax.self, expectedNames: ["4️⃣"])
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["4️⃣"]),
+          .lookInMembers(ProtocolDeclSyntax.self),
         ],
       ],
       expectedResultTypes: .all(

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -633,7 +633,7 @@ final class testNameLookup: XCTestCase {
     )
   }
 
-  func testGuardOnFileScope() {  // TODO: Fix this according to ASTScope (ommiting class a)
+  func testGuardOnFileScope() {
     assertLexicalNameLookup(
       source: """
         let 1️⃣a = 0
@@ -904,7 +904,7 @@ final class testNameLookup: XCTestCase {
     )
   }
 
-  func testSwitchExpression() {  // TODO: For some reason ASTScope doesn't introduce any results besides first function call expr.
+  func testSwitchExpression() {
     assertLexicalNameLookup(
       source: """
         switch {
@@ -1070,7 +1070,7 @@ final class testNameLookup: XCTestCase {
     )
   }
 
-  func testSubscript() {  // TODO: Fix behavior of self keyword in subscript with accessors.
+  func testSubscript() {
     assertLexicalNameLookup(
       source: """
         class X {

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -1007,12 +1007,10 @@ final class testNameLookup: XCTestCase {
       references: [
         "1️⃣": [
           .fromScope(MemberBlockSyntax.self, expectedNames: ["3️⃣"]),
-          .lookInMembers(ProtocolDeclSyntax.self),
           .fromFileScope(expectedNames: ["0️⃣"]),
         ],
         "2️⃣": [
-          .fromScope(MemberBlockSyntax.self, expectedNames: ["4️⃣"]),
-          .lookInMembers(ProtocolDeclSyntax.self),
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["4️⃣"])
         ],
       ],
       expectedResultTypes: .all(

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -140,7 +140,7 @@ final class testNameLookup: XCTestCase {
     assertLexicalNameLookup(
       source: """
         7️⃣class a {
-          func foo() {
+          9️⃣func foo() {
             let 1️⃣a = 1
             let x = { [2️⃣weak self, 3️⃣a, 4️⃣unowned b] in
               print(5️⃣self, 6️⃣a, 8️⃣b)
@@ -152,20 +152,26 @@ final class testNameLookup: XCTestCase {
       references: [
         "5️⃣": [
           .fromScope(ClosureExprSyntax.self, expectedNames: [NameExpectation.identifier("2️⃣")]),
-          .fromScope(ClassDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("7️⃣"))]),
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("9️⃣"))]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
         "6️⃣": [
           .fromScope(ClosureExprSyntax.self, expectedNames: ["3️⃣"]),
           .fromScope(CodeBlockSyntax.self, expectedNames: ["1️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
           .fromFileScope(expectedNames: ["7️⃣"]),
         ],
-        "8️⃣": [.fromScope(ClosureExprSyntax.self, expectedNames: ["4️⃣"])],
+        "8️⃣": [
+          .fromScope(ClosureExprSyntax.self, expectedNames: ["4️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
       ],
       expectedResultTypes: .all(
         ClosureCaptureSyntax.self,
         except: [
           "1️⃣": IdentifierPatternSyntax.self,
           "7️⃣": ClassDeclSyntax.self,
+          "9️⃣": FunctionDeclSyntax.self,
         ]
       )
     )
@@ -309,10 +315,22 @@ final class testNameLookup: XCTestCase {
         }
         """,
       references: [
-        "5️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "4️⃣"])],
-        "6️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["2️⃣", "3️⃣"])],
-        "7️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["9️⃣"])],
-        "8️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["0️⃣"])],
+        "5️⃣": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "4️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "6️⃣": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["2️⃣", "3️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "7️⃣": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["9️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "8️⃣": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["0️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
       ],
       expectedResultTypes: .distinct([
         "1️⃣": IdentifierPatternSyntax.self,
@@ -343,17 +361,28 @@ final class testNameLookup: XCTestCase {
         }
         """,
       references: [
-        "2️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"])],
-        "0️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"])],
-        "4️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"])],
+        "2️⃣": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "0️⃣": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "4️⃣": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
         "6️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: ["3️⃣"]),
           .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
         "8️⃣": [
           .fromScope(IfExprSyntax.self, expectedNames: ["5️⃣"]),
           .fromScope(CodeBlockSyntax.self, expectedNames: ["3️⃣"]),
           .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "9️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
       ],
       expectedResultTypes: .all(
@@ -408,23 +437,25 @@ final class testNameLookup: XCTestCase {
         """,
       references: [
         "7️⃣": [
-          .fromScope(CodeBlockSyntax.self, expectedNames: ["4️⃣", "5️⃣"]),
-          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "2️⃣", "3️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣", "4️⃣"]),
           .fromScope(
-            ClassDeclSyntax.self,
-            expectedNames: [NameExpectation.implicit(.self("🔟")), NameExpectation.implicit(.Self("🔟"))]
+            FunctionDeclSyntax.self,
+            expectedNames: [NameExpectation.implicit(.self("3️⃣"))]
           ),
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "2️⃣", "3️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
           .fromFileScope(expectedNames: ["🔟"]),
         ],
         "0️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: ["8️⃣", "9️⃣"]),
           .fromScope(IfExprSyntax.self, expectedNames: ["6️⃣"]),
-          .fromScope(CodeBlockSyntax.self, expectedNames: ["4️⃣", "5️⃣"]),
-          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "2️⃣", "3️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣", "4️⃣"]),
           .fromScope(
-            ClassDeclSyntax.self,
-            expectedNames: [NameExpectation.implicit(.self("🔟")), NameExpectation.implicit(.Self("🔟"))]
+            FunctionDeclSyntax.self,
+            expectedNames: [NameExpectation.implicit(.self("3️⃣"))]
           ),
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["1️⃣", "2️⃣", "3️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
           .fromFileScope(expectedNames: ["🔟"]),
         ],
       ],
@@ -483,7 +514,7 @@ final class testNameLookup: XCTestCase {
           .fromScope(CodeBlockSyntax.self, expectedNames: ["1️⃣"]),
         ],
         "6️⃣": [
-          .fromScope(GuardStmtSyntax.self, expectedNames: ["2️⃣", "4️⃣"]),
+          .fromScope(GuardStmtSyntax.self, expectedNames: ["4️⃣", "2️⃣"]),
           .fromScope(CodeBlockSyntax.self, expectedNames: ["1️⃣"]),
         ],
       ],
@@ -513,10 +544,22 @@ final class testNameLookup: XCTestCase {
         let 🔟a = 0️⃣d
         """,
       references: [
-        "3️⃣": [.fromFileScope(expectedNames: ["1️⃣", "8️⃣"])],
-        "4️⃣": [.fromFileScope(expectedNames: ["2️⃣"])],
-        "5️⃣": [.fromFileScope(expectedNames: ["7️⃣"])],
-        "6️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
+        "3️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["1️⃣", "8️⃣"]),
+        ],
+        "4️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["2️⃣"]),
+        ],
+        "5️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["7️⃣"]),
+        ],
+        "6️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["9️⃣"]),
+        ],
         "0️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
       ],
       expectedResultTypes: .all(ClassDeclSyntax.self, except: ["8️⃣": IdentifierPatternSyntax.self])
@@ -543,10 +586,22 @@ final class testNameLookup: XCTestCase {
         let 🔟a = 0️⃣d
         """,
       references: [
-        "3️⃣": [.fromFileScope(expectedNames: ["1️⃣", "8️⃣", "🔟"])],
-        "4️⃣": [.fromFileScope(expectedNames: ["2️⃣"])],
-        "5️⃣": [.fromFileScope(expectedNames: ["7️⃣"])],
-        "6️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
+        "3️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["1️⃣", "8️⃣", "🔟"]),
+        ],
+        "4️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["2️⃣"]),
+        ],
+        "5️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["7️⃣"]),
+        ],
+        "6️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromFileScope(expectedNames: ["9️⃣"]),
+        ],
         "0️⃣": [.fromFileScope(expectedNames: ["9️⃣"])],
       ],
       expectedResultTypes: .all(
@@ -605,29 +660,35 @@ final class testNameLookup: XCTestCase {
   func testImplicitSelf() {
     assertLexicalNameLookup(
       source: """
-        1️⃣extension a {
-          2️⃣struct b {
-            func foo() {
+        extension a {
+          struct b {
+            2️⃣func foo() {
               let x: 3️⃣Self = 4️⃣self
             }
           }
 
-          func bar() {
+          1️⃣func bar() {
             let x: 5️⃣Self = 6️⃣self
           }
         }
         """,
       references: [
         "3️⃣": [
-          .fromScope(StructDeclSyntax.self, expectedNames: [NameExpectation.implicit(.Self("2️⃣"))]),
-          .fromScope(ExtensionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.Self("1️⃣"))]),
+          .lookInMembers(StructDeclSyntax.self),
+          .lookInMembers(ExtensionDeclSyntax.self),
         ],
         "4️⃣": [
-          .fromScope(StructDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("2️⃣"))]),
-          .fromScope(ExtensionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("2️⃣"))]),
+          .lookInMembers(StructDeclSyntax.self),
+          .lookInMembers(ExtensionDeclSyntax.self),
         ],
-        "5️⃣": [.fromScope(ExtensionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.Self("1️⃣"))])],
-        "6️⃣": [.fromScope(ExtensionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))])],
+        "5️⃣": [
+          .lookInMembers(ExtensionDeclSyntax.self)
+        ],
+        "6️⃣": [
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .lookInMembers(ExtensionDeclSyntax.self),
+        ],
       ]
     )
   }
@@ -677,16 +738,16 @@ final class testNameLookup: XCTestCase {
   func testBacktickCompatibility() {
     assertLexicalNameLookup(
       source: """
-        1️⃣struct Foo {
-          func test() {
+        struct Foo {
+          1️⃣func test() {
             let 2️⃣`self` = 1
             print(3️⃣self)
             print(4️⃣`self`)
           }
         }
 
-        5️⃣struct Bar {
-          func test() {
+        struct Bar {
+          5️⃣func test() {
             print(6️⃣self)
             let 7️⃣`self` = 1
             print(8️⃣`self`)
@@ -696,18 +757,22 @@ final class testNameLookup: XCTestCase {
       references: [
         "3️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("2️⃣")]),
-          .fromScope(StructDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .lookInMembers(StructDeclSyntax.self),
         ],
         "4️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("2️⃣")]),
-          .fromScope(StructDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .lookInMembers(StructDeclSyntax.self),
         ],
         "6️⃣": [
-          .fromScope(StructDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("5️⃣"))])
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("5️⃣"))]),
+          .lookInMembers(StructDeclSyntax.self),
         ],
         "8️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("7️⃣")]),
-          .fromScope(StructDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("5️⃣"))]),
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("5️⃣"))]),
+          .lookInMembers(StructDeclSyntax.self),
         ],
       ]
     )
@@ -716,8 +781,8 @@ final class testNameLookup: XCTestCase {
   func testImplicitSelfOverride() {
     assertLexicalNameLookup(
       source: """
-        1️⃣class Foo {
-          func test() {
+        class Foo {
+          1️⃣func test() {
             let 2️⃣`Self` = "abc"
             print(3️⃣Self.self)
 
@@ -729,11 +794,12 @@ final class testNameLookup: XCTestCase {
       references: [
         "3️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("2️⃣")]),
-          .fromScope(ClassDeclSyntax.self, expectedNames: [NameExpectation.implicit(.Self("1️⃣"))]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
         "5️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("4️⃣")]),
-          .fromScope(ClassDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .fromScope(FunctionDeclSyntax.self, expectedNames: [NameExpectation.implicit(.self("1️⃣"))]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
       ]
     )
@@ -825,7 +891,7 @@ final class testNameLookup: XCTestCase {
       references: [
         "7️⃣": [
           .fromScope(GuardStmtSyntax.self, expectedNames: ["6️⃣"]),
-          .fromScope(CodeBlockSyntax.self, expectedNames: ["1️⃣", "4️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["4️⃣", "1️⃣"]),
         ],
         "8️⃣": [
           .fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣"]),
@@ -876,13 +942,25 @@ final class testNameLookup: XCTestCase {
         }
         """,
       references: [
-        "3️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"])],
-        "4️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["2️⃣"])],
+        "3️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "4️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["2️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
         "6️⃣": [
           .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["5️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
           .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
-        "8️⃣": [.fromScope(MemberBlockSyntax.self, expectedNames: ["7️⃣"])],
+        "8️⃣": [
+          .lookInMembers(ClassDeclSyntax.self),
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["7️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
       ],
       expectedResultTypes: .all(GenericParameterSyntax.self, except: ["7️⃣": IdentifierPatternSyntax.self])
     )
@@ -891,13 +969,25 @@ final class testNameLookup: XCTestCase {
   func testGenericParameterOrdering() {
     assertLexicalNameLookup(
       source: """
-        class Foo<1️⃣A: 2️⃣A, B: 3️⃣A, 4️⃣C: 5️⃣D, D: 6️⃣C> {}
+        class Foo<1️⃣A: 2️⃣A, B: 3️⃣A, 4️⃣C: 5️⃣D, 7️⃣D: 6️⃣C> {}
         """,
       references: [
-        "2️⃣": [],
-        "3️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"])],
-        "5️⃣": [],
-        "6️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"])],
+        "2️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "3️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "5️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["7️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "6️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
       ],
       expectedResultTypes: .all(GenericParameterSyntax.self)
     )
@@ -949,14 +1039,25 @@ final class testNameLookup: XCTestCase {
         "6️⃣": [
           .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["3️⃣"]),
           .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
-        "8️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"])],
-        "9️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"])],
+        "8️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "9️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["4️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
         "0️⃣": [
           .fromScope(FunctionDeclSyntax.self, expectedNames: ["5️⃣"]),
           .fromScope(MemberBlockSyntax.self, expectedNames: ["2️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
         ],
-        "🔟": [.fromScope(FunctionDeclSyntax.self, expectedNames: ["7️⃣"])],
+        "🔟": [
+          .fromScope(FunctionDeclSyntax.self, expectedNames: ["7️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
       ],
       expectedResultTypes: .all(
         GenericParameterSyntax.self,
@@ -981,12 +1082,30 @@ final class testNameLookup: XCTestCase {
         }
         """,
       references: [
-        "4️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"])],
-        "6️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["2️⃣"])],
-        "7️⃣": [.fromScope(GenericParameterClauseSyntax.self, expectedNames: ["2️⃣"])],
-        "8️⃣": [.fromScope(SubscriptDeclSyntax.self, expectedNames: ["3️⃣"])],
-        "9️⃣": [.fromScope(SubscriptDeclSyntax.self, expectedNames: ["5️⃣"])],
-        "🔟": [.fromScope(MemberBlockSyntax.self, expectedNames: ["0️⃣"])],
+        "4️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["1️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "6️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["2️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "7️⃣": [
+          .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["2️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "8️⃣": [
+          .fromScope(SubscriptDeclSyntax.self, expectedNames: ["3️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "9️⃣": [
+          .fromScope(SubscriptDeclSyntax.self, expectedNames: ["5️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
+        "🔟": [
+          .fromScope(MemberBlockSyntax.self, expectedNames: ["0️⃣"]),
+          .lookInMembers(ClassDeclSyntax.self),
+        ],
       ],
       expectedResultTypes: .all(
         GenericParameterSyntax.self,

--- a/Tests/SwiftLexicalLookupTest/ResultExpectation.swift
+++ b/Tests/SwiftLexicalLookupTest/ResultExpectation.swift
@@ -18,6 +18,7 @@ import XCTest
 enum ResultExpectation {
   case fromScope(ScopeSyntax.Type, expectedNames: [ExpectedName])
   case fromFileScope(expectedNames: [ExpectedName])
+  case lookInMembers(LookInMembersScopeSyntax.Type)
 
   var expectedNames: [ExpectedName] {
     switch self {
@@ -25,6 +26,8 @@ enum ResultExpectation {
       return expectedNames
     case .fromFileScope(expectedNames: let expectedNames):
       return expectedNames
+    case .lookInMembers:
+      return []
     }
   }
 
@@ -34,6 +37,8 @@ enum ResultExpectation {
       return "fromScope"
     case .fromFileScope:
       return "fromFileScope"
+    case .lookInMembers:
+      return "lookInMembers"
     }
   }
 
@@ -57,22 +62,16 @@ enum ResultExpectation {
         NameExpectation.assertNames(marker: marker, acutalNames: actualNames, expectedNames: expectedNames)
       case (.fromFileScope(_, let actualNames), .fromFileScope(let expectedNames)):
         NameExpectation.assertNames(marker: marker, acutalNames: actualNames, expectedNames: expectedNames)
+      case (.lookInMembers(let scope), .lookInMembers(let expectedType)):
+        XCTAssert(
+          scope.syntaxNodeType == expectedType,
+          "For marker \(marker), scope result type of \(scope.syntaxNodeType) doesn't match expected \(expectedType)"
+        )
       default:
         XCTFail(
           "For marker \(marker), actual result kind \(actual.debugDescription) doesn't match expected \(expected.debugDescription)"
         )
       }
-    }
-  }
-}
-
-extension LookupResult {
-  var debugDescription: String {
-    switch self {
-    case .fromScope:
-      return "fromScope"
-    case .fromFileScope:
-      return "fromFileScope"
     }
   }
 }


### PR DESCRIPTION
This PR brings closer the current `SwiftLexicalLookup` unqualified lookup implementation to `ASTScope`. Changes include:
- New `lookInMembers` result kind. It prompts client where to perform member lookup.
- Add configuration to not include member names. Compiler doesn't introduce members during unqualified lookup itself.
- Add configuration to terminate lookup early in first encountered sequential scope. It's supposed to match behavior of `ASTScope::lookupLocalDecls` `stopAfterInnermostBraceStmt` parameter.
- Fix `self` keyword behavior. Compiler introduces it on a function boundary, that's why this PR moves it into function declaration scope.
- Reverse order of name introductions in sequential scopes.
- Make closure expression a sequential scope to properly handle it's children.
- Remove setting of `accessibleAfter` for generic parameters.
 
This PR also includes a simple debug description functionality for all lookup components to make it easier to work with the library.