### PR TITLE
[Perf] Optimize SourceLocationConverter

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -365,20 +365,6 @@ extension Syntax: Identifiable {
 }
 
 extension Syntax {
-  /// Enumerate all of the syntax text present in this node, and all
-  /// of its children, to give a source-accurate view of the bytes.
-  ///
-  /// Unlike `description`, this provides a source-accurate representation
-  /// even in the presence of malformed UTF-8 in the input source.
-  ///
-  /// The ``SyntaxText`` arguments passed to the visitor are only guaranteed
-  /// to be valid within that call. It is unsafe to escape the `SyntaxValue`
-  /// values outside of the closure.
-  @_spi(RawSyntax)
-  public func withEachSyntaxText(body: (SyntaxText) throws -> Void) rethrows {
-    try raw.withEachSyntaxText(body: body)
-  }
-
   /// Retrieve the syntax text as an array of bytes that models the input
   /// source even in the presence of invalid UTF-8.
   public var syntaxTextBytes: [UInt8] {

--- a/Sources/SwiftSyntax/SyntaxArenaAllocatedBuffer.swift
+++ b/Sources/SwiftSyntax/SyntaxArenaAllocatedBuffer.swift
@@ -17,7 +17,8 @@
 /// reference its contents, we know that the pointer's contents won't get
 /// deallocated while being accessed and thus we can add an unchecked `Sendable`
 /// conformance.
-@_spi(RawSyntax) public struct SyntaxArenaAllocatedPointer<Element: Sendable>: @unchecked Sendable {
+@_spi(RawSyntax)
+public struct SyntaxArenaAllocatedPointer<Element: Sendable>: @unchecked Sendable {
   private let pointer: UnsafePointer<Element>
 
   /// Create a pointer from an `UnsafePointer` that was allocated inside a
@@ -61,22 +62,21 @@ public struct SyntaxArenaAllocatedBufferPointer<Element: Sendable>: RandomAccess
   /// - Important: The client needs to ensure sure that the buffer is indeed
   ///   allocated by a ``SyntaxArena`` and that the ``SyntaxArena`` will outlive
   ///   any users of this ``SyntaxArenaAllocatedBufferPointer``.
-  @_spi(RawSyntax) public init(_ buffer: UnsafeBufferPointer<Element>) {
+  public init(_ buffer: UnsafeBufferPointer<Element>) {
     self.buffer = buffer
   }
 
-  @_spi(RawSyntax)
   public subscript<RangeType: RangeExpression<Int>>(
     range: RangeType
   ) -> SyntaxArenaAllocatedBufferPointer<Element> {
     return SyntaxArenaAllocatedBufferPointer(UnsafeBufferPointer(rebasing: self.buffer[range]))
   }
 
-  @_spi(RawSyntax) public subscript(_ index: Int) -> Element {
+  public subscript(_ index: Int) -> Element {
     return self.buffer[index]
   }
 
-  @_spi(RawSyntax) public func makeIterator() -> UnsafeBufferPointer<Element>.Iterator {
+  public func makeIterator() -> UnsafeBufferPointer<Element>.Iterator {
     return buffer.makeIterator()
   }
 
@@ -110,5 +110,9 @@ public struct SyntaxArenaAllocatedBufferPointer<Element: Sendable>: RandomAccess
 
   public func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<Element>) throws -> R) rethrows -> R? {
     try body(buffer)
+  }
+
+  public func _copyContents(initializing ptr: UnsafeMutableBufferPointer<Element>) -> (Iterator, Int) {
+    buffer._copyContents(initializing: ptr)
   }
 }

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -47,10 +47,11 @@ import Musl
 /// replacement character (`\u{FFFD}`).
 @_spi(RawSyntax)
 public struct SyntaxText: Sendable {
-  var buffer: SyntaxArenaAllocatedBufferPointer<UInt8>
+  public typealias Buffer = SyntaxArenaAllocatedBufferPointer<UInt8>
+  var buffer: Buffer
 
   /// Construct a ``SyntaxText`` whose text is represented by the given `buffer`.
-  public init(buffer: SyntaxArenaAllocatedBufferPointer<UInt8>) {
+  public init(buffer: Buffer) {
     self.buffer = buffer
   }
 
@@ -179,6 +180,18 @@ extension SyntaxText: RandomAccessCollection {
   /// Access the byte at `index`.
   public subscript(index: Index) -> Element {
     get { return buffer[index] }
+  }
+
+  public func makeIterator() -> Buffer.Iterator {
+    buffer.makeIterator()
+  }
+
+  public func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<Element>) throws -> R) rethrows -> R? {
+    try buffer.withContiguousStorageIfAvailable(body)
+  }
+
+  public func _copyContents(initializing ptr: UnsafeMutableBufferPointer<Element>) -> (Iterator, Int) {
+    buffer._copyContents(initializing: ptr)
   }
 }
 


### PR DESCRIPTION
* Implement `Sequence._copyContent(initializing:)` where needed, so `Array.append(contentsOf:)` is optimized
* In `RawSyntax.syntaxTextBytes`, copy consecutive `SyntaxText` at once, instead of copying for each token text.
* Small optimization in `SyntaxText.forEachLineLength(prefix:body:)`

```
Before:
average: 18.771, relative standard deviation: 0.979%, values: [19.052985, 19.032665, 18.911477, 18.644740, 18.631579, 18.601624, 18.566964, 18.623408, 18.683928, 18.957693]

After:
average: 9.473, relative standard deviation: 1.175%, values: [9.469722, 9.550222, 9.545583, 9.646544, 9.579049, 9.553190, 9.342481, 9.383785, 9.340003, 9.324244]
```