### PR TITLE
Fix all documentation warnings about mislabeled parameters

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -88,7 +88,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     DeclSyntax(
       """
       /// Visit a ``TokenSyntax``.
-      ///   - Parameter node: the node that is being visited
+      ///   - Parameter token: the token that is being visited
       ///   - Returns: the rewritten node
       open func visit(_ token: TokenSyntax) -> TokenSyntax {
         return token

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxVisitorFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxVisitorFile.swift
@@ -84,7 +84,7 @@ let syntaxVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     DeclSyntax(
       """
       /// Visiting ``TokenSyntax`` specifically.
-      ///   - Parameter node: the node we are visiting.
+      ///   - Parameter token: the token we are visiting.
       ///   - Returns: how should we continue visiting.
       open func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
         return .visitChildren

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/TriviaPiecesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/TriviaPiecesFile.swift
@@ -55,13 +55,13 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Prints the provided trivia as they would be written in a source file.
       ///
       /// - Parameter stream: The stream to which to print the trivia.
-      public func write(to target: inout some TextOutputStream)
+      public func write(to stream: inout some TextOutputStream)
       """
     ) {
       DeclSyntax(
         """
         func printRepeated(_ character: String, count: Int) {
-          for _ in 0..<count { target.write(character) }
+          for _ in 0..<count { stream.write(character) }
         }
         """
       )
@@ -75,7 +75,7 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           } else {
             SwitchCaseSyntax("case let .\(trivia.enumCaseName)(text):") {
-              ExprSyntax("target.write(text)")
+              ExprSyntax("stream.write(text)")
             }
           }
         }

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -583,9 +583,9 @@ extension SyntaxProtocol {
 
   /// Prints the raw value of this node to the provided stream.
   /// - Parameter stream: The stream to which to print the raw tree.
-  public func write<Target>(to target: inout Target)
+  public func write<Target>(to stream: inout Target)
   where Target: TextOutputStream {
-    Syntax(self).raw.write(to: &target)
+    Syntax(self).raw.write(to: &stream)
   }
 
   /// A copy of this node without the leading trivia of the first token in the
@@ -667,8 +667,8 @@ extension SyntaxProtocol {
   ///   `[startLine:startCol...endLine:endCol]` to each node.
   ///   - mark: Adds `***` around the given node, intended to highlight it in
   ///   the dump.
-  ///   - indentLevel: The starting indent level, 0 by default. Each level is 2
-  ///   spaces.
+  ///   - indentString: The starting indentation, empty by default. Each
+  ///   additional indentation will add 2 spaces.
   public func debugDescription(
     includeTrivia: Bool = false,
     converter: SourceLocationConverter? = nil,

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -140,9 +140,9 @@ extension Trivia: TextOutputStreamable {
   /// Prints the provided trivia as they would be written in a source file.
   ///
   /// - Parameter stream: The stream to which to print the trivia.
-  public func write(to target: inout some TextOutputStream) {
+  public func write(to stream: inout some TextOutputStream) {
     for piece in pieces {
-      piece.write(to: &target)
+      piece.write(to: &stream)
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -59,7 +59,7 @@ open class SyntaxRewriter {
   }
 
   /// Visit a ``TokenSyntax``.
-  ///   - Parameter node: the node that is being visited
+  ///   - Parameter token: the token that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ token: TokenSyntax) -> TokenSyntax {
     return token

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -3465,7 +3465,7 @@ open class SyntaxVisitor {
   }
 
   /// Visiting ``TokenSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
+  ///   - Parameter token: the token we are visiting.
   ///   - Returns: how should we continue visiting.
   open func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren

--- a/Sources/SwiftSyntax/generated/TriviaPieces.swift
+++ b/Sources/SwiftSyntax/generated/TriviaPieces.swift
@@ -55,29 +55,29 @@ extension TriviaPiece: TextOutputStreamable {
   /// Prints the provided trivia as they would be written in a source file.
   ///
   /// - Parameter stream: The stream to which to print the trivia.
-  public func write(to target: inout some TextOutputStream) {
+  public func write(to stream: inout some TextOutputStream) {
     func printRepeated(_ character: String, count: Int) {
       for _ in 0 ..< count {
-        target.write(character)
+        stream.write(character)
       }
     }
     switch self {
     case let .backslashes(count):
       printRepeated(#"\"#, count: count)
     case let .blockComment(text):
-      target.write(text)
+      stream.write(text)
     case let .carriageReturns(count):
       printRepeated("\r", count: count)
     case let .carriageReturnLineFeeds(count):
       printRepeated("\r\n", count: count)
     case let .docBlockComment(text):
-      target.write(text)
+      stream.write(text)
     case let .docLineComment(text):
-      target.write(text)
+      stream.write(text)
     case let .formfeeds(count):
       printRepeated("\u{c}", count: count)
     case let .lineComment(text):
-      target.write(text)
+      stream.write(text)
     case let .newlines(count):
       printRepeated("\n", count: count)
     case let .pounds(count):
@@ -87,7 +87,7 @@ extension TriviaPiece: TextOutputStreamable {
     case let .tabs(count):
       printRepeated("\t", count: count)
     case let .unexpectedText(text):
-      target.write(text)
+      stream.write(text)
     case let .verticalTabs(count):
       printRepeated("\u{b}", count: count)
     }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
@@ -41,7 +41,7 @@ public protocol MemberMacro: AttachedMacro {
   /// - Parameters:
   ///   - node: The custom attribute describing the attached macro.
   ///   - declaration: The declaration the macro attribute is attached to.
-  ///   - conformingTo: The set of protocols that were declared
+  ///   - protocols: The set of protocols that were declared
   ///     in the set of conformances for the macro and to which the declaration
   ///     does not explicitly conform. The member macro itself cannot declare
   ///     conformances to these protocols (only an extension macro can do that),


### PR DESCRIPTION
I was trying to understand one of the macro API and the web documentation was missing the doc I was looking at, so I went to source and saw it was there, but wasn't being used because the name of the parameter was wrong.

I fixed all "not found" documentation warnings in the project. (Note that there are about 1400 more warnings about -missing- parameter documentation, but that's another PR for another day lol)