### PR TITLE
[CMake] Disable `SWIFTSYNTAX_EMIT_MODULE` by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,6 @@ if(SWIFT_SUPPORTS_DISABLE_IMPLICIT_BACKTRACING_MODULE_IMPORT)
   add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-backtracing-module-import>")
 endif()
 
-# SWIFTSYNTAX_EMIT_MODULE is TRUE by default
-if(NOT DEFINED SWIFTSYNTAX_EMIT_MODULE)
-  set(SWIFTSYNTAX_EMIT_MODULE TRUE)
-endif()
-
 if(NOT DEFINED Swift_COMPILER_PACKAGE_CMO_SUPPORT AND SWIFTSYNTAX_EMIT_MODULE)
   swift_get_package_cmo_support(Swift_COMPILER_PACKAGE_CMO_SUPPORT)
 endif()


### PR DESCRIPTION
`SWIFTSYNTAX_EMIT_MODULE` flag is for compiling swift-syntax with library evolution enabled. But that is only useful for limited use cases. When using swift-syntax just as a CMake dependencies, not-enabling library evolution is probably the desired behavior.