### PR TITLE
Fix `CodeGenerationFormat` to correctly handle trailing trivia when formatting list elements

### DIFF
--- a/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
+++ b/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
@@ -158,7 +158,14 @@ public class CodeGenerationFormat: BasicFormat {
     }
     formattedChildren = formattedChildren.map { child in
       var child = child
-      child.trailingTrivia = Trivia(pieces: child.trailingTrivia.drop(while: \.isSpaceOrTab))
+
+      if let firstNonSpaceOrTabIndex = child.trailingTrivia.firstIndex(where: { !$0.isSpaceOrTab }) {
+        if child.trailingTrivia[firstNonSpaceOrTabIndex].isNewline {
+          child.trailingTrivia = Trivia(pieces: child.trailingTrivia.suffix(from: firstNonSpaceOrTabIndex))
+        }
+      } else {
+        child.trailingTrivia = Trivia()
+      }
 
       if !child.startsOnNewline {
         child.leadingTrivia = indentedNewline + child.leadingTrivia

--- a/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
+++ b/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
@@ -173,13 +173,15 @@ public class CodeGenerationFormat: BasicFormat {
       return child
     }
     decreaseIndentationLevel()
-    if let lastChild = formattedChildren.last {
+    if let lastChild = formattedChildren.last,
+      !lastChild.trailingTrivia.contains(where: \.isNewline)
+    {
       let nextTokenStartsWithNewline =
         lastChild.nextToken(viewMode: .sourceAccurate)?.leadingTrivia.first?.isNewline ?? false
       if !nextTokenStartsWithNewline {
         formattedChildren[formattedChildren.count - 1] = lastChild.with(
           \.trailingTrivia,
-          indentedNewline
+          lastChild.trailingTrivia + indentedNewline
         )
       }
     }


### PR DESCRIPTION
This fixes 2 issues with how `CodeGenerationFormat` handles trailing trivia when formatting lists to be separated by a newline. These issues don't manifest in the current codebase, but the fixes in this PR will prevent them from appearing in the future. Examples are provided below.

## [Change `CodeGenerationFormat` to keep whitespace after comma if it precedes other trivia on the same line](https://github.com/swiftlang/swift-syntax/commit/e08a18392cf7b4a37eb149ba563a0230f3a213bc)

### Example

```swift
DeclSyntax(
  """
  public static func \(tokenSpec.funcDeclName)(
    _ value: Keyword, // EXAMPLE <--
    leadingTrivia: Trivia = [],
    trailingTrivia: Trivia = [],
    presence: SourcePresence = .present
  ) -> TokenSyntax {
    // ...
  }
  """
)
```
#### Before (missing space between `,` and `//`)
```swift
public static func keyword(
  _ value: Keyword,// EXAMPLE <--
  leadingTrivia: Trivia = [],
  trailingTrivia: Trivia = [],
  presence: SourcePresence = .present
) -> TokenSyntax {
  // ...
}
```
#### After
```swift
public static func keyword(
  _ value: Keyword, // EXAMPLE <--
  leadingTrivia: Trivia = [],
  trailingTrivia: Trivia = [],
  presence: SourcePresence = .present
) -> TokenSyntax {
  // ...
}
```

### Another example
```swift
DeclSyntax(
  """
  func verify<Node: RawSyntaxNodeProtocol>(_ raw: RawSyntax?, /* EXAMPLE <-- */ as _: Node.Type, file: StaticString = #fileID, line: UInt = #line) -> ValidationError? {
    // ...
  }
  """
)
```
#### Before (missing space between `,` and `/*`)
```swift
func verify<Node: RawSyntaxNodeProtocol>(
  _ raw: RawSyntax?,/* EXAMPLE <-- */ 
  as _: Node.Type,
  file: StaticString = #fileID,
  line: UInt = #line
) -> ValidationError? {
  // ...
}
```
#### After
```swift
func verify<Node: RawSyntaxNodeProtocol>(
  _ raw: RawSyntax?, /* EXAMPLE <-- */ 
  as _: Node.Type,
  file: StaticString = #fileID,
  line: UInt = #line
) -> ValidationError? {
  // ...
}
```

## [Fix `CodeGenerationFormat` to keep existing trailing trivia when adding a newline after the last element of a list](https://github.com/swiftlang/swift-syntax/commit/1d831905f784ce7877de045924e3817f7124ba3d)

### Example

```swift
DeclSyntax(
  """
  func verify<Node: RawSyntaxNodeProtocol>(_ raw: RawSyntax?, as _: Node.Type, file: StaticString = #fileID, line: UInt = #line /* EXAMPLE <-- */) -> ValidationError? {
    // ...
  }
  """
)
```

#### Before (missing  `/* EXAMPLE <-- */`)
```swift
func verify<Node: RawSyntaxNodeProtocol>(
  _ raw: RawSyntax?,
  as _: Node.Type,
  file: StaticString = #fileID,
  line: UInt = #line
) -> ValidationError? {
  // ...
}
```

#### After
```swift
func verify<Node: RawSyntaxNodeProtocol>(
  _ raw: RawSyntax?,
  as _: Node.Type,
  file: StaticString = #fileID,
  line: UInt = #line /* EXAMPLE <-- */
) -> ValidationError? {
  // ...
}
```