### PR TITLE
Fixing typo in deinit documentation

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -488,7 +488,7 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "deinitializer",
     documentation: """
-      A `deint` declaration
+      A `deinit` declaration
 
       An example of a deinitializer is
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -846,7 +846,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 
 // MARK: - DeinitializerDeclSyntax
 
-/// A `deint` declaration
+/// A `deinit` declaration
 /// 
 /// An example of a deinitializer is
 /// 


### PR DESCRIPTION
# Changes
- Fixing a typo in the deinitializer documentation from `deint` to `deinit`

Generated source code using `./swift-syntax-dev-utils generate-source-code` and ran the pre-checks `./swift-syntax-dev-utils local-pr-precheck`