### PR TITLE
[SwiftLexicalLookup] Add support for `#if` and macro declarations. More `ASTScope` related fixes.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -184,7 +184,7 @@ let package = Package(
 
     .target(
       name: "SwiftLexicalLookup",
-      dependencies: ["SwiftSyntax"]
+      dependencies: ["SwiftSyntax", "SwiftIfConfig"]
     ),
 
     .testTarget(

--- a/Sources/SwiftLexicalLookup/CMakeLists.txt
+++ b/Sources/SwiftLexicalLookup/CMakeLists.txt
@@ -26,5 +26,6 @@ add_swift_syntax_library(SwiftLexicalLookup
 )
 
 target_link_swift_syntax_libraries(SwiftLexicalLookup PUBLIC
-  SwiftSyntax)
+  SwiftSyntax
+  SwiftIfConfig)
 

--- a/Sources/SwiftLexicalLookup/LookupConfig.swift
+++ b/Sources/SwiftLexicalLookup/LookupConfig.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftIfConfig
+
 @_spi(Experimental) public struct LookupConfig {
   /// Specifies whether lookup should finish in the closest sequential scope.
   ///
@@ -31,14 +33,17 @@
   /// If `finishInSequentialScope` would be set to `false`, the only name
   /// returned by lookup would be the `a` declaration from inside function body.
   @_spi(Experimental) public var finishInSequentialScope: Bool
+  @_spi(Experimental) public var buildConfiguration: BuildConfiguration?
 
   /// Creates a new lookup configuration.
   ///
   /// - `finishInSequentialScope` - specifies whether lookup should finish
   ///   in the closest sequential scope. `false` by default.
   @_spi(Experimental) public init(
-    finishInSequentialScope: Bool = false
+    finishInSequentialScope: Bool = false,
+    buildConfiguration: BuildConfiguration? = nil
   ) {
     self.finishInSequentialScope = finishInSequentialScope
+    self.buildConfiguration = buildConfiguration
   }
 }

--- a/Sources/SwiftLexicalLookup/LookupConfig.swift
+++ b/Sources/SwiftLexicalLookup/LookupConfig.swift
@@ -33,7 +33,7 @@ import SwiftIfConfig
   /// If `finishInSequentialScope` would be set to `false`, the only name
   /// returned by lookup would be the `a` declaration from inside function body.
   @_spi(Experimental) public var finishInSequentialScope: Bool
-  @_spi(Experimental) public var buildConfiguration: BuildConfiguration?
+  @_spi(Experimental) public var configuredRegions: ConfiguredRegions?
 
   /// Creates a new lookup configuration.
   ///
@@ -41,9 +41,9 @@ import SwiftIfConfig
   ///   in the closest sequential scope. `false` by default.
   @_spi(Experimental) public init(
     finishInSequentialScope: Bool = false,
-    buildConfiguration: BuildConfiguration? = nil
+    configuredRegions: ConfiguredRegions? = nil
   ) {
     self.finishInSequentialScope = finishInSequentialScope
-    self.buildConfiguration = buildConfiguration
+    self.configuredRegions = configuredRegions
   }
 }

--- a/Sources/SwiftLexicalLookup/LookupName.swift
+++ b/Sources/SwiftLexicalLookup/LookupName.swift
@@ -104,6 +104,10 @@ import SwiftSyntax
       case .variableDecl(let variableDecl):
         return variableDecl.bindings.first?.accessorBlock?.positionAfterSkippingLeadingTrivia
           ?? variableDecl.endPosition
+      case .accessorDecl(let accessorDecl):
+        return accessorDecl.accessorSpecifier.positionAfterSkippingLeadingTrivia
+      case .deinitializerDecl(let deinitializerDecl):
+        return deinitializerDecl.deinitKeyword.positionAfterSkippingLeadingTrivia
       default:
         return declSyntax.positionAfterSkippingLeadingTrivia
       }
@@ -111,13 +115,15 @@ import SwiftSyntax
       switch Syntax(declSyntax).as(SyntaxEnum.self) {
       case .protocolDecl(let protocolDecl):
         return protocolDecl.name.positionAfterSkippingLeadingTrivia
+      case .extensionDecl(let extensionDecl):
+        return extensionDecl.extensionKeyword.positionAfterSkippingLeadingTrivia
       default:
         return declSyntax.positionAfterSkippingLeadingTrivia
       }
+    case .newValue(let accessorDecl), .oldValue(let accessorDecl):
+      return accessorDecl.accessorSpecifier.positionAfterSkippingLeadingTrivia
     case .error(let catchClause):
       return catchClause.catchItems.positionAfterSkippingLeadingTrivia
-    default:
-      return syntax.positionAfterSkippingLeadingTrivia
     }
   }
 }
@@ -276,7 +282,11 @@ import SwiftSyntax
     identifiable: IdentifiableSyntax,
     accessibleAfter: AbsolutePosition? = nil
   ) -> [LookupName] {
-    [.identifier(identifiable, accessibleAfter: accessibleAfter)]
+    if case .wildcard = identifiable.identifier.tokenKind {
+      return []
+    }
+
+    return [.identifier(identifiable, accessibleAfter: accessibleAfter)]
   }
 
   /// Extracts name introduced by `NamedDeclSyntax` node.

--- a/Sources/SwiftLexicalLookup/Scopes/FunctionScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/FunctionScopeSyntax.swift
@@ -22,7 +22,7 @@ extension FunctionScopeSyntax {
   @_spi(Experimental) public var defaultIntroducedNames: [LookupName] {
     signature.parameterClause.parameters.flatMap { parameter in
       LookupName.getNames(from: parameter)
-    } + (parentScope?.is(MemberBlockSyntax.self) ?? false ? [.implicit(.self(self))] : [])
+    } + (isMember ? [.implicit(.self(self))] : [])
   }
 
   /// Lookup results from this function scope.

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
@@ -498,7 +498,26 @@ import SwiftSyntax
 }
 
 @_spi(Experimental) extension CatchClauseSyntax: ScopeSyntax {
-  /// Implicit `error` when there are no catch items.
+  /// Name introduced by the catch clause.
+  ///
+  /// `defaultIntroducedNames` contains implicit `error` name if
+  /// no names are declared in catch items and they don't contain any expression patterns.
+  /// Otherwise, `defaultIntroducedNames` contains names introduced by the clause.
+  ///
+  /// ### Example
+  /// ```swift
+  /// do {
+  ///   // ...
+  /// } catch SomeError, .x(let a) {
+  ///   // <-- lookup here, result: [a]
+  /// } catch .x(let a) {
+  ///   // <-- lookup here, result: [a]
+  /// } catch SomeError {
+  ///   // <-- lookup here, result: [empty]
+  /// } catch {
+  ///   // <-- lookup here, result: implicit(error)
+  /// }
+  /// ```
   @_spi(Experimental) public var defaultIntroducedNames: [LookupName] {
     var containsExpressionSyntax = false
 
@@ -942,8 +961,8 @@ extension SubscriptDeclSyntax: WithGenericParametersScopeSyntax, CanInterleaveRe
   ) -> [LookupResult] {
     let clause: IfConfigClauseSyntax?
 
-    if let buildConfiguration = config.buildConfiguration {
-      (clause, _) = activeClause(in: buildConfiguration)
+    if let configuredRegions = config.configuredRegions {
+      clause = configuredRegions.activeClause(for: self)
     } else {
       clause =
         clauses
@@ -967,8 +986,8 @@ extension SubscriptDeclSyntax: WithGenericParametersScopeSyntax, CanInterleaveRe
   func getNamedDecls(for config: LookupConfig) -> [NamedDeclSyntax] {
     let clause: IfConfigClauseSyntax?
 
-    if let buildConfiguration = config.buildConfiguration {
-      (clause, _) = activeClause(in: buildConfiguration)
+    if let configuredRegions = config.configuredRegions {
+      clause = configuredRegions.activeClause(for: self)
     } else {
       clause =
         clauses

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftIfConfig
 import SwiftSyntax
 
 @_spi(Experimental) extension SyntaxProtocol {
@@ -391,7 +392,11 @@ import SwiftSyntax
 }
 @_spi(Experimental) extension ExtensionDeclSyntax: LookInMembersScopeSyntax {
   @_spi(Experimental) public var lookupMembersPosition: AbsolutePosition {
-    extendedType.position
+    if let memberType = extendedType.as(MemberTypeSyntax.self) {
+      return memberType.name.positionAfterSkippingLeadingTrivia
+    }
+
+    return extendedType.positionAfterSkippingLeadingTrivia
   }
 
   @_spi(Experimental) public var defaultIntroducedNames: [LookupName] {
@@ -420,8 +425,8 @@ import SwiftSyntax
         + defaultLookupImplementation(identifier, at: lookUpPosition, with: config, propagateToParent: false)
         + [.lookInMembers(self)]
         + lookupInParent(identifier, at: lookUpPosition, with: config)
-    } else if !extendedType.range.contains(lookUpPosition) && genericWhereClause != nil {
-      if inRightTypeOrSameTypeRequirement(lookUpPosition) {
+    } else if !extendedType.range.contains(lookUpPosition), let genericWhereClause {
+      if genericWhereClause.range.contains(lookUpPosition) {
         return [.lookInGenericParametersOfExtendedType(self)] + [.lookInMembers(self)]
           + defaultLookupImplementation(identifier, at: lookUpPosition, with: config)
       }
@@ -432,23 +437,6 @@ import SwiftSyntax
 
     return [.lookInGenericParametersOfExtendedType(self)]
       + lookupInParent(identifier, at: lookUpPosition, with: config)
-  }
-
-  /// Returns `true` if `checkedPosition` is a right type of a
-  /// conformance requirement or inside a same type requirement.
-  private func inRightTypeOrSameTypeRequirement(
-    _ checkedPosition: AbsolutePosition
-  ) -> Bool {
-    genericWhereClause?.requirements.contains { elem in
-      switch Syntax(elem.requirement).as(SyntaxEnum.self) {
-      case .conformanceRequirement(let conformanceRequirement):
-        return conformanceRequirement.rightType.range.contains(checkedPosition)
-      case .sameTypeRequirement(let sameTypeRequirement):
-        return sameTypeRequirement.range.contains(checkedPosition)
-      default:
-        return false
-      }
-    } ?? false
   }
 }
 
@@ -491,7 +479,7 @@ import SwiftSyntax
 
     let implicitSelf: [LookupName] = [.implicit(.self(self))]
       .filter { name in
-        checkIdentifier(identifier, refersTo: name, at: lookUpPosition)
+        checkIdentifier(identifier, refersTo: name, at: lookUpPosition) && !attributes.range.contains(lookUpPosition)
       }
 
     return defaultLookupImplementation(
@@ -512,13 +500,19 @@ import SwiftSyntax
 @_spi(Experimental) extension CatchClauseSyntax: ScopeSyntax {
   /// Implicit `error` when there are no catch items.
   @_spi(Experimental) public var defaultIntroducedNames: [LookupName] {
+    var containsExpressionSyntax = false
+
     let extractedNames = catchItems.flatMap { item in
       guard let pattern = item.pattern else { return [LookupName]() }
+
+      if !containsExpressionSyntax && pattern.is(ExpressionPatternSyntax.self) {
+        containsExpressionSyntax = true
+      }
 
       return LookupName.getNames(from: pattern)
     }
 
-    return extractedNames.isEmpty ? [.implicit(.error(self))] : extractedNames
+    return extractedNames.isEmpty && !containsExpressionSyntax ? [.implicit(.error(self))] : extractedNames
   }
 
   @_spi(Experimental) public var scopeDebugName: String {
@@ -594,14 +588,27 @@ import SwiftSyntax
       checkIdentifier(identifier, refersTo: name, at: lookUpPosition)
     }
 
-    return sequentialLookup(
-      in: statements,
-      identifier,
-      at: lookUpPosition,
-      with: config,
-      propagateToParent: false
-    ) + LookupResult.getResultArray(for: self, withNames: filteredNamesFromLabel)
-      + (config.finishInSequentialScope ? [] : lookupInParent(identifier, at: lookUpPosition, with: config))
+    if label.range.contains(lookUpPosition) {
+      return config.finishInSequentialScope ? [] : lookupInParent(identifier, at: lookUpPosition, with: config)
+    } else if config.finishInSequentialScope {
+      return sequentialLookup(
+        in: statements,
+        identifier,
+        at: lookUpPosition,
+        with: config,
+        propagateToParent: false
+      )
+    } else {
+      return sequentialLookup(
+        in: statements,
+        identifier,
+        at: lookUpPosition,
+        with: config,
+        propagateToParent: false
+      )
+        + LookupResult.getResultArray(for: self, withNames: filteredNamesFromLabel)
+        + lookupInParent(identifier, at: lookUpPosition, with: config)
+    }
   }
 }
 
@@ -697,6 +704,18 @@ import SwiftSyntax
   }
 }
 
+@_spi(Experimental) extension MacroDeclSyntax: WithGenericParametersScopeSyntax {
+  public var defaultIntroducedNames: [LookupName] {
+    signature.parameterClause.parameters.flatMap { parameter in
+      LookupName.getNames(from: parameter)
+    }
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "MacroDeclScope"
+  }
+}
+
 @_spi(Experimental)
 extension SubscriptDeclSyntax: WithGenericParametersScopeSyntax, CanInterleaveResultsLaterScopeSyntax {
   /// Parameters introduced by this subscript and possibly `self` keyword.
@@ -758,7 +777,7 @@ extension SubscriptDeclSyntax: WithGenericParametersScopeSyntax, CanInterleaveRe
   ) -> [LookupResult] {
     var thisScopeResults: [LookupResult] = []
 
-    if !parameterClause.range.contains(lookUpPosition) && !returnClause.range.contains(lookUpPosition) {
+    if accessorBlock?.range.contains(lookUpPosition) ?? false {
       thisScopeResults = defaultLookupImplementation(
         identifier,
         at: position,
@@ -866,8 +885,6 @@ extension SubscriptDeclSyntax: WithGenericParametersScopeSyntax, CanInterleaveRe
     with config: LookupConfig
   ) -> [LookupResult] {
     if bindings.first?.accessorBlock?.range.contains(lookUpPosition) ?? false {
-      let isMember = parentScope?.is(MemberBlockSyntax.self) ?? false
-
       return defaultLookupImplementation(
         in: (isMember ? [.implicit(.self(self))] : LookupName.getNames(from: self)),
         identifier,
@@ -887,10 +904,99 @@ extension SubscriptDeclSyntax: WithGenericParametersScopeSyntax, CanInterleaveRe
     with config: LookupConfig,
     resultsToInterleave: [LookupResult]
   ) -> [LookupResult] {
-    guard parentScope?.is(MemberBlockSyntax.self) ?? false else {
+    guard isMember else {
       return lookup(identifier, at: lookUpPosition, with: config)
     }
 
     return resultsToInterleave + lookupInParent(identifier, at: lookUpPosition, with: config)
+  }
+}
+
+@_spi(Experimental) extension DeinitializerDeclSyntax: ScopeSyntax {
+  @_spi(Experimental) public var defaultIntroducedNames: [LookupName] {
+    [.implicit(.self(self))]
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "DeinitializerScope"
+  }
+}
+
+@_spi(Experimental) extension IfConfigDeclSyntax: IntroducingToSequentialParentScopeSyntax, SequentialScopeSyntax {
+  /// Names from all clauses.
+  var namesIntroducedToSequentialParent: [LookupName] {
+    clauses.flatMap { clause in
+      clause.elements.flatMap { element in
+        LookupName.getNames(from: element, accessibleAfter: element.endPosition)
+      } ?? []
+    }
+  }
+
+  /// Performs sequential lookup in the active clause.
+  /// Active clause is determined by the `BuildConfiguration`
+  /// inside `config`. If not specified, defaults to the `#else` clause.
+  func lookupFromSequentialParent(
+    _ identifier: Identifier?,
+    at lookUpPosition: AbsolutePosition,
+    with config: LookupConfig
+  ) -> [LookupResult] {
+    let clause: IfConfigClauseSyntax?
+
+    if let buildConfiguration = config.buildConfiguration {
+      (clause, _) = activeClause(in: buildConfiguration)
+    } else {
+      clause =
+        clauses
+        .first { clause in
+          clause.poundKeyword.tokenKind == .poundElse
+        }
+    }
+
+    return sequentialLookup(
+      in: clause?.elements?.as(CodeBlockItemListSyntax.self) ?? [],
+      identifier,
+      at: lookUpPosition,
+      with: config,
+      ignoreNamedDecl: true,
+      propagateToParent: false
+    )
+  }
+
+  /// Returns all `NamedDeclSyntax` nodes in the active clause specified
+  /// by `BuildConfiguration` in `config` from bottom-most to top-most.
+  func getNamedDecls(for config: LookupConfig) -> [NamedDeclSyntax] {
+    let clause: IfConfigClauseSyntax?
+
+    if let buildConfiguration = config.buildConfiguration {
+      (clause, _) = activeClause(in: buildConfiguration)
+    } else {
+      clause =
+        clauses
+        .first { clause in
+          clause.poundKeyword.tokenKind == .poundElse
+        }
+    }
+
+    guard let clauseElements = clause?.elements?.as(CodeBlockItemListSyntax.self) else { return [] }
+
+    var result: [NamedDeclSyntax] = []
+
+    for elem in clauseElements.reversed() {
+      if let namedDecl = elem.item.asProtocol(NamedDeclSyntax.self) {
+        result.append(namedDecl)
+      } else if let ifConfigDecl = elem.item.as(IfConfigDeclSyntax.self) {
+        result += ifConfigDecl.getNamedDecls(for: config)
+      }
+    }
+
+    return result
+  }
+
+  @_spi(Experimental) public var defaultIntroducedNames: [LookupName] {
+    []
+  }
+
+  @_spi(Experimental) public var scopeDebugName: String {
+    "IfConfigScope"
   }
 }

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeSyntax.swift
@@ -122,8 +122,27 @@ extension SyntaxProtocol {
     introducedName.isAccessible(at: lookUpPosition) && introducedName.refersTo(identifier)
   }
 
+  var isMember: Bool {
+    if parentScope?.is(MemberBlockSyntax.self) ?? false {
+      return true
+    } else if let parentIfConfig = parentScope?.as(IfConfigDeclSyntax.self) {
+      return parentIfConfig.isMember
+    } else {
+      return false
+    }
+  }
+
   /// Debug description of this scope.
   @_spi(Experimental) public var scopeDebugDescription: String {
     scopeDebugName + " " + debugLineWithColumnDescription
+  }
+
+  /// Hierarchy of scopes starting from this scope.
+  @_spi(Experimental) public var scopeDebugHierarchyDescription: String {
+    if let parentScope = parentScope {
+      return parentScope.scopeDebugHierarchyDescription + " <-- " + scopeDebugDescription
+    } else {
+      return scopeDebugDescription
+    }
   }
 }

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -705,10 +705,7 @@ final class testNameLookup: XCTestCase {
         """,
       references: [
         "2️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("1️⃣")])],
-        "3️⃣": [
-          .fromScope(CatchClauseSyntax.self, expectedNames: [NameExpectation.implicit(.error("6️⃣"))]),
-          .fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("1️⃣")]),
-        ],
+        "3️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("1️⃣")])],
         "5️⃣": [
           .fromScope(CatchClauseSyntax.self, expectedNames: [NameExpectation.implicit(.error("4️⃣"))]),
           .fromScope(CodeBlockSyntax.self, expectedNames: [NameExpectation.identifier("1️⃣")]),
@@ -1010,6 +1007,84 @@ final class testNameLookup: XCTestCase {
       expectedResultTypes: .all(
         GenericParameterSyntax.self
       )
+    )
+  }
+
+  func testDefaultIfConfigBehavior() {
+    assertLexicalNameLookup(
+      source: """
+        func foo() {
+          let 0️⃣a = 1️⃣x
+
+          #if DEBUG
+
+          let b = 2️⃣x
+          class A {}
+
+          #else
+
+          let 3️⃣c = 4️⃣x
+          5️⃣class B {}
+          
+          #if DEBUG
+
+          let d = 6️⃣x
+          class C {}
+
+          #else
+
+          let 7️⃣e = 8️⃣x
+          9️⃣class D {}
+
+          #endif
+          
+          #endif
+          
+          🔟class E {}
+        }
+        """,
+      references: [
+        "1️⃣": [.fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣", "9️⃣", "🔟"])],
+        "2️⃣": [
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["0️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣", "9️⃣", "🔟"]),
+        ],
+        "4️⃣": [
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["0️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣", "9️⃣", "🔟"]),
+        ],
+        "6️⃣": [
+          .fromScope(IfConfigDeclSyntax.self, expectedNames: ["3️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["0️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣", "9️⃣", "🔟"]),
+        ],
+        "8️⃣": [
+          .fromScope(IfConfigDeclSyntax.self, expectedNames: ["3️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["0️⃣"]),
+          .fromScope(CodeBlockSyntax.self, expectedNames: ["5️⃣", "9️⃣", "🔟"]),
+        ],
+      ],
+      useNilAsTheParameter: true
+    )
+  }
+
+  func testMacroDeclaration() {
+    let sameResult: [ResultExpectation] = [
+      .fromScope(MacroDeclSyntax.self, expectedNames: ["1️⃣", "3️⃣"]),
+      .fromScope(GenericParameterClauseSyntax.self, expectedNames: ["0️⃣"]),
+    ]
+
+    assertLexicalNameLookup(
+      source: """
+        public macro externalMacro<0️⃣T>(1️⃣module: 2️⃣String, 3️⃣type: 4️⃣String) -> 5️⃣T = 6️⃣X
+        """,
+      references: [
+        "2️⃣": sameResult,
+        "4️⃣": sameResult,
+        "5️⃣": sameResult,
+        "6️⃣": sameResult,
+      ],
+      useNilAsTheParameter: true
     )
   }
 }


### PR DESCRIPTION
This PR includes more fixes that bring `SwiftLexicalLookup` unqualified lookup implementation closer to the `ASTScope` counterpart. Those include:
- Handling of `#if` clauses thanks to `SwiftIfConfig`.
- Macro declaration support.
- Sequential scope improvements. Now, only uses `.reversed()` for iteration. Since it's more likely code block contains more variable decls than named decls, sequential lookup first goes through all items, and collects named decls.
- Bring back `wildcard` token filtering for names from `IdentifiableSyntax`.
- More minor fixes.

With this PR, I was able to run validation for the entire Swift standard library with just **two** remaining bugs!