### PR TITLE
Make InitializerDeclSyntax parseable

### DIFF
--- a/Sources/SwiftSyntaxBuilder/DeclSyntaxParseable.swift
+++ b/Sources/SwiftSyntaxBuilder/DeclSyntaxParseable.swift
@@ -50,6 +50,7 @@ extension EnumDeclSyntax: DeclSyntaxParseable {}
 extension ExtensionDeclSyntax: DeclSyntaxParseable {}
 extension FunctionDeclSyntax: DeclSyntaxParseable {}
 extension ImportDeclSyntax: DeclSyntaxParseable {}
+extension InitializerDeclSyntax: DeclSyntaxParseable {}
 extension VariableDeclSyntax: DeclSyntaxParseable {}
 extension MacroDeclSyntax: DeclSyntaxParseable {}
 extension OperatorDeclSyntax: DeclSyntaxParseable {}

--- a/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
@@ -87,4 +87,14 @@ final class InitializerDeclTests: XCTestCase {
       """
     )
   }
+
+  func testParseableInitializer() throws {
+    assertBuildResult(
+      try InitializerDeclSyntax("init() {}"),
+      """
+      init() {
+      }
+      """
+    )
+  }
 }


### PR DESCRIPTION
Fixes an omission I discovered while doing other work.