### PR TITLE
Fix three broken links

### DIFF
--- a/Contributor Documentation/Changing Swift Syntax.md
+++ b/Contributor Documentation/Changing Swift Syntax.md
@@ -65,7 +65,7 @@ Node(
 
 Added syntactic elements will require corresponding changes to the included
 SwiftParser library. For an introduction on parsing Swift nodes, see
-[the article on Parsing Basics](https://github.com/swiftlang/swift-syntax/tree/main/Sources/SwiftParser/SwiftParser.docc/ParsingBasics.md).
+[the article on Parsing Basics](./Parsing%20Basics.md).
 
 When updating nodes, certain clients of SwiftSyntax that are relying upon those
 nodes will need to be changed in tandem. For example, the

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -4,7 +4,7 @@ Each example can be executed by navigating into this folder and running `swift r
 
 - [AddOneToIntegerLiterals](Sources/AddOneToIntegerLiterals/AddOneToIntegerLiterals.swift): Command line tool to add 1 to every integer literal in a source file
 - [CodeGenerationUsingSwiftSyntaxBuilder](Sources/CodeGenerationUsingSwiftSyntaxBuilder/CodeGenerationUsingSwiftSyntaxBuilder.swift): Code-generate a simple source file using SwiftSyntaxBuilder
-- [ExamplePlugin](Sources/ExamplePlugin): Compiler plugin executable using [`SwiftCompilerPlugin`](../Sources/SwiftCompilerPlugin)
+- [ExamplePlugin](Examples/Sources/MacroExamples/Implementation/Plugin.swift): Compiler plugin executable using [`SwiftCompilerPlugin`](../Sources/SwiftCompilerPlugin)
 - [MacroExamples](Sources/MacroExamples): A collection of Swift macros
 
 Furthermore, SwiftSyntax uses [`SwiftSyntaxBuilder`](../Sources/SwiftSyntaxBuilder) extensively to generate its own code. That code can be found in the [CodeGeneration](../CodeGeneration) package.

--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -68,7 +68,7 @@
 
 - `DeclGroupSyntax.introducer`
   - Description: The `DeclGroupSyntax` trait has an extra `introducer` property, ie. the keyword that introduces the declaration.
-  - Issue: https://github.com/swiftlang/sourcekit-lsp/issues/2535
+  - Issue: https://github.com/swiftlang/swift-syntax/issues/2535
   - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2539
 
 - `ExprSyntax.interpretedAsVersionTuple`


### PR DESCRIPTION
Fixes up several broken links in the documentation:
- ExamplePlugin was rolled in to the MacroExamples in #2222 but the link was not updated.
- A link the changelog pointed to sourcekit-lsp when it should have been swift-syntax.
- The Parsing Basics document has moved.