### PR TITLE
[6.1] Fix build warnings in the `Examples` package

### DIFF
--- a/Examples/Sources/MacroExamples/Implementation/ComplexMacros/DictionaryIndirectionMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/ComplexMacros/DictionaryIndirectionMacro.swift
@@ -19,6 +19,7 @@ extension DictionaryStorageMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     return ["\n  var _storage: [String: Any] = [:]"]

--- a/Examples/Sources/MacroExamples/Implementation/ComplexMacros/ObservableMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/ComplexMacros/ObservableMacro.swift
@@ -35,6 +35,7 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {

--- a/Examples/Sources/MacroExamples/Implementation/ComplexMacros/OptionSetMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/ComplexMacros/OptionSetMacro.swift
@@ -177,6 +177,7 @@ extension OptionSetMacro: MemberMacro {
   public static func expansion(
     of attribute: AttributeSyntax,
     providingMembersOf decl: some DeclGroupSyntax,
+    conformingTo: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     // Decode the expansion arguments.

--- a/Examples/Sources/MacroExamples/Implementation/Member/CaseDetectionMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Member/CaseDetectionMacro.swift
@@ -17,6 +17,7 @@ public enum CaseDetectionMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     declaration.memberBlock.members

--- a/Examples/Sources/MacroExamples/Implementation/Member/CustomCodable.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Member/CustomCodable.swift
@@ -17,6 +17,7 @@ public enum CustomCodable: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     let memberList = declaration.memberBlock.members

--- a/Examples/Sources/MacroExamples/Implementation/Member/MetaEnumMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Member/MetaEnumMacro.swift
@@ -82,6 +82,7 @@ extension MetaEnumMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     let macro = try MetaEnumMacro(node: node, declaration: declaration, context: context)

--- a/Examples/Sources/MacroExamples/Implementation/Member/NewTypeMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Member/NewTypeMacro.swift
@@ -20,6 +20,7 @@ extension NewTypeMacro: MemberMacro {
   public static func expansion<Declaration, Context>(
     of node: AttributeSyntax,
     providingMembersOf declaration: Declaration,
+    conformingTo: [TypeSyntax],
     in context: Context
   ) throws -> [DeclSyntax] where Declaration: DeclGroupSyntax, Context: MacroExpansionContext {
     do {


### PR DESCRIPTION
- **Explanation**: The `Examples` package had compiler warnings and we require that there are no warnings in swift-syntax so we can tag a (pre)release. Fix those warnings.
- **Scope**: Only example code
- **Risk**: None, examples don’t get build as part of the toolchain
- **Testing**: Verified that it builds without warnings with this code.
- **Issue**: n/a
- **Reviewer**:   @bnbarham 