### PR TITLE
SwiftSyntax support for experimental @abi attribute

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -141,6 +141,11 @@ public let ATTRIBUTE_NODES: [Node] = [
             name: "documentationArguments",
             kind: .node(kind: .documentationAttributeArgumentList)
           ),
+          Child(
+            name: "abiArguments",
+            kind: .node(kind: .abiAttributeArguments),
+            experimentalFeature: .abiAttribute
+          )
         ]),
         documentation: """
           The arguments of the attribute.
@@ -247,6 +252,20 @@ public let ATTRIBUTE_NODES: [Node] = [
           deprecatedCollectionElementName: "Availability"
         ),
         documentation: "The list of OS versions in which the declaration became ABI stable."
+      ),
+    ]
+  ),
+
+  Node(
+    kind: .abiAttributeArguments,
+    base: .syntax,
+    experimentalFeature: .abiAttribute,
+    nameForDiagnostics: "ABI-providing declaration",
+    documentation: "The arguments of the '@abi' attribute",
+    children: [
+      Child(
+        name: "provider",
+        kind: .node(kind: .decl)
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/Child.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Child.swift
@@ -36,6 +36,16 @@ public enum TokenChoice: Equatable, IdentifierConvertible {
   }
 }
 
+/// If a child can be optional, what flavor of optional is it? Used to make
+/// some children optional without breaking source compatibility.
+public enum Optionality: String {
+  /// An ordinary `Optional` which must be explicitly unwrapped by users.
+  case normal = "?"
+  /// An implicitly-unwrapped `Optional` which maintains source compatibility
+  /// if the child's optionality has changed.
+  case implicitlyUnwrapped = "!"
+}
+
 public enum ChildKind {
   /// The child always contains a node of the given `kind`.
   case node(kind: SyntaxNodeKind)
@@ -95,7 +105,7 @@ public class Child: NodeChoiceConvertible {
   public let kind: ChildKind
 
   /// Whether this child is optional and can be `nil`.
-  public let isOptional: Bool
+  public let optionality: Optionality?
 
   public let experimentalFeature: ExperimentalFeature?
 
@@ -256,7 +266,7 @@ public class Child: NodeChoiceConvertible {
     experimentalFeature: ExperimentalFeature? = nil,
     nameForDiagnostics: String? = nil,
     documentation: String? = nil,
-    isOptional: Bool = false
+    optionality: Optionality? = nil
   ) {
     precondition(name.first?.isLowercase ?? true, "The first letter of a child’s name should be lowercase")
     precondition(
@@ -270,6 +280,31 @@ public class Child: NodeChoiceConvertible {
     self.nameForDiagnostics = nameForDiagnostics
     self.documentationSummary = SwiftSyntax.Trivia.docCommentTrivia(from: documentation)
     self.documentationAbstract = String(documentation?.split(whereSeparator: \.isNewline).first ?? "")
-    self.isOptional = isOptional
+    self.optionality = optionality
+  }
+
+  /// If a classification is passed, it specifies the color identifiers in
+  /// that subtree should inherit for syntax coloring. Must be a member of
+  /// ``SyntaxClassification``.
+  /// If `forceClassification` is also set to true, all child nodes (not only
+  /// identifiers) inherit the syntax classification.
+  convenience init(
+    name: String,
+    deprecatedName: String? = nil,
+    kind: ChildKind,
+    experimentalFeature: ExperimentalFeature? = nil,
+    nameForDiagnostics: String? = nil,
+    documentation: String? = nil,
+    isOptional: Bool
+  ) {
+    self.init(
+      name: name,
+      deprecatedName: deprecatedName,
+      kind: kind,
+      experimentalFeature: experimentalFeature,
+      nameForDiagnostics: nameForDiagnostics,
+      documentation: documentation,
+      optionality: isOptional ? .normal : nil
+    )
   }
 }

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -227,7 +227,8 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "memberBlock",
-        kind: .node(kind: .memberBlock)
+        kind: .node(kind: .memberBlock),
+        optionality: .implicitlyUnwrapped
       ),
     ]
   ),
@@ -401,7 +402,8 @@ public let DECL_NODES: [Node] = [
         name: "memberBlock",
         kind: .node(kind: .memberBlock),
         documentation:
-          "The members of the class declaration. As class extension declarations may declare additional members, the contents of this member block isn't guaranteed to be a complete list of members for this type."
+          "The members of the class declaration. As class extension declarations may declare additional members, the contents of this member block isn't guaranteed to be a complete list of members for this type.",
+        optionality: .implicitlyUnwrapped
       ),
     ]
   ),
@@ -827,7 +829,8 @@ public let DECL_NODES: [Node] = [
         name: "memberBlock",
         kind: .node(kind: .memberBlock),
         documentation:
-          "The cases and other members associated with this enum declaration. Because enum extension declarations may declare additional members the contents of this member block isn't guaranteed to be a complete list of members for this type."
+          "The cases and other members associated with this enum declaration. Because enum extension declarations may declare additional members the contents of this member block isn't guaranteed to be a complete list of members for this type.",
+        optionality: .implicitlyUnwrapped
       ),
     ]
   ),
@@ -906,7 +909,8 @@ public let DECL_NODES: [Node] = [
         name: "memberBlock",
         kind: .node(kind: .memberBlock),
         documentation:
-          "The members of the extension declaration. As this is an extension, the contents of this member block isn't guaranteed to be a complete list of members for this type."
+          "The members of the extension declaration. As this is an extension, the contents of this member block isn't guaranteed to be a complete list of members for this type.",
+        optionality: .implicitlyUnwrapped
       ),
     ]
   ),
@@ -2011,7 +2015,8 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "memberBlock",
         kind: .node(kind: .memberBlock),
-        documentation: "The members of the protocol declaration."
+        documentation: "The members of the protocol declaration.",
+        optionality: .implicitlyUnwrapped
       ),
     ]
   ),
@@ -2182,7 +2187,8 @@ public let DECL_NODES: [Node] = [
         name: "memberBlock",
         kind: .node(kind: .memberBlock),
         documentation:
-          "The members of the struct declaration. Because struct extension declarations may declare additional members the contents of this member block isn't guaranteed to be a complete list of members for this type."
+          "The members of the struct declaration. Because struct extension declarations may declare additional members the contents of this member block isn't guaranteed to be a complete list of members for this type.",
+        optionality: .implicitlyUnwrapped
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -19,6 +19,7 @@ public enum ExperimentalFeature: String, CaseIterable {
   case nonescapableTypes
   case trailingComma
   case coroutineAccessors
+  case abiAttribute
 
   /// The name of the feature, which is used in the doc comment.
   public var featureName: String {
@@ -35,6 +36,8 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "trailing comma"
     case .coroutineAccessors:
       return "CoroutineAccessors"
+    case .abiAttribute:
+      return "@abi attribute"
     }
   }
 

--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -34,7 +34,7 @@ struct GrammarGenerator {
   }
 
   private func grammar(for child: Child) -> String {
-    let optionality = child.isOptional ? "?" : ""
+    let optionality = child.optionality?.rawValue ?? ""
     switch child.kind {
     case .node(let kind):
       return "\(kind.doccLink)\(optionality)"

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -131,6 +131,7 @@ public enum Keyword: CaseIterable {
   case _underlyingVersion
   case _UnknownLayout
   case _version
+  case abi
   case accesses
   case actor
   case addressWithNativeOwner
@@ -404,6 +405,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("_UnknownLayout")
     case ._version:
       return KeywordSpec("_version")
+    case .abi:
+      return KeywordSpec("abi", experimentalFeature: .abiAttribute)
     case .accesses:
       return KeywordSpec("accesses")
     case .actor:

--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -22,6 +22,7 @@ public enum SyntaxNodeKind: String, CaseIterable, IdentifierConvertible, TypeCon
 
   case _canImportExpr
   case _canImportVersionInfo
+  case abiAttributeArguments
   case accessorBlock
   case accessorDecl
   case accessorDeclList
@@ -340,6 +341,15 @@ public enum SyntaxNodeKind: String, CaseIterable, IdentifierConvertible, TypeCon
     return .identifier(rawValue)
   }
 
+  public var uppercasedFirstWordRawValue: String {
+    switch self {
+    case .abiAttributeArguments:
+      "ABIAttributeArguments"
+    default:
+      rawValue.withFirstCharacterUppercased
+    }
+  }
+
   public var syntaxType: TypeSyntax {
     switch self {
     case .syntax:
@@ -347,7 +357,7 @@ public enum SyntaxNodeKind: String, CaseIterable, IdentifierConvertible, TypeCon
     case .syntaxCollection:
       return "SyntaxCollection"
     default:
-      return "\(raw: rawValue.withFirstCharacterUppercased)Syntax"
+      return "\(raw: uppercasedFirstWordRawValue)Syntax"
     }
   }
 

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -63,7 +63,7 @@ public let TRAITS: [Trait] = [
           "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
-      Child(name: "memberBlock", kind: .node(kind: .memberBlock)),
+      Child(name: "memberBlock", kind: .node(kind: .memberBlock), optionality: .implicitlyUnwrapped),
     ]
   ),
   Trait(

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -40,7 +40,7 @@ extension Child {
     }
     return SyntaxBuildableType(
       kind: buildableKind,
-      isOptional: isOptional
+      optionality: optionality
     )
   }
 
@@ -58,7 +58,7 @@ extension Child {
   }
 
   public var defaultValue: ExprSyntax? {
-    if isOptional || isUnexpectedNodes {
+    if optionality != nil || isUnexpectedNodes {
       if buildableType.isBaseType && kind.isNodeChoicesEmpty {
         return ExprSyntax("\(buildableType.buildable).none")
       } else {
@@ -131,7 +131,7 @@ extension Child {
     }
 
     var preconditionChoices: [ExprSyntax] = []
-    if buildableType.isOptional {
+    if buildableType.optionality != nil {
       preconditionChoices.append(
         ExprSyntax(
           SequenceExprSyntax {

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -151,7 +151,7 @@ public struct SyntaxBuildableType: Hashable {
   public var resultBuilderType: TypeSyntax {
     switch kind {
     case .node(kind: let kind):
-      return TypeSyntax("\(raw: kind.rawValue.withFirstCharacterUppercased)Builder")
+      return TypeSyntax("\(raw: kind.uppercasedFirstWordRawValue)Builder")
     case .token:
       preconditionFailure("Tokens cannot be constructed using result builders")
     }

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -20,10 +20,10 @@ import SyntaxSupport
 /// kind.
 public struct SyntaxBuildableType: Hashable {
   public let kind: SyntaxOrTokenNodeKind
-  public let isOptional: Bool
+  public let optionality: Optionality?
 
-  public init(kind: SyntaxOrTokenNodeKind, isOptional: Bool = false) {
-    self.isOptional = isOptional
+  public init(kind: SyntaxOrTokenNodeKind, optionality: Optionality? = nil) {
+    self.optionality = optionality
     self.kind = kind
   }
 
@@ -60,7 +60,7 @@ public struct SyntaxBuildableType: Hashable {
   /// with fixed test), return an expression that can be used as the
   /// default value for a function parameter. Otherwise, return `nil`.
   public var defaultValue: ExprSyntax? {
-    if isOptional {
+    if optionality != nil {
       return ExprSyntax(NilLiteralExprSyntax())
     } else if let token = token {
       if token.text != nil {
@@ -108,7 +108,7 @@ public struct SyntaxBuildableType: Hashable {
       if case .some(.some(let builderInitializableType)) = BUILDER_INITIALIZABLE_TYPES[kind] {
         return Self(
           kind: .node(kind: builderInitializableType),
-          isOptional: isOptional
+          optionality: optionality
         )
       } else {
         return self
@@ -132,8 +132,8 @@ public struct SyntaxBuildableType: Hashable {
   /// The corresponding `*Syntax` type defined in the `SwiftSyntax` module,
   /// which will eventually get built from `SwiftSyntaxBuilder`. If the type
   /// is optional, this terminates with a `?`.
-  public var syntax: TypeSyntax {
-    return optionalWrapped(type: syntaxBaseName)
+  public func syntax(canUseIUO: Bool = true) -> TypeSyntax {
+    return optionalWrapped(type: syntaxBaseName, canUseIUO: canUseIUO)
   }
 
   /// The type that is used for parameters in SwiftSyntaxBuilder that take this
@@ -167,27 +167,33 @@ public struct SyntaxBuildableType: Hashable {
     }
   }
 
-  /// Wraps a type in an optional depending on whether `isOptional` is true.
-  public func optionalWrapped(type: some TypeSyntaxProtocol) -> TypeSyntax {
-    if isOptional {
+  /// Wraps a type in an optional depending on whether `optionality` is true.
+  public func optionalWrapped(type: some TypeSyntaxProtocol, canUseIUO: Bool = true) -> TypeSyntax {
+    switch optionality {
+    case .some(.implicitlyUnwrapped):
+      if canUseIUO {
+        return TypeSyntax(ImplicitlyUnwrappedOptionalTypeSyntax(wrappedType: type))
+      }
+      fallthrough
+    case .some(.normal):
       return TypeSyntax(OptionalTypeSyntax(wrappedType: type))
-    } else {
+    case nil:
       return TypeSyntax(type)
     }
   }
 
-  /// Wraps a type in an optional chaining depending on whether `isOptional` is true.
+  /// Wraps a type in an optional chaining depending on whether `optionality` is true.
   public func optionalChained(expr: some ExprSyntaxProtocol) -> ExprSyntax {
-    if isOptional {
+    if optionality != nil {
       return ExprSyntax(OptionalChainingExprSyntax(expression: expr))
     } else {
       return ExprSyntax(expr)
     }
   }
 
-  /// Wraps a type in a force unwrap expression depending on whether `isOptional` is true.
+  /// Wraps a type in a force unwrap expression depending on whether `optionality` is true.
   public func forceUnwrappedIfNeeded(expr: some ExprSyntaxProtocol) -> ExprSyntax {
-    if isOptional {
+    if optionality != nil {
       return ExprSyntax(ForceUnwrapExprSyntax(expression: expr))
     } else {
       return ExprSyntax(expr)

--- a/CodeGeneration/Sources/generate-swift-syntax/LayoutNode+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/LayoutNode+Extensions.swift
@@ -31,11 +31,11 @@ extension LayoutNode {
         paramType = child.syntaxNodeKind.syntaxType
       }
 
-      if child.isOptional {
+      if let optionality = child.optionality {
         if paramType.is(SomeOrAnyTypeSyntax.self) {
-          paramType = "(\(paramType))?"
+          paramType = "(\(paramType))\(raw: optionality.rawValue)"
         } else {
-          paramType = "\(paramType)?"
+          paramType = "\(paramType)\(raw: optionality.rawValue)"
         }
       }
 
@@ -125,7 +125,7 @@ extension LayoutNode {
         let builderInitializableType = child.buildableType.builderInitializableType
         if child.buildableType.builderInitializableType != child.buildableType {
           let param = Node.from(type: child.buildableType).layoutNode!.singleNonDefaultedChild
-          if child.isOptional {
+          if child.optionality != nil {
             produceExpr = ExprSyntax(
               "\(childName)Builder().map { \(child.buildableType.syntaxBaseName)(\(param.labelDeclName): $0) }"
             )
@@ -139,7 +139,7 @@ extension LayoutNode {
         }
         builderParameters.append(
           FunctionParameterSyntax(
-            "@\(builderInitializableType.resultBuilderType) \(childName)Builder: () throws-> \(builderInitializableType.syntax)"
+            "@\(builderInitializableType.resultBuilderType) \(childName)Builder: () throws -> \(builderInitializableType.syntax(canUseIUO: false))"
           )
         )
       } else {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -161,7 +161,7 @@ func rawSyntaxNodesFile(nodesStartingWith: [Character]) -> SourceFileSyntax {
               let list = ExprListSyntax {
                 ExprSyntax("layout.initialize(repeating: nil)")
                 for (index, child) in node.children.enumerated() {
-                  let optionalMark = child.isOptional ? "?" : ""
+                  let optionalMark = (child.optionality != nil) ? "?" : ""
 
                   ExprSyntax(
                     "layout[\(raw: index)] = \(child.baseCallName)\(raw: optionalMark).raw"
@@ -188,7 +188,7 @@ func rawSyntaxNodesFile(nodesStartingWith: [Character]) -> SourceFileSyntax {
             try VariableDeclSyntax(
               "public var \(child.varDeclName): Raw\(child.buildableType.buildable)"
             ) {
-              let exclamationMark = child.isOptional ? "" : "!"
+              let exclamationMark = child.optionality != nil ? "" : "!"
 
               if child.syntaxNodeKind == .syntax {
                 ExprSyntax("layoutView.children[\(raw: index)]\(raw: exclamationMark)")
@@ -232,7 +232,7 @@ fileprivate extension Child {
     var paramType: TypeSyntax
     if !kind.isNodeChoicesEmpty {
       paramType = "\(syntaxChoicesType)"
-    } else if hasBaseType && !isOptional {
+    } else if hasBaseType && optionality == nil {
       // we restrict the use of generic type to non-optional parameter types, otherwise call sites would no longer be
       // able to just pass `nil` to this parameter without specializing `(some Raw<Kind>SyntaxNodeProtocol)?`
       //

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
@@ -22,7 +22,14 @@ let renamedChildrenCompatibilityFile = try! SourceFileSyntax(leadingTrivia: copy
         if let deprecatedVarName = child.deprecatedVarName {
           let childType: TypeSyntax =
             child.kind.isNodeChoicesEmpty ? child.syntaxNodeKind.syntaxType : child.syntaxChoicesType
-          let type = child.isOptional ? TypeSyntax("\(childType)?") : childType
+          let type = switch child.optionality {
+          case .none:
+            childType
+          case .normal:
+            TypeSyntax("\(childType)?")
+          case .implicitlyUnwrapped:
+            TypeSyntax("\(childType)!")
+          }
 
           DeclSyntax(
             """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxEnumFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxEnumFile.swift
@@ -60,7 +60,7 @@ let syntaxEnumFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
   for base in SYNTAX_NODES where base.kind.isBase {
     let baseKind = base.kind
-    let baseName = baseKind.rawValue.withFirstCharacterUppercased
+    let baseName = baseKind.uppercasedFirstWordRawValue
     let enumType: TypeSyntax = "\(raw: baseName)SyntaxEnum"
 
     try! EnumDeclSyntax(

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -135,7 +135,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
 
           let childType: TypeSyntax =
             child.kind.isNodeChoicesEmpty ? child.syntaxNodeKind.syntaxType : child.syntaxChoicesType
-          let type = child.isOptional ? TypeSyntax("\(childType)?") : TypeSyntax("\(childType)")
+          let type = TypeSyntax("\(childType)\(raw: child.optionality?.rawValue ?? "")")
 
           try! VariableDeclSyntax(
             """
@@ -145,7 +145,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
           ) {
             AccessorDeclSyntax(accessorSpecifier: .keyword(.get)) {
               let optionalityMarker: TokenSyntax =
-                child.isOptional ? .infixQuestionMarkToken() : .exclamationMarkToken()
+                child.optionality != nil ? .infixQuestionMarkToken() : .exclamationMarkToken()
               StmtSyntax("return Syntax(self).child(at: \(raw: index))\(optionalityMarker).cast(\(childType).self)")
             }
 

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -28,7 +28,7 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       for child in trait.children {
-        let questionMark = child.isOptional ? "?" : ""
+        let questionMark = child.optionality?.rawValue ?? ""
 
         DeclSyntax(
           """

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -81,7 +81,7 @@ fileprivate extension ChildKind {
 fileprivate extension Child {
   func hasSameType(as other: Child) -> Bool {
     return identifier.description == other.identifier.description && kind.hasSameType(as: other.kind)
-      && isOptional == other.isOptional
+      && optionality == other.optionality
   }
 
   func isFollowedByColonToken(in node: LayoutNode) -> Bool {
@@ -816,7 +816,7 @@ class ValidateSyntaxNodes: XCTestCase {
 
     for node in SYNTAX_NODES.compactMap(\.layoutNode) {
       for child in node.children {
-        if case .collection = child.kind, child.isOptional, !child.isUnexpectedNodes {
+        if case .collection = child.kind, child.optionality != nil, !child.isUnexpectedNodes {
           failures.append(
             ValidationFailure(
               node: node.kind,

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
@@ -645,7 +645,8 @@ import SwiftSyntax
     var results: [LookupResult] = []
 
     if let primaryAssociatedTypeClause,
-      primaryAssociatedTypeClause.range.contains(lookUpPosition)
+       primaryAssociatedTypeClause.range.contains(lookUpPosition),
+       let memberBlock
     {
       results = memberBlock.lookupAssociatedTypeDeclarations(
         identifier,

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-@_spi(RawSyntax) internal import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) internal import SwiftSyntax
 #else
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftSyntax
 #endif
 
 extension Parser {
@@ -58,6 +58,7 @@ extension Parser {
     case _typeEraser
     case _unavailableFromAsync
     case `rethrows`
+    case abi
     case attached
     case available
     case backDeployed
@@ -95,6 +96,7 @@ extension Parser {
       case TokenSpec(._typeEraser): self = ._typeEraser
       case TokenSpec(._unavailableFromAsync): self = ._unavailableFromAsync
       case TokenSpec(.`rethrows`): self = .rethrows
+      case TokenSpec(.abi) where experimentalFeatures.contains(.abiAttribute): self = .abi
       case TokenSpec(.attached): self = .attached
       case TokenSpec(.available): self = .available
       case TokenSpec(.backDeployed): self = .backDeployed
@@ -136,6 +138,7 @@ extension Parser {
       case ._typeEraser: return .keyword(._typeEraser)
       case ._unavailableFromAsync: return .keyword(._unavailableFromAsync)
       case .`rethrows`: return .keyword(.rethrows)
+      case .abi: return .keyword(.abi)
       case .attached: return .keyword(.attached)
       case .available: return .keyword(.available)
       case .backDeployed: return .keyword(.backDeployed)
@@ -176,9 +179,16 @@ extension Parser {
     case noArgument
   }
 
+  /// Parse the argument of an attribute, if it has one.
+  ///
+  /// - Parameters:
+  ///   - argumentMode: Indicates whether the attribute must, may, or may not have an argument.
+  ///   - parseArguments: Called to parse the argument list. If there is an opening parenthesis, it will have already been consumed.
+  ///   - parseMissingArguments: If provided, called instead of `parseArgument` when an argument list was required but no opening parenthesis was present.
   mutating func parseAttribute(
     argumentMode: AttributeArgumentMode,
-    parseArguments: (inout Parser) -> RawAttributeSyntax.Arguments
+    parseArguments: (inout Parser) -> RawAttributeSyntax.Arguments,
+    parseMissingArguments: ((inout Parser) -> RawAttributeSyntax.Arguments)? = nil
   ) -> RawAttributeListSyntax.Element {
     var (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     if atSign.trailingTriviaByteLength > 0 || self.currentToken.leadingTriviaByteLength > 0 {
@@ -213,7 +223,11 @@ extension Parser {
         )
         leftParen = leftParen.tokenView.withTokenDiagnostic(tokenDiagnostic: diagnostic, arena: self.arena)
       }
-      let argument = parseArguments(&self)
+      let argument = if let parseMissingArguments, leftParen.presence == .missing {
+        parseMissingArguments(&self)
+      } else {
+        parseArguments(&self)
+      }
       let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
       return .attribute(
         RawAttributeSyntax(
@@ -255,6 +269,12 @@ extension Parser {
     }
 
     switch peek(isAtAnyIn: DeclarationAttributeWithSpecialSyntax.self) {
+    case .abi:
+      return parseAttribute(argumentMode: .required) { parser in
+        return .abiArguments(parser.parseABIAttributeArguments())
+      } parseMissingArguments: { parser in
+        return .abiArguments(parser.parseABIAttributeArguments(missing: true))
+      }
     case .available, ._spi_available:
       return parseAttribute(argumentMode: .required) { parser in
         return .availability(parser.parseAvailabilityArgumentSpecList())
@@ -915,6 +935,33 @@ extension Parser {
       elements: [isolationKindElement],
       arena: self.arena
     )
+  }
+}
+
+extension Parser {
+  mutating func parseABIAttributeArguments(missing: Bool = false) -> RawABIAttributeArgumentsSyntax {
+    let providerDecl: RawDeclSyntax = if missing {
+      // There are two situations where the left paren might be missing:
+      //   1. The user just forgot the paren: `@abi var x_abi: Int) var x: Int`
+      //   2. The user forgot the whole argument list: `@abi var x: Int`
+      // Normally, we would distinguish these by seeing if whatever comes after
+      // the attribute parses as an argument. However, for @abi the argument is
+      // a decl, so in #2, we would consume the decl the attribute is attached
+      // to! This leads to a lousy diagnostic in that situation.
+      // Avoid this problem by simply returning a missing decl immediately.
+      // FIXME: Could we look ahead to find an unbalanced parenthesis?
+      RawDeclSyntax(
+        RawMissingDeclSyntax(
+          attributes: self.emptyCollection(RawAttributeListSyntax.self),
+          modifiers: self.emptyCollection(RawDeclModifierListSyntax.self),
+          arena: arena
+        )
+      )
+    } else {
+      parseDeclaration(in: .attribute)
+    }
+
+    return RawABIAttributeArgumentsSyntax(provider: providerDecl, arena: arena)
   }
 }
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -168,11 +168,24 @@ extension Parser {
     }
   }
 
+  /// Information about the syntactic position of the declaration being parsed.
+  /// Used to tweak recovery and to permit missing bodies.
+  enum DeclarationParsingContext {
+    /// The declaration is at the top level of a file.
+    case topLevelCode
+
+    /// The declaration is nested inside the member list of a DeclGroupSyntax.
+    case memberList
+
+    /// The declaration is nested inside the argument list of an attribute.
+    case attribute
+  }
+
   /// Parse a declaration.
   ///
-  /// If `inMemberDeclList` is `true`, we know that the next item must be a
+  /// If `parseContext` is `memberList`, we know that the next item must be a
   /// declaration and thus start with a keyword. This allows further recovery.
-  mutating func parseDeclaration(inMemberDeclList: Bool = false) -> RawDeclSyntax {
+  mutating func parseDeclaration(in parseContext: DeclarationParsingContext = .topLevelCode) -> RawDeclSyntax {
     // If we are at a `#if` of attributes, the `#if` directive should be
     // parsed when we're parsing the attributes.
     if self.at(.poundIf) && !self.withLookahead({ $0.consumeIfConfigOfAttributes() }) {
@@ -221,7 +234,14 @@ extension Parser {
       // to parse.
       // If we are inside a memberDecl list, we don't want to eat closing braces (which most likely close the outer context)
       // while recovering to the declaration start.
-      let recoveryPrecedence = inMemberDeclList ? TokenPrecedence.closingBrace : nil
+      let recoveryPrecedence = switch parseContext {
+      case .topLevelCode:
+        Optional<TokenPrecedence>.none
+      case .memberList:
+        Optional(TokenPrecedence.closingBrace)
+      case .attribute:
+        Optional(TokenPrecedence.weakBracketed(closingDelimiter: .rightParen))
+      }
       recoveryResult = self.canRecoverTo(anyIn: DeclarationKeyword.self, overrideRecoveryPrecedence: recoveryPrecedence)
     }
 
@@ -230,28 +250,28 @@ extension Parser {
       return RawDeclSyntax(self.parseImportDeclaration(attrs, handle))
     case (.lhs(.class), let handle)?:
       return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawClassDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        self.parseNominalTypeDeclaration(for: RawClassDeclSyntax.self, attrs: attrs, introucerHandle: handle, parseContext: parseContext)
       )
     case (.lhs(.enum), let handle)?:
       return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawEnumDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        self.parseNominalTypeDeclaration(for: RawEnumDeclSyntax.self, attrs: attrs, introucerHandle: handle, parseContext: parseContext)
       )
     case (.lhs(.case), let handle)?:
       return RawDeclSyntax(self.parseEnumCaseDeclaration(attrs, handle))
     case (.lhs(.struct), let handle)?:
       return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawStructDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        self.parseNominalTypeDeclaration(for: RawStructDeclSyntax.self, attrs: attrs, introucerHandle: handle, parseContext: parseContext)
       )
     case (.lhs(.protocol), let handle)?:
       return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawProtocolDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        self.parseNominalTypeDeclaration(for: RawProtocolDeclSyntax.self, attrs: attrs, introucerHandle: handle, parseContext: parseContext)
       )
     case (.lhs(.associatedtype), let handle)?:
       return RawDeclSyntax(self.parseAssociatedTypeDeclaration(attrs, handle))
     case (.lhs(.typealias), let handle)?:
       return RawDeclSyntax(self.parseTypealiasDeclaration(attrs, handle))
     case (.lhs(.extension), let handle)?:
-      return RawDeclSyntax(self.parseExtensionDeclaration(attrs, handle))
+      return RawDeclSyntax(self.parseExtensionDeclaration(attrs, handle, parseContext: parseContext))
     case (.lhs(.func), let handle)?:
       return RawDeclSyntax(self.parseFuncDeclaration(attrs, handle))
     case (.lhs(.subscript), let handle)?:
@@ -266,19 +286,19 @@ extension Parser {
       return RawDeclSyntax(self.parsePrecedenceGroupDeclaration(attrs, handle))
     case (.lhs(.actor), let handle)?:
       return RawDeclSyntax(
-        self.parseNominalTypeDeclaration(for: RawActorDeclSyntax.self, attrs: attrs, introucerHandle: handle)
+        self.parseNominalTypeDeclaration(for: RawActorDeclSyntax.self, attrs: attrs, introucerHandle: handle, parseContext: parseContext)
       )
     case (.lhs(.macro), let handle)?:
       return RawDeclSyntax(self.parseMacroDeclaration(attrs: attrs, introducerHandle: handle))
     case (.lhs(.pound), let handle)?:
       return RawDeclSyntax(self.parseMacroExpansionDeclaration(attrs, handle))
     case (.rhs, let handle)?:
-      return RawDeclSyntax(self.parseBindingDeclaration(attrs, handle, inMemberDeclList: inMemberDeclList))
+      return RawDeclSyntax(self.parseBindingDeclaration(attrs, handle, inMemberDeclList: parseContext != .topLevelCode))
     case nil:
       break
     }
 
-    if inMemberDeclList {
+    if parseContext != .topLevelCode {
       let isProbablyVarDecl = self.at(.identifier, .wildcard) && self.peek(isAt: .colon, .equal, .comma)
       let isProbablyTupleDecl = self.at(.leftParen) && self.peek(isAt: .identifier, .wildcard)
 
@@ -377,7 +397,8 @@ extension Parser {
   /// Parse an extension declaration.
   mutating func parseExtensionDeclaration(
     _ attrs: DeclAttributes,
-    _ handle: RecoveryConsumptionHandle
+    _ handle: RecoveryConsumptionHandle,
+    parseContext: DeclarationParsingContext
   ) -> RawExtensionDeclSyntax {
     let (unexpectedBeforeExtensionKeyword, extensionKeyword) = self.eat(handle)
     let type = self.parseType()
@@ -395,7 +416,12 @@ extension Parser {
     } else {
       whereClause = nil
     }
-    let memberBlock = self.parseMemberBlock(introducer: extensionKeyword)
+    let memberBlock: RawMemberBlockSyntax?
+    if parseContext == .attribute && !self.at(.leftBrace) {
+      memberBlock = nil
+    } else {
+      memberBlock = self.parseMemberBlock(introducer: extensionKeyword)
+    }
     return RawExtensionDeclSyntax(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,
@@ -746,7 +772,7 @@ extension Parser {
     if self.at(.poundSourceLocation) {
       decl = RawDeclSyntax(self.parsePoundSourceLocationDirective())
     } else {
-      decl = self.parseDeclaration(inMemberDeclList: true)
+      decl = self.parseDeclaration(in: .memberList)
     }
 
     let semi = self.consume(if: .semicolon)

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -211,7 +211,8 @@ extension Parser {
   mutating func parseNominalTypeDeclaration<T>(
     for T: T.Type,
     attrs: DeclAttributes,
-    introucerHandle: RecoveryConsumptionHandle
+    introucerHandle: RecoveryConsumptionHandle,
+    parseContext: DeclarationParsingContext
   ) -> T where T: NominalTypeDeclarationTrait {
     let (unexpectedBeforeIntroducerKeyword, introducerKeyword) = self.eat(introucerHandle)
     let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
@@ -258,7 +259,12 @@ extension Parser {
       whereClause = nil
     }
 
-    let memberBlock = self.parseMemberBlock(introducer: introducerKeyword)
+    let memberBlock: RawMemberBlockSyntax?
+    if parseContext == .attribute && !self.at(.leftBrace) {
+      memberBlock = nil
+    } else {
+      memberBlock = self.parseMemberBlock(introducer: introducerKeyword)
+    }
     return T.init(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -29,7 +29,7 @@ protocol NominalTypeDeclarationTrait {
     primaryOrGenerics: PrimaryOrGenerics?,
     inheritanceClause: RawInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax?,
     arena: __shared SyntaxArena
   )
 
@@ -47,7 +47,7 @@ extension RawProtocolDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawPrimaryAssociatedTypeClauseSyntax?,
     inheritanceClause: RawInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax?,
     arena: __shared SyntaxArena
   ) {
     self.init(
@@ -81,7 +81,7 @@ extension RawClassDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax?,
     arena: __shared SyntaxArena
   ) {
     self.init(
@@ -115,7 +115,7 @@ extension RawActorDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax?,
     arena: __shared SyntaxArena
   ) {
     self.init(
@@ -149,7 +149,7 @@ extension RawStructDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax?,
     arena: __shared SyntaxArena
   ) {
     self.init(
@@ -183,7 +183,7 @@ extension RawEnumDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax?,
     arena: __shared SyntaxArena
   ) {
     self.init(

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -283,6 +283,7 @@ enum TokenPrecedence: Comparable {
       ._swift_native_objc_runtime_base,
       ._typeEraser,
       ._unavailableFromAsync,
+      .abi,
       .attached,
       .available,
       .backDeployed,

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -41,4 +41,7 @@ extension Parser.ExperimentalFeatures {
 
   /// Whether to enable the parsing of CoroutineAccessors.
   public static let coroutineAccessors = Self (rawValue: 1 << 5)
+
+  /// Whether to enable the parsing of @abi attribute.
+  public static let abiAttribute = Self (rawValue: 1 << 6)
 }

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -23,6 +23,8 @@ extension SyntaxKind {
     switch self {
     case .token:
       return "token"
+    case .abiAttributeArguments:
+      return "ABI-providing declaration"
     case .accessorDecl:
       return "accessor"
     case .accessorEffectSpecifiers:

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -136,7 +136,11 @@ extension DeclGroupSyntax {
   @available(*, deprecated, renamed: "memberBlock")
   public var members: MemberDeclBlockSyntax {
     get {
-      return memberBlock
+      return memberBlock ?? MemberDeclBlockSyntax(
+        leftBrace: .leftBraceToken(presence: .missing),
+        members: [],
+        rightBrace: .rightBraceToken(presence: .missing)
+      )
     }
     set(value) {
       memberBlock = value

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -17,6 +17,12 @@
 @_spi(RawSyntax)
 public func childName(_ keyPath: AnyKeyPath) -> String? {
   switch keyPath {
+  case \ABIAttributeArgumentsSyntax.unexpectedBeforeProvider:
+    return "unexpectedBeforeProvider"
+  case \ABIAttributeArgumentsSyntax.provider:
+    return "provider"
+  case \ABIAttributeArgumentsSyntax.unexpectedAfterProvider:
+    return "unexpectedAfterProvider"
   case \AccessorBlockSyntax.unexpectedBeforeLeftBrace:
     return "unexpectedBeforeLeftBrace"
   case \AccessorBlockSyntax.leftBrace:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -71,6 +71,10 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case _underlyingVersion
   case _UnknownLayout
   case _version
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  case abi
   case accesses
   case actor
   case addressWithNativeOwner
@@ -271,6 +275,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
       }
     case 3:
       switch text {
+      case "abi":
+        self = .abi
       case "any":
         self = .any
       case "Any":
@@ -871,6 +877,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
     "_underlyingVersion",
     "_UnknownLayout",
     "_version",
+    "abi",
     "accesses",
     "actor",
     "addressWithNativeOwner",

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -152,7 +152,7 @@ extension ActorDeclSyntax {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -1123,7 +1123,7 @@ extension ClassDeclSyntax {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -2643,7 +2643,7 @@ extension EnumDeclSyntax {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -6415,7 +6415,7 @@ extension ProtocolDeclSyntax {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -7188,7 +7188,7 @@ extension StructDeclSyntax {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -56,6 +56,20 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  override open func visit(_ node: ABIAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  override open func visitPost(_ node: ABIAttributeArgumentsSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+
   override open func visit(_ node: AccessorBlockSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -1517,6 +1517,7 @@ extension Syntax {
   public static var structure: SyntaxNodeStructure {
     return .choices([
       .node(TokenSyntax.self),
+      .node(ABIAttributeArgumentsSyntax.self),
       .node(AccessorBlockSyntax.self),
       .node(AccessorDeclListSyntax.self),
       .node(AccessorDeclSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -15,6 +15,10 @@
 /// Enum to exhaustively switch over all different syntax nodes.
 public enum SyntaxEnum: Sendable {
   case token(TokenSyntax)
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  case abiAttributeArguments(ABIAttributeArgumentsSyntax)
   case accessorBlock(AccessorBlockSyntax)
   case accessorDeclList(AccessorDeclListSyntax)
   case accessorDecl(AccessorDeclSyntax)
@@ -321,6 +325,8 @@ extension Syntax {
     switch raw.kind {
     case .token:
       return .token(TokenSyntax(self)!)
+    case .abiAttributeArguments:
+      return .abiAttributeArguments(ABIAttributeArgumentsSyntax(self)!)
     case .accessorBlock:
       return .accessorBlock(AccessorBlockSyntax(self)!)
     case .accessorDeclList:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -15,6 +15,10 @@
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
 public enum SyntaxKind: Sendable {
   case token
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  case abiAttributeArguments
   case accessorBlock
   case accessorDeclList
   case accessorDecl
@@ -446,6 +450,8 @@ public enum SyntaxKind: Sendable {
     switch self {
     case .token:
       return TokenSyntax.self
+    case .abiAttributeArguments:
+      return ABIAttributeArgumentsSyntax.self
     case .accessorBlock:
       return AccessorBlockSyntax.self
     case .accessorDeclList:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -106,6 +106,16 @@ open class SyntaxRewriter {
     return rewritten.cast(T.self)
   }
 
+  /// Visit a `ABIAttributeArgumentsSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  open func visit(_ node: ABIAttributeArgumentsSyntax) -> ABIAttributeArgumentsSyntax {
+    return visitChildren(node._syntaxNode).cast(ABIAttributeArgumentsSyntax.self)
+  }
+
   /// Visit a ``AccessorBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -2191,6 +2201,10 @@ open class SyntaxRewriter {
       return {
         self.visitImpl(&$0, TokenSyntax.self, self.visit)
       }
+    case .abiAttributeArguments:
+      return {
+        self.visitImpl(&$0, ABIAttributeArgumentsSyntax.self, self.visit)
+      }
     case .accessorBlock:
       return {
         self.visitImpl(&$0, AccessorBlockSyntax.self, self.visit)
@@ -3333,6 +3347,8 @@ open class SyntaxRewriter {
     switch node.raw.kind {
     case .token:
       return visitImpl(&node, TokenSyntax.self, visit)
+    case .abiAttributeArguments:
+      return visitImpl(&node, ABIAttributeArgumentsSyntax.self, visit)
     case .accessorBlock:
       return visitImpl(&node, AccessorBlockSyntax.self, visit)
     case .accessorDeclList:

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -99,7 +99,7 @@ public protocol DeclGroupSyntax: SyntaxProtocol, DeclSyntaxProtocol {
     set
   }
 
-  var memberBlock: MemberBlockSyntax {
+  var memberBlock: MemberBlockSyntax! {
     get
     set
   }

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -38,6 +38,24 @@ open class SyntaxVisitor {
     visit(&syntaxNode)
   }
 
+  /// Visiting `ABIAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  open func visit(_ node: ABIAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `ABIAttributeArgumentsSyntax` and its descendants.
+  ///   - node: the node we just finished visiting.
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  open func visitPost(_ node: ABIAttributeArgumentsSyntax) {
+  }
+
   /// Visiting ``AccessorBlockSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -3535,6 +3553,10 @@ open class SyntaxVisitor {
         // No children to visit.
         self.visitPost(node)
       }
+    case .abiAttributeArguments:
+      return {
+        self.visitImpl(&$0, ABIAttributeArgumentsSyntax.self, self.visit, self.visitPost)
+      }
     case .accessorBlock:
       return {
         self.visitImpl(&$0, AccessorBlockSyntax.self, self.visit, self.visitPost)
@@ -4681,6 +4703,8 @@ open class SyntaxVisitor {
       _ = visit(node)
       // No children to visit.
       visitPost(node)
+    case .abiAttributeArguments:
+      visitImpl(&node, ABIAttributeArgumentsSyntax.self, visit, visitPost)
     case .accessorBlock:
       visitImpl(&node, AccessorBlockSyntax.self, visit, visitPost)
     case .accessorDeclList:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
@@ -487,7 +487,7 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax!,
     _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -509,7 +509,7 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
-      layout[15] = memberBlock.raw
+      layout[15] = memberBlock?.raw
       layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
@@ -575,8 +575,8 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 
-  public var memberBlock: RawMemberBlockSyntax {
-    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))!
+  public var memberBlock: RawMemberBlockSyntax! {
+    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))
   }
 
   public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
@@ -12,6 +12,67 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.8)
+@_spi(ExperimentalLanguageFeatures)
+#endif
+@_spi(RawSyntax)
+public struct RawABIAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .abiAttributeArguments
+  }
+
+  public var raw: RawSyntax
+
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+
+  public init?(_ other: some RawSyntaxNodeProtocol) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeProvider: RawUnexpectedNodesSyntax? = nil,
+    provider: some RawDeclSyntaxNodeProtocol,
+    _ unexpectedAfterProvider: RawUnexpectedNodesSyntax? = nil,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .abiAttributeArguments, uninitializedCount: 3, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeProvider?.raw
+      layout[1] = provider.raw
+      layout[2] = unexpectedAfterProvider?.raw
+    }
+    self.init(unchecked: raw)
+  }
+
+  public var unexpectedBeforeProvider: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var provider: RawDeclSyntax {
+    layoutView.children[1].map(RawDeclSyntax.init(raw:))!
+  }
+
+  public var unexpectedAfterProvider: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
 @_spi(RawSyntax)
 public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
   public enum Accessors: RawSyntaxNodeProtocol {
@@ -1322,9 +1383,12 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     case unavailableFromAsyncArguments(RawUnavailableFromAsyncAttributeArgumentsSyntax)
     case effectsArguments(RawEffectsAttributeArgumentListSyntax)
     case documentationArguments(RawDocumentationAttributeArgumentListSyntax)
+    /// - Note: Requires experimental feature `abiAttribute`.
+    @_spi(ExperimentalLanguageFeatures)
+    case abiArguments(RawABIAttributeArgumentsSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      RawLabeledExprListSyntax.isKindOf(raw) || RawTokenSyntax.isKindOf(raw) || RawStringLiteralExprSyntax.isKindOf(raw) || RawAvailabilityArgumentListSyntax.isKindOf(raw) || RawSpecializeAttributeArgumentListSyntax.isKindOf(raw) || RawObjCSelectorPieceListSyntax.isKindOf(raw) || RawImplementsAttributeArgumentsSyntax.isKindOf(raw) || RawDifferentiableAttributeArgumentsSyntax.isKindOf(raw) || RawDerivativeAttributeArgumentsSyntax.isKindOf(raw) || RawBackDeployedAttributeArgumentsSyntax.isKindOf(raw) || RawConventionAttributeArgumentsSyntax.isKindOf(raw) || RawConventionWitnessMethodAttributeArgumentsSyntax.isKindOf(raw) || RawOpaqueReturnTypeOfAttributeArgumentsSyntax.isKindOf(raw) || RawExposeAttributeArgumentsSyntax.isKindOf(raw) || RawOriginallyDefinedInAttributeArgumentsSyntax.isKindOf(raw) || RawUnderscorePrivateAttributeArgumentsSyntax.isKindOf(raw) || RawDynamicReplacementAttributeArgumentsSyntax.isKindOf(raw) || RawUnavailableFromAsyncAttributeArgumentsSyntax.isKindOf(raw) || RawEffectsAttributeArgumentListSyntax.isKindOf(raw) || RawDocumentationAttributeArgumentListSyntax.isKindOf(raw)
+      RawLabeledExprListSyntax.isKindOf(raw) || RawTokenSyntax.isKindOf(raw) || RawStringLiteralExprSyntax.isKindOf(raw) || RawAvailabilityArgumentListSyntax.isKindOf(raw) || RawSpecializeAttributeArgumentListSyntax.isKindOf(raw) || RawObjCSelectorPieceListSyntax.isKindOf(raw) || RawImplementsAttributeArgumentsSyntax.isKindOf(raw) || RawDifferentiableAttributeArgumentsSyntax.isKindOf(raw) || RawDerivativeAttributeArgumentsSyntax.isKindOf(raw) || RawBackDeployedAttributeArgumentsSyntax.isKindOf(raw) || RawConventionAttributeArgumentsSyntax.isKindOf(raw) || RawConventionWitnessMethodAttributeArgumentsSyntax.isKindOf(raw) || RawOpaqueReturnTypeOfAttributeArgumentsSyntax.isKindOf(raw) || RawExposeAttributeArgumentsSyntax.isKindOf(raw) || RawOriginallyDefinedInAttributeArgumentsSyntax.isKindOf(raw) || RawUnderscorePrivateAttributeArgumentsSyntax.isKindOf(raw) || RawDynamicReplacementAttributeArgumentsSyntax.isKindOf(raw) || RawUnavailableFromAsyncAttributeArgumentsSyntax.isKindOf(raw) || RawEffectsAttributeArgumentListSyntax.isKindOf(raw) || RawDocumentationAttributeArgumentListSyntax.isKindOf(raw) || RawABIAttributeArgumentsSyntax.isKindOf(raw)
     }
 
     public var raw: RawSyntax {
@@ -1368,6 +1432,8 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       case .effectsArguments(let node):
         return node.raw
       case .documentationArguments(let node):
+        return node.raw
+      case .abiArguments(let node):
         return node.raw
       }
     }
@@ -1413,6 +1479,8 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
         self = .effectsArguments(node)
       } else if let node = node.as(RawDocumentationAttributeArgumentListSyntax.self) {
         self = .documentationArguments(node)
+      } else if let node = node.as(RawABIAttributeArgumentsSyntax.self) {
+        self = .abiArguments(node)
       } else {
         return nil
       }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesC.swift
@@ -521,7 +521,7 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax!,
     _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -543,7 +543,7 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
-      layout[15] = memberBlock.raw
+      layout[15] = memberBlock?.raw
       layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
@@ -609,8 +609,8 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 
-  public var memberBlock: RawMemberBlockSyntax {
-    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))!
+  public var memberBlock: RawMemberBlockSyntax! {
+    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))
   }
 
   public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesEF.swift
@@ -750,7 +750,7 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax!,
     _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -772,7 +772,7 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
-      layout[15] = memberBlock.raw
+      layout[15] = memberBlock?.raw
       layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
@@ -838,8 +838,8 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 
-  public var memberBlock: RawMemberBlockSyntax {
-    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))!
+  public var memberBlock: RawMemberBlockSyntax! {
+    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))
   }
 
   public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
@@ -1283,7 +1283,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax!,
     _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -1303,7 +1303,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[10] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[11] = genericWhereClause?.raw
       layout[12] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
-      layout[13] = memberBlock.raw
+      layout[13] = memberBlock?.raw
       layout[14] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
@@ -1361,8 +1361,8 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 
-  public var memberBlock: RawMemberBlockSyntax {
-    layoutView.children[13].map(RawMemberBlockSyntax.init(raw:))!
+  public var memberBlock: RawMemberBlockSyntax! {
+    layoutView.children[13].map(RawMemberBlockSyntax.init(raw:))
   }
 
   public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesOP.swift
@@ -2719,7 +2719,7 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax!,
     _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -2741,7 +2741,7 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
-      layout[15] = memberBlock.raw
+      layout[15] = memberBlock?.raw
       layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
@@ -2807,8 +2807,8 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 
-  public var memberBlock: RawMemberBlockSyntax {
-    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))!
+  public var memberBlock: RawMemberBlockSyntax! {
+    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))
   }
 
   public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
@@ -1449,7 +1449,7 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil,
-    memberBlock: RawMemberBlockSyntax,
+    memberBlock: RawMemberBlockSyntax!,
     _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -1471,7 +1471,7 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
-      layout[15] = memberBlock.raw
+      layout[15] = memberBlock?.raw
       layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
@@ -1537,8 +1537,8 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 
-  public var memberBlock: RawMemberBlockSyntax {
-    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))!
+  public var memberBlock: RawMemberBlockSyntax! {
+    layoutView.children[15].map(RawMemberBlockSyntax.init(raw:))
   }
 
   public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -209,6 +209,11 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   switch kind {
   case .token:
     assertionFailure("validateLayout for .token kind is not supported")
+  case .abiAttributeArguments:
+    assert(layout.count == 3)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawDeclSyntax.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
   case .accessorBlock:
     assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -287,7 +287,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 13, verify(layout[13], as: RawGenericWhereClauseSyntax?.self))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax.self))
+    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax!.self))
     assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
   case .arrayElementList:
     for (index, element) in layout.enumerated() {
@@ -533,7 +533,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 13, verify(layout[13], as: RawGenericWhereClauseSyntax?.self))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax.self))
+    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax!.self))
     assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
   case .classRestrictionType:
     assert(layout.count == 3)
@@ -1122,7 +1122,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 13, verify(layout[13], as: RawGenericWhereClauseSyntax?.self))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax.self))
+    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax!.self))
     assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
   case .exposeAttributeArguments:
     assert(layout.count == 7)
@@ -1175,7 +1175,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 11, verify(layout[11], as: RawGenericWhereClauseSyntax?.self))
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 13, verify(layout[13], as: RawMemberBlockSyntax.self))
+    assertNoError(kind, 13, verify(layout[13], as: RawMemberBlockSyntax!.self))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
   case .fallThroughStmt:
     assert(layout.count == 3)
@@ -2218,7 +2218,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 13, verify(layout[13], as: RawGenericWhereClauseSyntax?.self))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax.self))
+    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax!.self))
     assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
   case .regexLiteralExpr:
     assert(layout.count == 11)
@@ -2387,7 +2387,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 13, verify(layout[13], as: RawGenericWhereClauseSyntax?.self))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax.self))
+    assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax!.self))
     assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
   case .subscriptCallExpr:
     assert(layout.count == 13)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -792,7 +792,7 @@ public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-///  - `memberBlock`: ``MemberBlockSyntax``
+///  - `memberBlock`: ``MemberBlockSyntax``!
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -828,7 +828,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -869,7 +869,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
         unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
         genericWhereClause?.raw,
         unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw,
-        memberBlock.raw,
+        memberBlock?.raw,
         unexpectedAfterMemberBlock?.raw
       ]
       let raw = RawSyntax.makeLayout(
@@ -1085,9 +1085,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     }
   }
 
-  public var memberBlock: MemberBlockSyntax {
+  public var memberBlock: MemberBlockSyntax! {
     get {
-      return Syntax(self).child(at: 15)!.cast(MemberBlockSyntax.self)
+      return Syntax(self).child(at: 15)?.cast(MemberBlockSyntax.self)
     }
     set(value) {
       self = Syntax(self).replacingChild(at: 15, with: Syntax(value), arena: SyntaxArena()).cast(ActorDeclSyntax.self)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -12,6 +12,87 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MARK: - ABIAttributeArgumentsSyntax
+
+/// The arguments of the '@abi' attribute
+///
+/// - Note: Requires experimental feature `abiAttribute`.
+///
+/// ### Children
+/// 
+///  - `provider`: ``DeclSyntax``
+///
+/// ### Contained in
+/// 
+///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
+#if compiler(>=5.8)
+@_spi(ExperimentalLanguageFeatures)
+#endif
+public struct ABIAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
+  public let _syntaxNode: Syntax
+
+  public init?(_ node: __shared some SyntaxProtocol) {
+    guard node.raw.kind == .abiAttributeArguments else {
+      return nil
+    }
+    self._syntaxNode = node._syntaxNode
+  }
+
+  /// - Parameters:
+  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeProvider: UnexpectedNodesSyntax? = nil,
+    provider: some DeclSyntaxProtocol,
+    _ unexpectedAfterProvider: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    // Extend the lifetime of all parameters so their arenas don't get destroyed
+    // before they can be added as children of the new arena.
+    self = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeProvider, provider, unexpectedAfterProvider))) { (arena, _) in
+      let layout: [RawSyntax?] = [unexpectedBeforeProvider?.raw, provider.raw, unexpectedAfterProvider?.raw]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.abiAttributeArguments,
+        from: layout,
+        arena: arena,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia
+      )
+      return Syntax.forRoot(raw, rawNodeArena: arena).cast(Self.self)
+    }
+  }
+
+  public var unexpectedBeforeProvider: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 0)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 0, with: Syntax(value), arena: SyntaxArena()).cast(ABIAttributeArgumentsSyntax.self)
+    }
+  }
+
+  public var provider: DeclSyntax {
+    get {
+      return Syntax(self).child(at: 1)!.cast(DeclSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 1, with: Syntax(value), arena: SyntaxArena()).cast(ABIAttributeArgumentsSyntax.self)
+    }
+  }
+
+  public var unexpectedAfterProvider: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 2)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 2, with: Syntax(value), arena: SyntaxArena()).cast(ABIAttributeArgumentsSyntax.self)
+    }
+  }
+
+  public static let structure: SyntaxNodeStructure = .layout([\Self.unexpectedBeforeProvider, \Self.provider, \Self.unexpectedAfterProvider])
+}
+
 // MARK: - AccessorBlockSyntax
 
 /// ### Children
@@ -2291,7 +2372,7 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
 ///  - `atSign`: `@`
 ///  - `attributeName`: ``TypeSyntax``
 ///  - `leftParen`: `(`?
-///  - `arguments`: (``LabeledExprListSyntax`` | ``TokenSyntax`` | ``StringLiteralExprSyntax`` | ``AvailabilityArgumentListSyntax`` | ``SpecializeAttributeArgumentListSyntax`` | ``ObjCSelectorPieceListSyntax`` | ``ImplementsAttributeArgumentsSyntax`` | ``DifferentiableAttributeArgumentsSyntax`` | ``DerivativeAttributeArgumentsSyntax`` | ``BackDeployedAttributeArgumentsSyntax`` | ``ConventionAttributeArgumentsSyntax`` | ``ConventionWitnessMethodAttributeArgumentsSyntax`` | ``OpaqueReturnTypeOfAttributeArgumentsSyntax`` | ``ExposeAttributeArgumentsSyntax`` | ``OriginallyDefinedInAttributeArgumentsSyntax`` | ``UnderscorePrivateAttributeArgumentsSyntax`` | ``DynamicReplacementAttributeArgumentsSyntax`` | ``UnavailableFromAsyncAttributeArgumentsSyntax`` | ``EffectsAttributeArgumentListSyntax`` | ``DocumentationAttributeArgumentListSyntax``)?
+///  - `arguments`: (``LabeledExprListSyntax`` | ``TokenSyntax`` | ``StringLiteralExprSyntax`` | ``AvailabilityArgumentListSyntax`` | ``SpecializeAttributeArgumentListSyntax`` | ``ObjCSelectorPieceListSyntax`` | ``ImplementsAttributeArgumentsSyntax`` | ``DifferentiableAttributeArgumentsSyntax`` | ``DerivativeAttributeArgumentsSyntax`` | ``BackDeployedAttributeArgumentsSyntax`` | ``ConventionAttributeArgumentsSyntax`` | ``ConventionWitnessMethodAttributeArgumentsSyntax`` | ``OpaqueReturnTypeOfAttributeArgumentsSyntax`` | ``ExposeAttributeArgumentsSyntax`` | ``OriginallyDefinedInAttributeArgumentsSyntax`` | ``UnderscorePrivateAttributeArgumentsSyntax`` | ``DynamicReplacementAttributeArgumentsSyntax`` | ``UnavailableFromAsyncAttributeArgumentsSyntax`` | ``EffectsAttributeArgumentListSyntax`` | ``DocumentationAttributeArgumentListSyntax`` | `ABIAttributeArgumentsSyntax`)?
 ///  - `rightParen`: `)`?
 ///
 /// ### Contained in
@@ -2320,6 +2401,9 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     case unavailableFromAsyncArguments(UnavailableFromAsyncAttributeArgumentsSyntax)
     case effectsArguments(EffectsAttributeArgumentListSyntax)
     case documentationArguments(DocumentationAttributeArgumentListSyntax)
+    /// - Note: Requires experimental feature `abiAttribute`.
+    @_spi(ExperimentalLanguageFeatures)
+    case abiArguments(ABIAttributeArgumentsSyntax)
 
     public var _syntaxNode: Syntax {
       switch self {
@@ -2362,6 +2446,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
       case .effectsArguments(let node):
         return node._syntaxNode
       case .documentationArguments(let node):
+        return node._syntaxNode
+      case .abiArguments(let node):
         return node._syntaxNode
       }
     }
@@ -2446,6 +2532,12 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
       self = .documentationArguments(node)
     }
 
+    /// - Note: Requires experimental feature `abiAttribute`.
+    @_spi(ExperimentalLanguageFeatures)
+    public init(_ node: ABIAttributeArgumentsSyntax) {
+      self = .abiArguments(node)
+    }
+
     public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(LabeledExprListSyntax.self) {
         self = .argumentList(node)
@@ -2487,6 +2579,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
         self = .effectsArguments(node)
       } else if let node = node.as(DocumentationAttributeArgumentListSyntax.self) {
         self = .documentationArguments(node)
+      } else if let node = node.as(ABIAttributeArgumentsSyntax.self) {
+        self = .abiArguments(node)
       } else {
         return nil
       }
@@ -2513,7 +2607,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
         .node(DynamicReplacementAttributeArgumentsSyntax.self),
         .node(UnavailableFromAsyncAttributeArgumentsSyntax.self),
         .node(EffectsAttributeArgumentListSyntax.self),
-        .node(DocumentationAttributeArgumentListSyntax.self)
+        .node(DocumentationAttributeArgumentListSyntax.self),
+        .node(ABIAttributeArgumentsSyntax.self)
       ])
     }
 
@@ -2955,6 +3050,34 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
     public func cast(_ syntaxType: DocumentationAttributeArgumentListSyntax.Type) -> DocumentationAttributeArgumentListSyntax {
       return self.as(DocumentationAttributeArgumentListSyntax.self)!
+    }
+
+    /// Checks if the current syntax node can be cast to `ABIAttributeArgumentsSyntax`.
+    ///
+    /// - Returns: `true` if the node can be cast, `false` otherwise.
+    /// - Note: Requires experimental feature `abiAttribute`.
+    @_spi(ExperimentalLanguageFeatures)
+    public func `is`(_ syntaxType: ABIAttributeArgumentsSyntax.Type) -> Bool {
+      return self.as(syntaxType) != nil
+    }
+
+    /// Attempts to cast the current syntax node to `ABIAttributeArgumentsSyntax`.
+    ///
+    /// - Returns: An instance of `ABIAttributeArgumentsSyntax`, or `nil` if the cast fails.
+    /// - Note: Requires experimental feature `abiAttribute`.
+    @_spi(ExperimentalLanguageFeatures)
+    public func `as`(_ syntaxType: ABIAttributeArgumentsSyntax.Type) -> ABIAttributeArgumentsSyntax? {
+      return ABIAttributeArgumentsSyntax.init(self)
+    }
+
+    /// Force-casts the current syntax node to `ABIAttributeArgumentsSyntax`.
+    ///
+    /// - Returns: An instance of `ABIAttributeArgumentsSyntax`.
+    /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
+    /// - Note: Requires experimental feature `abiAttribute`.
+    @_spi(ExperimentalLanguageFeatures)
+    public func cast(_ syntaxType: ABIAttributeArgumentsSyntax.Type) -> ABIAttributeArgumentsSyntax {
+      return self.as(ABIAttributeArgumentsSyntax.self)!
     }
   }
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
@@ -740,7 +740,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-///  - `memberBlock`: ``MemberBlockSyntax``
+///  - `memberBlock`: ``MemberBlockSyntax``!
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -779,7 +779,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -820,7 +820,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
         unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
         genericWhereClause?.raw,
         unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw,
-        memberBlock.raw,
+        memberBlock?.raw,
         unexpectedAfterMemberBlock?.raw
       ]
       let raw = RawSyntax.makeLayout(
@@ -1039,9 +1039,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
   }
 
   /// The members of the class declaration. As class extension declarations may declare additional members, the contents of this member block isn't guaranteed to be a complete list of members for this type.
-  public var memberBlock: MemberBlockSyntax {
+  public var memberBlock: MemberBlockSyntax! {
     get {
-      return Syntax(self).child(at: 15)!.cast(MemberBlockSyntax.self)
+      return Syntax(self).child(at: 15)?.cast(MemberBlockSyntax.self)
     }
     set(value) {
       self = Syntax(self).replacingChild(at: 15, with: Syntax(value), arena: SyntaxArena()).cast(ClassDeclSyntax.self)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -1229,7 +1229,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-///  - `memberBlock`: ``MemberBlockSyntax``
+///  - `memberBlock`: ``MemberBlockSyntax``!
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -1268,7 +1268,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynta
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -1309,7 +1309,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynta
         unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
         genericWhereClause?.raw,
         unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw,
-        memberBlock.raw,
+        memberBlock?.raw,
         unexpectedAfterMemberBlock?.raw
       ]
       let raw = RawSyntax.makeLayout(
@@ -1528,9 +1528,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynta
   }
 
   /// The cases and other members associated with this enum declaration. Because enum extension declarations may declare additional members the contents of this member block isn't guaranteed to be a complete list of members for this type.
-  public var memberBlock: MemberBlockSyntax {
+  public var memberBlock: MemberBlockSyntax! {
     get {
-      return Syntax(self).child(at: 15)!.cast(MemberBlockSyntax.self)
+      return Syntax(self).child(at: 15)?.cast(MemberBlockSyntax.self)
     }
     set(value) {
       self = Syntax(self).replacingChild(at: 15, with: Syntax(value), arena: SyntaxArena()).cast(EnumDeclSyntax.self)
@@ -2125,7 +2125,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStm
 ///  - `extendedType`: ``TypeSyntax``
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-///  - `memberBlock`: ``MemberBlockSyntax``
+///  - `memberBlock`: ``MemberBlockSyntax``!
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -2161,7 +2161,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -2198,7 +2198,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
         unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
         genericWhereClause?.raw,
         unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw,
-        memberBlock.raw,
+        memberBlock?.raw,
         unexpectedAfterMemberBlock?.raw
       ]
       let raw = RawSyntax.makeLayout(
@@ -2402,9 +2402,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
   }
 
   /// The members of the extension declaration. As this is an extension, the contents of this member block isn't guaranteed to be a complete list of members for this type.
-  public var memberBlock: MemberBlockSyntax {
+  public var memberBlock: MemberBlockSyntax! {
     get {
-      return Syntax(self).child(at: 13)!.cast(MemberBlockSyntax.self)
+      return Syntax(self).child(at: 13)?.cast(MemberBlockSyntax.self)
     }
     set(value) {
       self = Syntax(self).replacingChild(at: 13, with: Syntax(value), arena: SyntaxArena()).cast(ExtensionDeclSyntax.self)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
@@ -4335,7 +4335,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
 ///  - `primaryAssociatedTypeClause`: ``PrimaryAssociatedTypeClauseSyntax``?
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-///  - `memberBlock`: ``MemberBlockSyntax``
+///  - `memberBlock`: ``MemberBlockSyntax``!
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -4374,7 +4374,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -4415,7 +4415,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
         unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
         genericWhereClause?.raw,
         unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw,
-        memberBlock.raw,
+        memberBlock?.raw,
         unexpectedAfterMemberBlock?.raw
       ]
       let raw = RawSyntax.makeLayout(
@@ -4634,9 +4634,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
   }
 
   /// The members of the protocol declaration.
-  public var memberBlock: MemberBlockSyntax {
+  public var memberBlock: MemberBlockSyntax! {
     get {
-      return Syntax(self).child(at: 15)!.cast(MemberBlockSyntax.self)
+      return Syntax(self).child(at: 15)?.cast(MemberBlockSyntax.self)
     }
     set(value) {
       self = Syntax(self).replacingChild(at: 15, with: Syntax(value), arena: SyntaxArena()).cast(ProtocolDeclSyntax.self)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -2242,7 +2242,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-///  - `memberBlock`: ``MemberBlockSyntax``
+///  - `memberBlock`: ``MemberBlockSyntax``!
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -2281,7 +2281,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
-    memberBlock: MemberBlockSyntax,
+    memberBlock: MemberBlockSyntax! = nil,
     _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -2322,7 +2322,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
         unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
         genericWhereClause?.raw,
         unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw,
-        memberBlock.raw,
+        memberBlock?.raw,
         unexpectedAfterMemberBlock?.raw
       ]
       let raw = RawSyntax.makeLayout(
@@ -2541,9 +2541,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
   }
 
   /// The members of the struct declaration. Because struct extension declarations may declare additional members the contents of this member block isn't guaranteed to be a complete list of members for this type.
-  public var memberBlock: MemberBlockSyntax {
+  public var memberBlock: MemberBlockSyntax! {
     get {
-      return Syntax(self).child(at: 15)!.cast(MemberBlockSyntax.self)
+      return Syntax(self).child(at: 15)?.cast(MemberBlockSyntax.self)
     }
     set(value) {
       self = Syntax(self).replacingChild(at: 15, with: Syntax(value), arena: SyntaxArena()).cast(StructDeclSyntax.self)

--- a/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
@@ -153,7 +153,7 @@ extension WithOptionalCodeBlockSyntax where Self: DeclSyntaxProtocol {
 // MARK: HasTrailingMemberDeclBlock
 
 public protocol HasTrailingMemberDeclBlock {
-  var memberBlock: MemberBlockSyntax { get set }
+  var memberBlock: MemberBlockSyntax! { get set }
 
   /// Constructs a syntax node where `header` builds the text of the node before the members in braces and `membersBuilder` is used to list the node’s members.
   ///
@@ -178,14 +178,14 @@ public protocol HasTrailingMemberDeclBlock {
   /// Throws an error if `header` defines a different node type than the type the initializer is called on. E.g. if calling `try StructDeclSyntax("class MyClass") {}`
   init(
     _ header: SyntaxNodeString,
-    @MemberBlockItemListBuilder membersBuilder: () throws -> MemberBlockItemListSyntax
+    @MemberBlockItemListBuilder membersBuilder: () throws -> MemberBlockItemListSyntax?
   ) throws
 }
 
 extension HasTrailingMemberDeclBlock where Self: DeclSyntaxProtocol {
   public init(
     _ header: SyntaxNodeString,
-    @MemberBlockItemListBuilder membersBuilder: () throws -> MemberBlockItemListSyntax
+    @MemberBlockItemListBuilder membersBuilder: () throws -> MemberBlockItemListSyntax?
   ) throws {
     // If the type provides a custom `SyntaxParseable` implementation, use that. Otherwise construct it as a
     // `DeclSyntax`.
@@ -202,7 +202,7 @@ extension HasTrailingMemberDeclBlock where Self: DeclSyntaxProtocol {
       throw SyntaxStringInterpolationInvalidNodeTypeError(expectedType: Self.self, actualNode: decl)
     }
     self = castedDecl
-    self.memberBlock = try MemberBlockSyntax(members: membersBuilder())
+    self.memberBlock = try membersBuilder().map { MemberBlockSyntax(members: $0) }
   }
 }
 

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -79,7 +79,7 @@ extension ActorDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -99,7 +99,9 @@ extension ActorDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -180,7 +182,7 @@ extension ClassDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -200,7 +202,9 @@ extension ClassDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -461,7 +465,7 @@ extension EnumDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -481,7 +485,9 @@ extension EnumDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -541,7 +547,7 @@ extension ExtensionDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -559,7 +565,9 @@ extension ExtensionDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -1131,7 +1139,7 @@ extension ProtocolDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -1151,7 +1159,9 @@ extension ProtocolDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -1255,7 +1265,7 @@ extension StructDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -1275,7 +1285,9 @@ extension StructDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )

--- a/Sources/SwiftSyntaxBuilder/generated/RenamedChildrenBuilderCompatibility.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/RenamedChildrenBuilderCompatibility.swift
@@ -83,7 +83,7 @@ extension ActorDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -103,7 +103,9 @@ extension ActorDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -161,7 +163,7 @@ extension ClassDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -181,7 +183,9 @@ extension ClassDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -210,7 +214,7 @@ extension EnumDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -230,7 +234,9 @@ extension EnumDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -721,7 +727,7 @@ extension ProtocolDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -741,7 +747,9 @@ extension ProtocolDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )
@@ -799,7 +807,7 @@ extension StructDeclSyntax {
     genericWhereClause: GenericWhereClauseSyntax? = nil,
     unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil,
     unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
-    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax?,
     trailingTrivia: Trivia? = nil
   ) rethrows {
     try self.init(
@@ -819,7 +827,9 @@ extension StructDeclSyntax {
       unexpectedBetweenInheritanceClauseAndGenericWhereClause,
       genericWhereClause: genericWhereClause,
       unexpectedBetweenGenericWhereClauseAndMemberBlock,
-      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      memberBlock: memberBlockBuilder().map {
+        MemberBlockSyntax(members: $0)
+      },
       unexpectedAfterMemberBlock,
       trailingTrivia: trailingTrivia
     )

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftParser
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftParser
+@_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class AttributeTests: ParserTestCase {
@@ -962,6 +962,179 @@ final class AttributeTests: ParserTestCase {
       """
       var array = [@convention(swift) @isolated(any) () -> ()]()
       """
+    )
+  }
+
+  func testABIAttribute() {
+    assertParse(
+      """
+      @abi(func fn() -> Int)
+      func fn1() -> Int { }
+      """,
+      substructure: FunctionDeclSyntax(
+        attributes: [
+          .attribute(AttributeSyntax(
+            attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("abi"))),
+            leftParen: .leftParenToken(),
+            arguments: .abiArguments(
+              ABIAttributeArgumentsSyntax(
+                provider: FunctionDeclSyntax(
+                  name: .identifier("fn"),
+                  signature: FunctionSignatureSyntax(
+                    parameterClause: FunctionParameterClauseSyntax(
+                      parameters: []
+                    ),
+                    returnClause: ReturnClauseSyntax(
+                      type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int")))
+                    )
+                  )
+                )
+              )
+            ),
+            rightParen: .rightParenToken()
+          ))
+        ],
+        name: .identifier("fn1"),
+        signature: FunctionSignatureSyntax(
+          parameterClause: FunctionParameterClauseSyntax(
+            parameters: []
+          ),
+          returnClause: ReturnClauseSyntax(
+            type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int")))
+          )
+        ),
+        body: CodeBlockSyntax(statements: [])
+      ),
+      experimentalFeatures: [.abiAttribute]
+    )
+
+    assertParse(
+      """
+      @abi(var x, y)
+      var x, y
+      """,
+      experimentalFeatures: [.abiAttribute]
+    )
+
+    assertParse(
+      """
+      @abi(class Sub: Super, Proto where Assoc: OtherProto)
+      class Sub: Super, Proto where Assoc: OtherProto {}
+      """,
+      experimentalFeatures: [.abiAttribute]
+    )
+
+    // Invalid, but diagnosed in ASTGen
+    assertParse(
+      """
+      @abi(var x = 1, y = 2)
+      var x, y
+
+      @abi(var a { get {} set {} })
+      var a
+
+      @abi(class Sub: Super, Proto where Assoc: OtherProto {})
+      class Sub: Super, Proto where Assoc: OtherProto {}
+      """,
+      experimentalFeatures: [.abiAttribute]
+    )
+
+    // Caught here
+    assertParse(
+      """
+      class Sub: Super, Proto where Assoc: OtherProto1️⃣
+
+      func fn1() {}
+
+      @abi(var 2️⃣)
+      var v1
+
+      @abi4️⃣(var v23️⃣
+      var v2
+
+      @abi(5️⃣)
+      func fn2() {}
+
+      @abi6️⃣
+      func fn3() {}
+
+      // Suboptimal:
+      @abi7️⃣ func fn4_abi()8️⃣)
+      func fn4() {}9️⃣
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected '{' in class",
+          fixIts: ["insert '{'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected pattern in variable",
+          fixIts: ["insert pattern"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "3️⃣",
+          message: "expected ')' to end attribute",
+          notes: [
+            NoteSpec(
+              locationMarker: "4️⃣",
+              message: "to match this opening '('"
+            )
+          ],
+          fixIts: ["insert ')'"]
+        ),
+        // FIXME: Custom fix-it with copy of decl it's attached to
+        DiagnosticSpec(
+          locationMarker: "5️⃣",
+          message: "expected argument for '@abi' attribute",
+          fixIts: ["insert attribute argument"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "6️⃣",
+          message: "expected '(', ABI-providing declaration, and ')' in attribute",
+          fixIts: ["insert '(', ABI-providing declaration, and ')'"]
+        ),
+        // FIXME: Suboptimal diagnosis
+        DiagnosticSpec(
+          locationMarker: "7️⃣",
+          message: "expected '(', ABI-providing declaration, and ')' in attribute",
+          fixIts: ["insert '(', ABI-providing declaration, and ')'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "8️⃣",
+          message: "unexpected code ')' before function"
+        ),
+        // FIXME: Leave this out if the opener is missing?
+        DiagnosticSpec(
+          locationMarker: "9️⃣",
+          message: "expected '}' to end class",
+          fixIts: ["insert '}'"]
+        ),
+      ],
+      fixedSource: """
+      class Sub: Super, Proto where Assoc: OtherProto {
+
+      func fn1() {}
+
+      @abi(var <#pattern#>)
+      var v1
+
+      @abi(var v2)
+      var v2
+
+      @abi(<#declaration#>)
+      func fn2() {}
+
+      @abi(<#declaration#>)
+      func fn3() {}
+
+      // Suboptimal:
+      @abi(<#declaration#>) func fn4_abi())
+      func fn4() {}
+      }
+      """,
+      experimentalFeatures: [.abiAttribute]
     )
   }
 


### PR DESCRIPTION
Matches swiftlang/swift#76878.

Note that `@abi` introduces a situation we've never had before: the various `DeclGroupSyntax` decls can now have a `nil` `memberBlock`. This can only occur for children of an `ABIAttributeArgumentsSyntax` node, not any nodes that would occur in existing constructs. To preserve source compatibility with existing clients, I've made `memberBlock` an implicitly-unwrapped optional, but I'm open to opinions if that's not the design we'd like to have.

Another place I'd like feedback on is the way I'm parsing malformed `@abi` argument lists. Because the argument is literally an entire decl, I found that the default recovery behavior when the left paren was missing didn't work well, so I built something a little different. If you have better suggestions, I'd love to hear them.