### PR TITLE
[CoroutineAccessors] Add read and modify.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -113,6 +113,7 @@ public let DECL_NODES: [Node] = [
           .keyword(.mutableAddressWithOwner),
           .keyword(.mutableAddressWithNativeOwner),
           .keyword(._read),
+          .keyword(.read),
           .keyword(._modify),
           .keyword(.modify),
           .keyword(.`init`),

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -114,6 +114,7 @@ public let DECL_NODES: [Node] = [
           .keyword(.mutableAddressWithNativeOwner),
           .keyword(._read),
           .keyword(._modify),
+          .keyword(.modify),
           .keyword(.`init`),
         ])
       ),

--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -18,6 +18,7 @@ public enum ExperimentalFeature: String, CaseIterable {
   case doExpressions
   case nonescapableTypes
   case trailingComma
+  case coroutineAccessors
 
   /// The name of the feature, which is used in the doc comment.
   public var featureName: String {
@@ -32,6 +33,8 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "NonEscableTypes"
     case .trailingComma:
       return "trailing comma"
+    case .coroutineAccessors:
+      return "CoroutineAccessors"
     }
   }
 

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -246,6 +246,7 @@ public enum Keyword: CaseIterable {
   case `Protocol`
   case `protocol`
   case `public`
+  case read
   case reasync
   case renamed
   case `repeat`
@@ -631,6 +632,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("protocol", isLexerClassified: true)
     case .public:
       return KeywordSpec("public", isLexerClassified: true)
+    case .read:
+      return KeywordSpec("read")
     case .reasync:
       return KeywordSpec("reasync")
     case .renamed:

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -218,6 +218,7 @@ public enum Keyword: CaseIterable {
   case macro
   case message
   case metadata
+  case modify
   case module
   case mutableAddressWithNativeOwner
   case mutableAddressWithOwner
@@ -576,6 +577,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("message")
     case .metadata:
       return KeywordSpec("metadata")
+    case .modify:
+      return KeywordSpec("modify", experimentalFeature: .coroutineAccessors)
     case .module:
       return KeywordSpec("module")
     case .mutableAddressWithNativeOwner:

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -239,7 +239,7 @@ enum TokenPrecedence: Comparable {
       .dependsOn, .scoped, .sending,
       // Accessors
       .get, .set, .didSet, .willSet, .unsafeAddress, .addressWithOwner, .addressWithNativeOwner, .unsafeMutableAddress,
-      .mutableAddressWithOwner, .mutableAddressWithNativeOwner, ._read, ._modify,
+      .mutableAddressWithOwner, .mutableAddressWithNativeOwner, ._read, ._modify, .modify,
       // Misc
       .import:
       self = .declKeyword

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -239,7 +239,7 @@ enum TokenPrecedence: Comparable {
       .dependsOn, .scoped, .sending,
       // Accessors
       .get, .set, .didSet, .willSet, .unsafeAddress, .addressWithOwner, .addressWithNativeOwner, .unsafeMutableAddress,
-      .mutableAddressWithOwner, .mutableAddressWithNativeOwner, ._read, ._modify, .modify,
+      .mutableAddressWithOwner, .mutableAddressWithNativeOwner, ._read, .read, ._modify, .modify,
       // Misc
       .import:
       self = .declKeyword

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -38,4 +38,7 @@ extension Parser.ExperimentalFeatures {
 
   /// Whether to enable the parsing of trailing comma.
   public static let trailingComma = Self (rawValue: 1 << 4)
+
+  /// Whether to enable the parsing of CoroutineAccessors.
+  public static let coroutineAccessors = Self (rawValue: 1 << 5)
 }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -32,6 +32,7 @@ extension AccessorDeclSyntax {
     case mutableAddressWithOwner
     case mutableAddressWithNativeOwner
     case _read
+    case read
     case _modify
     #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
@@ -63,6 +64,8 @@ extension AccessorDeclSyntax {
         self = .mutableAddressWithNativeOwner
       case TokenSpec(._read):
         self = ._read
+      case TokenSpec(.read):
+        self = .read
       case TokenSpec(._modify):
         self = ._modify
       case TokenSpec(.modify) where experimentalFeatures.contains(.coroutineAccessors):
@@ -98,6 +101,8 @@ extension AccessorDeclSyntax {
         self = .mutableAddressWithNativeOwner
       case TokenSpec(._read):
         self = ._read
+      case TokenSpec(.read):
+        self = .read
       case TokenSpec(._modify):
         self = ._modify
       case TokenSpec(.modify):
@@ -133,6 +138,8 @@ extension AccessorDeclSyntax {
         return .keyword(.mutableAddressWithNativeOwner)
       case ._read:
         return .keyword(._read)
+      case .read:
+        return .keyword(.read)
       case ._modify:
         return .keyword(._modify)
       case .modify:
@@ -170,6 +177,8 @@ extension AccessorDeclSyntax {
         return .keyword(.mutableAddressWithNativeOwner)
       case ._read:
         return .keyword(._read)
+      case .read:
+        return .keyword(.read)
       case ._modify:
         return .keyword(._modify)
       case .modify:

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -33,6 +33,10 @@ extension AccessorDeclSyntax {
     case mutableAddressWithNativeOwner
     case _read
     case _modify
+    #if compiler(>=5.8)
+    @_spi(ExperimentalLanguageFeatures)
+    #endif
+    case modify
     case `init`
 
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -61,6 +65,8 @@ extension AccessorDeclSyntax {
         self = ._read
       case TokenSpec(._modify):
         self = ._modify
+      case TokenSpec(.modify) where experimentalFeatures.contains(.coroutineAccessors):
+        self = .modify
       case TokenSpec(.`init`):
         self = .`init`
       default:
@@ -94,6 +100,8 @@ extension AccessorDeclSyntax {
         self = ._read
       case TokenSpec(._modify):
         self = ._modify
+      case TokenSpec(.modify):
+        self = .modify
       case TokenSpec(.`init`):
         self = .`init`
       default:
@@ -127,6 +135,8 @@ extension AccessorDeclSyntax {
         return .keyword(._read)
       case ._modify:
         return .keyword(._modify)
+      case .modify:
+        return .keyword(.modify)
       case .`init`:
         return .keyword(.`init`)
       }
@@ -162,6 +172,8 @@ extension AccessorDeclSyntax {
         return .keyword(._read)
       case ._modify:
         return .keyword(._modify)
+      case .modify:
+        return .keyword(.modify)
       case .`init`:
         return .keyword(.`init`)
       }

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -161,6 +161,10 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case macro
   case message
   case metadata
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  case modify
   case module
   case mutableAddressWithNativeOwner
   case mutableAddressWithOwner
@@ -416,6 +420,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .inline
       case "linear":
         self = .linear
+      case "modify":
+        self = .modify
       case "module":
         self = .module
       case "prefix":
@@ -946,6 +952,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
     "macro",
     "message",
     "metadata",
+    "modify",
     "module",
     "mutableAddressWithNativeOwner",
     "mutableAddressWithOwner",

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -192,6 +192,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case `Protocol`
   case `protocol`
   case `public`
+  case read
   case reasync
   case renamed
   case `repeat`
@@ -326,6 +327,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .objc
       case "open":
         self = .open
+      case "read":
+        self = .read
       case "safe":
         self = .safe
       case "self":
@@ -980,6 +983,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
     "Protocol",
     "protocol",
     "public",
+    "read",
     "reasync",
     "renamed",
     "repeat",

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -243,6 +243,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       .keyword("mutableAddressWithNativeOwner"),
       .keyword("_read"),
       .keyword("_modify"),
+      .keyword("modify"),
       .keyword("init")
     ]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -242,6 +242,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       .keyword("mutableAddressWithOwner"),
       .keyword("mutableAddressWithNativeOwner"),
       .keyword("_read"),
+      .keyword("read"),
       .keyword("_modify"),
       .keyword("modify"),
       .keyword("init")

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -251,7 +251,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `modifier`: ``DeclModifierSyntax``?
-///  - `accessorSpecifier`: (`get` | `set` | `didSet` | `willSet` | `unsafeAddress` | `addressWithOwner` | `addressWithNativeOwner` | `unsafeMutableAddress` | `mutableAddressWithOwner` | `mutableAddressWithNativeOwner` | `_read` | `_modify` | `modify` | `init`)
+///  - `accessorSpecifier`: (`get` | `set` | `didSet` | `willSet` | `unsafeAddress` | `addressWithOwner` | `addressWithNativeOwner` | `unsafeMutableAddress` | `mutableAddressWithOwner` | `mutableAddressWithNativeOwner` | `_read` | `read` | `_modify` | `modify` | `init`)
 ///  - `parameters`: ``AccessorParametersSyntax``?
 ///  - `effectSpecifiers`: ``AccessorEffectSpecifiersSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
@@ -418,6 +418,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
   ///  - `mutableAddressWithOwner`
   ///  - `mutableAddressWithNativeOwner`
   ///  - `_read`
+  ///  - `read`
   ///  - `_modify`
   ///  - `modify`
   ///  - `init`

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -251,7 +251,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `modifier`: ``DeclModifierSyntax``?
-///  - `accessorSpecifier`: (`get` | `set` | `didSet` | `willSet` | `unsafeAddress` | `addressWithOwner` | `addressWithNativeOwner` | `unsafeMutableAddress` | `mutableAddressWithOwner` | `mutableAddressWithNativeOwner` | `_read` | `_modify` | `init`)
+///  - `accessorSpecifier`: (`get` | `set` | `didSet` | `willSet` | `unsafeAddress` | `addressWithOwner` | `addressWithNativeOwner` | `unsafeMutableAddress` | `mutableAddressWithOwner` | `mutableAddressWithNativeOwner` | `_read` | `_modify` | `modify` | `init`)
 ///  - `parameters`: ``AccessorParametersSyntax``?
 ///  - `effectSpecifiers`: ``AccessorEffectSpecifiersSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
@@ -419,6 +419,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
   ///  - `mutableAddressWithNativeOwner`
   ///  - `_read`
   ///  - `_modify`
+  ///  - `modify`
   ///  - `init`
   public var accessorSpecifier: TokenSyntax {
     get {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3334,4 +3334,20 @@ final class DeclarationTests: ParserTestCase {
       )
     )
   }
+
+  func testCoroutineAccessors() {
+    assertParse(
+      """
+      var i_rm: Int {
+        _read {
+          yield _i
+        }
+        modify {
+          yield &_i
+        }
+      }
+      """,
+      experimentalFeatures: .coroutineAccessors
+    )
+  }
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3339,7 +3339,7 @@ final class DeclarationTests: ParserTestCase {
     assertParse(
       """
       var i_rm: Int {
-        _read {
+        read {
           yield _i
         }
         modify {


### PR DESCRIPTION
Enable parsing the new keywords behind the CoroutineAccessors experimental feature.
