### PR TITLE
Support parsing of key path subscripts on metatypes

### DIFF
--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -190,9 +190,8 @@ extension Parser {
     return parseSimpleType(forAttributeName: true)
   }
 
-  /// Parse a "simple" type
   mutating func parseSimpleType(
-    stopAtFirstPeriod: Bool = false,
+    allowMemberTypes: Bool = true,
     forAttributeName: Bool = false
   ) -> RawTypeSyntax {
     enum TypeBaseStart: TokenSpecSet {
@@ -260,7 +259,7 @@ extension Parser {
 
     var loopProgress = LoopProgressCondition()
     while self.hasProgressed(&loopProgress) {
-      if !stopAtFirstPeriod, self.at(.period) {
+      if self.at(.period) && (allowMemberTypes || self.peek(isAt: .keyword(.Type), .keyword(.Protocol))) {
         let (unexpectedPeriod, period, skipMemberName) = self.consumeMemberPeriod(previousNode: base)
         if skipMemberName {
           let missingIdentifier = missingToken(.identifier)


### PR DESCRIPTION
This is needed to support parsing eg.
https://github.com/swiftlang/swift/pull/73242/files#diff-a94f38549dc87ce27c438b255ae2f29c69cc1c2c5e5069f327c5c7fae7bc553dR667