### PR TITLE
[6.1][Compat] Add GenericArgumentSyntax compatibility initializer

### DIFF
--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -326,6 +326,30 @@ extension EffectSpecifiersSyntax {
   }
 }
 
+extension GenericArgumentSyntax {
+  @_disfavoredOverload
+  @available(*, deprecated, message: "use GenericArgumentSyntax.Argument for 'argument'")
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeArgument: UnexpectedNodesSyntax? = nil,
+    argument: some TypeSyntaxProtocol,
+    _ unexpectedBetweenArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil,
+    trailingComma: TokenSyntax? = nil,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeArgument,
+      argument: .type(TypeSyntax(argument)),
+      unexpectedBetweenArgumentAndTrailingComma,
+      trailingComma: trailingComma,
+      unexpectedAfterTrailingComma,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 extension FunctionEffectSpecifiersSyntax {
   @_disfavoredOverload
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")


### PR DESCRIPTION
Cherry-pick #2920 into release/6.1

* **Explanation**: https://github.com/swiftlang/swift-syntax/pull/2859 changed the `argument` parameter from `some TypeSyntaxProtocol` to `GenericArgumentSyntax.Argument`. Add back the old initializer to keep the source compatibility.
* **Scope**: Syntax node initialization
* **Risk**: Low. Just adding a "disfavored" initializer overload
* **Testing**: Passes current test suite
* **Issues**: rdar://141562966
* **Reviewer**: TBA