### PR TITLE
Use fully-qualified types instead of `@retroactive` conformances

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
@@ -43,7 +43,7 @@ let syntaxExpressibleByStringInterpolationConformancesFile = SourceFileSyntax(le
     DeclSyntax(
       """
       #if compiler(>=6)
-      extension \(type): @retroactive ExpressibleByStringInterpolation {}
+      extension \(type): Swift.ExpressibleByStringInterpolation {}
       #endif
       """
     )

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -83,7 +83,7 @@ extension BooleanLiteralExprSyntax {
   }
 }
 #if compiler(>=6)
-extension BooleanLiteralExprSyntax: @retroactive ExpressibleByBooleanLiteral {}
+extension BooleanLiteralExprSyntax: Swift.ExpressibleByBooleanLiteral {}
 #else
 extension BooleanLiteralExprSyntax: ExpressibleByBooleanLiteral {}
 #endif
@@ -184,7 +184,7 @@ extension FloatLiteralExprSyntax {
 }
 
 #if compiler(>=6)
-extension FloatLiteralExprSyntax: @retroactive ExpressibleByFloatLiteral {}
+extension FloatLiteralExprSyntax: Swift.ExpressibleByFloatLiteral {}
 #else
 extension FloatLiteralExprSyntax: ExpressibleByFloatLiteral {}
 #endif
@@ -227,7 +227,7 @@ extension IntegerLiteralExprSyntax {
 }
 
 #if compiler(>=6)
-extension IntegerLiteralExprSyntax: @retroactive ExpressibleByIntegerLiteral {}
+extension IntegerLiteralExprSyntax: Swift.ExpressibleByIntegerLiteral {}
 #else
 extension IntegerLiteralExprSyntax: ExpressibleByIntegerLiteral {}
 #endif

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -466,7 +466,7 @@ extension TokenSyntax: SyntaxExpressibleByStringInterpolation {
 #if compiler(>=6)
 // Silence warning that TokenSyntax has a retroactive conformance to `ExpressibleByStringInterpolation` through
 // `SyntaxExpressibleByStringInterpolation`.
-extension TokenSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension TokenSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 // MARK: - Trivia expressible as string
@@ -515,7 +515,7 @@ extension Trivia {
 }
 
 #if compiler(>=6)
-extension Trivia: @retroactive ExpressibleByStringInterpolation {}
+extension Trivia: Swift.ExpressibleByStringInterpolation {}
 #else
 extension Trivia: ExpressibleByStringInterpolation {}
 #endif

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -21,138 +21,138 @@ import SwiftSyntax
 extension AccessorBlockSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension AccessorBlockSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension AccessorBlockSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension AccessorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension AccessorDeclSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension AccessorDeclSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension AttributeSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension AttributeSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension AttributeSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension CatchClauseSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension CatchClauseSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension ClosureParameterSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension ClosureParameterSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension ClosureParameterSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension CodeBlockItemSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension CodeBlockItemSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension CodeBlockItemSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension CodeBlockSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension CodeBlockSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension CodeBlockSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension DeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension DeclSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension DeclSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension EnumCaseParameterSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension EnumCaseParameterSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension EnumCaseParameterSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension ExprSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension ExprSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension ExprSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension FunctionParameterSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension FunctionParameterSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension FunctionParameterSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension GenericParameterClauseSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension GenericParameterClauseSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension GenericParameterClauseSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension MemberBlockSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension MemberBlockSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension MemberBlockSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension PatternSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension PatternSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension PatternSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension SourceFileSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension SourceFileSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension SourceFileSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension StmtSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension StmtSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension StmtSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension SwitchCaseSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension SwitchCaseSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension SwitchCaseSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension TypeSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension TypeSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension TypeSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension VersionTupleSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension VersionTupleSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension VersionTupleSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension AccessorDeclListSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension AccessorDeclListSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension AccessorDeclListSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension AttributeListSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension AttributeListSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension AttributeListSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension CodeBlockItemListSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension CodeBlockItemListSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension CodeBlockItemListSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 
 extension MemberBlockItemListSyntax: SyntaxExpressibleByStringInterpolation {}
 
 #if compiler(>=6)
-extension MemberBlockItemListSyntax: @retroactive ExpressibleByStringInterpolation {}
+extension MemberBlockItemListSyntax: Swift.ExpressibleByStringInterpolation {}
 #endif
 


### PR DESCRIPTION
When increasing the tools version of swift-syntax to 5.9 or higher, the package is built with `-package-name`. It appears that conformances within the same package domain are not considered retroactive, which means that the addition of `@retroactive` produces a compilation error.

To allow swift-syntax to build both within a single package domain and without, use fully-qualified types instead of `@retroactive` in the potentially retroactive conformances.

Fixes #2844