### PR TITLE
Fix a stack overflow when using `canRecoveryTo` with too many open delimiters

### DIFF
--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -125,7 +125,6 @@ class ParserTests: ParserTestCase {
   /// Swift compiler. This requires the Swift compiler to have been checked
   /// out into the "swift" directory alongside swift-syntax.
   func testSwiftValidationTestsuite() throws {
-    try XCTSkipIf(true, "Crashing with signal 10 in CI")
     try XCTSkipIf(longTestsDisabled)
     let testDir =
       packageDir


### PR DESCRIPTION
`canRecoverTo` calls itself recursively if it finds a nested opening token, eg. when calling `canRecoverTo` on `{{{`. To avoid stack overflowing, limit the number of nested `canRecoverTo` calls we make. Since returning a recovery handle from this function only improves error recovery but is not necessary for correctness, bailing from recovery is safe.