### PR TITLE
[6.0] Allow building swift-syntax in C++ interop mode

### DIFF
--- a/Sources/_SwiftSyntaxCShims/include/AtomicBool.h
+++ b/Sources/_SwiftSyntaxCShims/include/AtomicBool.h
@@ -21,7 +21,7 @@ typedef struct {
 } AtomicBool;
 
 static inline AtomicBool *_Nonnull swiftsyntax_atomic_bool_create(bool initialValue) {
-  AtomicBool *atomic = malloc(sizeof(AtomicBool));
+  AtomicBool *atomic = (AtomicBool *)malloc(sizeof(AtomicBool));
   atomic->value = initialValue;
   return atomic;
 }


### PR DESCRIPTION
- **Explanation**: If swift-syntax is being built with `-cxx-interoperability-mode=default`, it fails because of `cannot initialize a variable of type 'AtomicBool *' with an rvalue of type 'void *'`. Add a cast here to fix the build issue.
- **Scope**: Build of swift-syntax in C++ interop mode
- **Risk**: Very low, just adding an explicit cast from `void *` to `AtomicBool *`
- **Testing**: n/a
- **Issue**: rdar://129252735
- **Reviewer**:   @bnbarham on https://github.com/swiftlang/swift-syntax/pull/2752