### PR TITLE
[Compat] Add GenericArgumentSyntax comatibility initializer

### DIFF
--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -326,6 +326,30 @@ extension EffectSpecifiersSyntax {
   }
 }
 
+extension GenericArgumentSyntax {
+  @_disfavoredOverload
+  @available(*, deprecated, message: "use GenericArgumentSyntax.Argument for 'argument'")
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeArgument: UnexpectedNodesSyntax? = nil,
+    argument: some TypeSyntaxProtocol,
+    _ unexpectedBetweenArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil,
+    trailingComma: TokenSyntax? = nil,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeArgument,
+      argument: .type(TypeSyntax(argument)),
+      unexpectedBetweenArgumentAndTrailingComma,
+      trailingComma: trailingComma,
+      unexpectedAfterTrailingComma,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 extension FunctionEffectSpecifiersSyntax {
   @_disfavoredOverload
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")


### PR DESCRIPTION
https://github.com/swiftlang/swift-syntax/pull/2859 changed the `argument` property to `some TypeSyntaxProtocol` to `GenericArgumentSyntax.Argument`. Add back the old initializer