### PR TITLE
Add a string-based initializer for `ExperimentalFeatures`.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -21,8 +21,28 @@ public enum ExperimentalFeature: String, CaseIterable {
   case coroutineAccessors
   case valueGenerics
 
-  /// The name of the feature, which is used in the doc comment.
+  /// The name of the feature as it is written in the compiler's `Features.def` file.
   public var featureName: String {
+    switch self {
+    case .referenceBindings:
+      return "ReferenceBindings"
+    case .thenStatements:
+      return "ThenStatements"
+    case .doExpressions:
+      return "DoExpressions"
+    case .nonescapableTypes:
+      return "NonescapableTypes"
+    case .trailingComma:
+      return "TrailingComma"
+    case .coroutineAccessors:
+      return "CoroutineAccessors"
+    case .valueGenerics:
+      return "ValueGenerics"
+    }
+  }
+
+  /// A brief description of the feature that is used in the doc comment.
+  public var documentationDescription: String {
     switch self {
     case .referenceBindings:
       return "reference bindings"
@@ -31,13 +51,13 @@ public enum ExperimentalFeature: String, CaseIterable {
     case .doExpressions:
       return "'do' expressions"
     case .nonescapableTypes:
-      return "NonEscableTypes"
+      return "non-escapable types"
     case .trailingComma:
-      return "trailing comma"
+      return "trailing commas"
     case .coroutineAccessors:
-      return "CoroutineAccessors"
+      return "coroutine accessors"
     case .valueGenerics:
-      return "ValueGenerics"
+      return "value generics"
     }
   }
 

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ExperimentalFeaturesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ExperimentalFeaturesFile.swift
@@ -34,10 +34,31 @@ let experimentalFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) 
     for (i, feature) in ExperimentalFeature.allCases.enumerated() {
       DeclSyntax(
         """
-        /// Whether to enable the parsing of \(raw: feature.featureName).
+        /// Whether to enable the parsing of \(raw: feature.documentationDescription).
         public static let \(feature.token) = Self(rawValue: 1 << \(raw: i))
         """
       )
+    }
+
+    try! InitializerDeclSyntax(
+      """
+      /// Creates a new value representing the experimental feature with the
+      /// given name, or returns nil if the name is not recognized.
+      public init?(name: String)
+      """
+    ) {
+      try! SwitchExprSyntax("switch name") {
+        SwitchCaseListSyntax {
+          for feature in ExperimentalFeature.allCases {
+            SwitchCaseSyntax(#"case "\#(raw: feature.featureName)":"#) {
+              ExprSyntax("self = .\(feature.token)")
+            }
+          }
+          SwitchCaseSyntax("default:") {
+            StmtSyntax("return nil")
+          }
+        }
+      }
     }
   }
 }

--- a/Release Notes/601.md
+++ b/Release Notes/601.md
@@ -39,6 +39,10 @@
   - Description: This method indents a node’s contents using a provided piece of `Trivia`, optionally including the first line.
   - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2843
 
+- `Parser.ExperimentalFeatures` has a new `init?(name: String)` initializer.
+  - Description: This initializer returns the `Parser.ExperimentalFeatures` value that matches the experimental parser feature with the given name. The name must be spelled the same way as it is when passed to the compiler using the `-enable-experimental-feature` flag.
+  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2895
+
 ## API Behavior Changes
 
 - `SyntaxProtocol.trimmed` detaches the node

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -33,15 +33,38 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of 'do' expressions.
   public static let doExpressions = Self (rawValue: 1 << 2)
 
-  /// Whether to enable the parsing of NonEscableTypes.
+  /// Whether to enable the parsing of non-escapable types.
   public static let nonescapableTypes = Self (rawValue: 1 << 3)
 
-  /// Whether to enable the parsing of trailing comma.
+  /// Whether to enable the parsing of trailing commas.
   public static let trailingComma = Self (rawValue: 1 << 4)
 
-  /// Whether to enable the parsing of CoroutineAccessors.
+  /// Whether to enable the parsing of coroutine accessors.
   public static let coroutineAccessors = Self (rawValue: 1 << 5)
 
-  /// Whether to enable the parsing of ValueGenerics.
+  /// Whether to enable the parsing of value generics.
   public static let valueGenerics = Self (rawValue: 1 << 6)
+
+  /// Creates a new value representing the experimental feature with the
+  /// given name, or returns nil if the name is not recognized.
+  public init?(name: String) {
+    switch name {
+    case "ReferenceBindings":
+      self = .referenceBindings
+    case "ThenStatements":
+      self = .thenStatements
+    case "DoExpressions":
+      self = .doExpressions
+    case "NonescapableTypes":
+      self = .nonescapableTypes
+    case "TrailingComma":
+      self = .trailingComma
+    case "CoroutineAccessors":
+      self = .coroutineAccessors
+    case "ValueGenerics":
+      self = .valueGenerics
+    default:
+      return nil
+    }
+  }
 }


### PR DESCRIPTION
Tools (like swift-format) can use this to let users enable experimental features in the parser via interfaces like the command line, without having to handle the translation from string to option set themselves.