### PR TITLE
Improve documentation comments of some commonly used types

### DIFF
--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -454,6 +454,28 @@ extension Syntax {
   }
 }
 
+/// A type-erased expression node in the Swift syntax tree.
+///
+/// This type provides a common API for working with any kind of Swift expression. It can represent various expression types like:
+/// - Function calls (`print("Hello")`)
+/// - Literals (`42`, `true`, `"text"`)
+/// - Member access (`object.property`)
+/// - Operators (`a + b`)
+/// - And many more
+///
+/// Example converting a specific expression type to ExprSyntax:
+/// ```swift
+/// let specificExpr = StringLiteralExprSyntax(content: "Hello")
+/// let genericExpr = ExprSyntax(specificExpr)
+/// ```
+///
+/// Example checking and converting back to a specific type:
+/// ```swift
+/// if let stringLiteral = expr.as(StringLiteralExprSyntax.self) {
+///   // Work with the specific string literal expression
+/// }
+/// ```
+///
 /// ### Subtypes
 /// 
 /// - ``ArrayExprSyntax``
@@ -509,7 +531,10 @@ extension Syntax {
 public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Create a ``ExprSyntax`` node from a specialized syntax node.
+  /// Creates a type-erased expression from a specialized expression syntax node.
+  ///
+  /// - Parameters:
+  ///   - syntax: The specialized expression node to convert to a generic ExprSyntax.
   public init(_ syntax: __shared some ExprSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
@@ -517,7 +542,10 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self = Syntax(syntax).cast(Self.self)
   }
 
-  /// Create a ``ExprSyntax`` node from a specialized optional syntax node.
+  /// Creates an optional type-erased expression from an optional specialized expression syntax node.
+  ///
+  /// - Parameters:
+  ///   - syntax: The optional specialized expression node to convert to a generic ExprSyntax.
   public init?(_ syntax: __shared (some ExprSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
@@ -525,6 +553,10 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self.init(syntax)
   }
 
+  /// Creates a type-erased expression from an expression protocol type.
+  ///
+  /// - Parameters:
+  ///   - syntax: The expression protocol type to convert to a generic ExprSyntax.
   public init(fromProtocol syntax: __shared ExprSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
@@ -532,7 +564,10 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self = Syntax(syntax).cast(Self.self)
   }
 
-  /// Create a ``ExprSyntax`` node from a specialized optional syntax node.
+  /// Creates an optional type-erased expression from an optional expression protocol type.
+  ///
+  /// - Parameters:
+  ///   - syntax: The optional expression protocol type to convert to a generic ExprSyntax.
   public init?(fromProtocol syntax: __shared ExprSyntaxProtocol?) {
     guard let syntax = syntax else {
       return nil
@@ -540,6 +575,12 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
 
+  /// Creates a type-erased expression from any syntax node that represents an expression.
+  ///
+  /// This initializer succeeds only for syntax nodes that represent valid Swift expressions.
+  ///
+  /// - Parameters:
+  ///   - node: The syntax node to convert. Must be one of the supported expression kinds.
   public init?(_ node: __shared some SyntaxProtocol) {
     switch node.raw.kind {
     case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, ._canImportExpr, ._canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .declReferenceExpr, .dictionaryExpr, .discardAssignmentExpr, .doExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .simpleStringLiteralExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -855,12 +855,42 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.keyPathComponentList
 }
 
+/// A list of labeled expressions used in function calls, macro expansions, and other contexts where arguments can have labels.
+///
+/// This collection represents a list of expressions that may have labels, such as function call arguments or macro parameters.
+///
+/// Example of creating a list of labeled arguments:
+/// ```swift
+/// let arguments = LabeledExprListSyntax {
+///   LabeledExprSyntax(
+///     label: .identifier("localized"),
+///     colon: .colonToken(),
+///     expression: stringLiteral
+///   )
+///   LabeledExprSyntax(
+///     label: .identifier("defaultValue"),
+///     colon: .colonToken(),
+///     expression: defaultValueLiteral
+///   )
+/// }
+/// ```
+///
+/// Example of creating a function call with labeled arguments:
+/// ```swift
+/// let functionCall = FunctionCallExprSyntax(
+///   calledExpression: ExprSyntax(name),
+///   leftParen: .leftParenToken(),
+///   arguments: arguments,
+///   rightParen: .rightParenToken()
+/// )
+/// ```
+///
 /// ### Children
-/// 
+///
 /// ``LabeledExprSyntax`` `*`
 ///
 /// ### Contained in
-/// 
+///
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
 ///  - ``ExpressionSegmentSyntax``.``ExpressionSegmentSyntax/expressions``
 ///  - ``FunctionCallExprSyntax``.``FunctionCallExprSyntax/arguments``
@@ -874,6 +904,21 @@ public struct LabeledExprListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
+  /// Creates a list of labeled expressions from a syntax node.
+  ///
+  /// Example:
+  /// ```swift
+  /// let arguments = LabeledExprListSyntax {
+  ///   LabeledExprSyntax(
+  ///     label: .identifier("name"),
+  ///     colon: .colonToken(),
+  ///     expression: nameExpr
+  ///   )
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - node: The syntax node to create the list from. Must be of kind `.labeledExprList`.
   public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .labeledExprList else {
       return nil

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -605,13 +605,35 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 
 // MARK: - DeclReferenceExprSyntax
 
+/// An expression that refers to a declaration by name, such as a reference to a function, type, or variable.
+///
+/// This type represents references to declarations in Swift code, commonly used when building syntax for:
+/// - Function and type references
+/// - Variable and property references
+/// - Special declarations like `self`, `Self`, and `init`
+///
+/// Example creating a simple reference to a type:
+/// ```swift
+/// let stringReference = DeclReferenceExprSyntax(baseName: "String")
+/// ```
+///
+/// Example using a declaration reference in a function call:
+/// ```swift
+/// let functionCall = FunctionCallExprSyntax(
+///   calledExpression: DeclReferenceExprSyntax(baseName: "print"),
+///   leftParen: .leftParenToken(),
+///   arguments: arguments,
+///   rightParen: .rightParenToken()
+/// )
+/// ```
+///
 /// ### Children
-/// 
+///
 ///  - `baseName`: (`<identifier>` | `self` | `Self` | `init` | `deinit` | `subscript` | `<dollarIdentifier>` | `<binaryOperator>` | `<integerLiteral>`)
 ///  - `argumentNames`: ``DeclNameArgumentsSyntax``?
 ///
 /// ### Contained in
-/// 
+///
 ///  - ``DynamicReplacementAttributeArgumentsSyntax``.``DynamicReplacementAttributeArgumentsSyntax/declName``
 ///  - ``ImplementsAttributeArgumentsSyntax``.``ImplementsAttributeArgumentsSyntax/declName``
 ///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declName``
@@ -620,6 +642,13 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
+  /// Internal initializer used by swift-syntax to create declaration references from existing syntax nodes.
+  ///
+  /// This initializer is not intended for direct use when creating declaration references programmatically.
+  /// Instead, use the main initializer that accepts individual components.
+  ///
+  /// - Parameters:
+  ///   - node: An existing syntax node to convert. Must be of kind `.declReferenceExpr`.
   public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .declReferenceExpr else {
       return nil
@@ -627,9 +656,23 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     self._syntaxNode = node._syntaxNode
   }
 
+  /// Creates a new declaration reference with the given base name and optional components.
+  ///
+  /// Example creating a reference to a type:
+  /// ```swift
+  /// let reference = DeclReferenceExprSyntax(
+  ///   baseName: .identifier("String")
+  /// )
+  /// ```
+  ///
   /// - Parameters:
-  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node's first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - unexpectedBeforeBaseName: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - baseName: The name of the declaration being referenced.
+  ///   - unexpectedBetweenBaseNameAndArgumentNames: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - argumentNames: Optional argument labels when referring to specific function overloads.
+  ///   - unexpectedAfterArgumentNames: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node's last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBaseName: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -3039,8 +3039,50 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
 
 // MARK: - FunctionCallExprSyntax
 
+/// A function or method call expression.
+///
+/// This type represents function calls in Swift syntax, with support for labeled arguments and trailing closures. Function calls have three main parts:
+/// - The called expression (like a function name or method reference)
+/// - Parenthesized arguments (which may be labeled)
+/// - Optional trailing closures
+///
+/// Example creating a simple function call:
+/// ```swift
+/// let call = FunctionCallExprSyntax(
+///   calledExpression: DeclReferenceExprSyntax(baseName: "print"),
+///   leftParen: .leftParenToken(),
+///   arguments: LabeledExprListSyntax([
+///     LabeledExprSyntax(
+///       expression: StringLiteralExprSyntax(content: "Hello")
+///     )
+///   ]),
+///   rightParen: .rightParenToken()
+/// )
+/// ```
+///
+/// Example creating a function call with labeled arguments:
+/// ```swift
+/// let call = FunctionCallExprSyntax(
+///   calledExpression: DeclReferenceExprSyntax(baseName: "String"),
+///   leftParen: .leftParenToken(),
+///   arguments: LabeledExprListSyntax {
+///     LabeledExprSyntax(
+///       label: .identifier("localized"),
+///       colon: .colonToken(),
+///       expression: keyExpr
+///     )
+///     LabeledExprSyntax(
+///       label: .identifier("defaultValue"),
+///       colon: .colonToken(),
+///       expression: defaultExpr
+///     )
+///   },
+///   rightParen: .rightParenToken()
+/// )
+/// ```
+///
 /// ### Children
-/// 
+///
 ///  - `calledExpression`: ``ExprSyntax``
 ///  - `leftParen`: `(`?
 ///  - `arguments`: ``LabeledExprListSyntax``
@@ -3050,6 +3092,13 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
+  /// Internal initializer used by swift-syntax to create function calls from existing syntax nodes.
+  ///
+  /// This initializer is not intended for direct use when creating function calls programmatically.
+  /// Instead, use the main initializer that accepts individual components.
+  ///
+  /// - Parameters:
+  ///   - node: An existing syntax node to convert. Must be of kind `.functionCallExpr`.
   public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .functionCallExpr else {
       return nil
@@ -3057,9 +3106,36 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     self._syntaxNode = node._syntaxNode
   }
 
+  /// Creates a new function call expression with the given components.
+  ///
+  /// Example:
+  /// ```swift
+  /// let call = FunctionCallExprSyntax(
+  ///   calledExpression: DeclReferenceExprSyntax(baseName: "print"),
+  ///   leftParen: .leftParenToken(),
+  ///   arguments: LabeledExprListSyntax([
+  ///     LabeledExprSyntax(expression: valueExpr)
+  ///   ]),
+  ///   rightParen: .rightParenToken()
+  /// )
+  /// ```
+  ///
   /// - Parameters:
-  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node's first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - unexpectedBeforeCalledExpression: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - calledExpression: The expression being called (usually a reference to a function or method).
+  ///   - unexpectedBetweenCalledExpressionAndLeftParen: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - leftParen: The opening parenthesis token, created using `.leftParenToken()`.
+  ///   - unexpectedBetweenLeftParenAndArguments: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - arguments: The list of arguments to the function.
+  ///   - unexpectedBetweenArgumentsAndRightParen: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - rightParen: The closing parenthesis token, created using `.rightParenToken()`.
+  ///   - unexpectedBetweenRightParenAndTrailingClosure: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - trailingClosure: An optional trailing closure argument.
+  ///   - unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - additionalTrailingClosures: Additional trailing closure arguments.
+  ///   - unexpectedAfterAdditionalTrailingClosures: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node's last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -788,25 +788,59 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable, _
 
 // MARK: - LabeledExprSyntax
 
-/// An expression that is prefixed by a label.
-/// 
-/// For example, labeled expressions occur in
-/// - Function calls, where the label is the parameter label.
-/// - Tuples, where the label is the name of the tuple element.
+/// An expression with an optional label and colon, used in function calls, tuple elements, and macro arguments.
+///
+/// This type represents labeled expressions in Swift syntax, commonly used for:
+/// - Function call arguments with parameter labels
+/// - Tuple elements with names
+/// - Macro arguments with labels
+///
+/// Example creating a labeled expression for a function call:
+/// ```swift
+/// let labeledArg = LabeledExprSyntax(
+///   label: .identifier("localized"),
+///   colon: .colonToken(),
+///   expression: stringLiteral
+/// )
+/// ```
+///
+/// Example creating multiple labeled expressions in a list:
+/// ```swift
+/// let arguments = LabeledExprListSyntax {
+///   LabeledExprSyntax(
+///     label: .identifier("name"),
+///     colon: .colonToken(),
+///     expression: nameExpr
+///   )
+///   LabeledExprSyntax(
+///     label: .identifier("value"),
+///     colon: .colonToken(),
+///     expression: valueExpr,
+///     trailingComma: .commaToken()
+///   )
+/// }
+/// ```
 ///
 /// ### Children
-/// 
+///
 ///  - `label`: (`<identifier>` | `_`)?
 ///  - `colon`: `:`?
 ///  - `expression`: ``ExprSyntax``
 ///  - `trailingComma`: `,`?
 ///
 /// ### Contained in
-/// 
+///
 ///  - ``LabeledExprListSyntax``
 public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
+  /// Internal initializer used by swift-syntax to create labeled expressions from existing syntax nodes.
+  ///
+  /// This initializer is not intended for direct use when creating labeled expressions programmatically.
+  /// Instead, use the main initializer that accepts individual components.
+  ///
+  /// - Parameters:
+  ///   - node: An existing syntax node to convert. Must be of kind `.labeledExpr`.
   public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .labeledExpr else {
       return nil
@@ -814,9 +848,29 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     self._syntaxNode = node._syntaxNode
   }
 
+  /// Creates a new labeled expression with the given components.
+  ///
+  /// Example creating a labeled string literal argument:
+  /// ```swift
+  /// let argument = LabeledExprSyntax(
+  ///   label: .identifier("defaultValue"),
+  ///   colon: .colonToken(),
+  ///   expression: stringLiteral
+  /// )
+  /// ```
+  ///
   /// - Parameters:
-  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node's first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - unexpectedBeforeLabel: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - label: The optional label for this expression, created using `.identifier()` for named labels or `._` for unnamed ones.
+  ///   - unexpectedBetweenLabelAndColon: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - colon: The colon token that follows the label, created using `.colonToken()`.
+  ///   - unexpectedBetweenColonAndExpression: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - expression: The expression being labeled.
+  ///   - unexpectedBetweenExpressionAndTrailingComma: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - trailingComma: An optional trailing comma, useful when this expression is part of a list.
+  ///   - unexpectedAfterTrailingComma: Used internally by swift-syntax to handle malformed source code. When creating expressions programmatically, you should pass nil.
+  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node's last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -2277,16 +2277,31 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 
 // MARK: - StringSegmentSyntax
 
-/// A literal segment inside a string segment.
-/// 
-/// - SeeAlso: ``ExpressionSegmentSyntax``
+/// A string literal segment that represents plain text content within a string literal expression.
+///
+/// Used to construct string literals programmatically, especially in macros that need to generate or manipulate string content. For example, in a string literal `"Hello \(name)"`, the `"Hello "` part would be represented by a `StringSegmentSyntax`.
+///
+/// Creating a string segment requires special attention to use `.stringSegment()` for the content token to ensure proper formatting. For example, when creating a simple string segment:
+/// ```swift
+/// let segment = StringSegmentSyntax(content: .stringSegment("Hello World"))
+/// ```
+///
+/// This type is commonly used in macros for:
+/// - Creating and validating string literals at compile time (e.g., URL validation)
+/// - Building string-based error messages and diagnostics
+/// - Generating code that contains string literals
+/// - Constructing string interpolations
+///
+/// Important: When creating a string segment from a string literal, always use `.stringSegment(string)` rather than just passing the string directly. Using the raw string will create an identifier token instead of a string segment token, which can lead to formatting issues.
+///
+/// - SeeAlso: ``ExpressionSegmentSyntax`` for segments containing string interpolations
 ///
 /// ### Children
-/// 
+///
 ///  - `content`: `<stringSegment>`
 ///
 /// ### Contained in
-/// 
+///
 ///  - ``SimpleStringLiteralSegmentListSyntax``
 ///  - ``StringLiteralSegmentListSyntax``
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
@@ -2299,9 +2314,23 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     self._syntaxNode = node._syntaxNode
   }
 
+  /// Creates a new string segment with the given content and optional trivia.
+  ///
+  /// Example:
+  /// ```swift
+  /// let stringLiteral = StringLiteralExprSyntax(
+  ///   openingQuote: .stringQuoteToken(),
+  ///   segments: StringLiteralSegmentListSyntax([.stringSegment(.stringSegment("Some Text"))]),
+  ///   closingQuote: .stringQuoteToken()
+  /// )
+  /// ```
+  ///
   /// - Parameters:
-  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node's first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - unexpectedBeforeContent: Used internally by swift-syntax to handle malformed source code. When creating string segments programmatically, you should pass nil.
+  ///   - content: The string content token, created using `.stringSegment("your string")`
+  ///   - unexpectedAfterContent: Used internally by swift-syntax to handle malformed source code. When creating string segments programmatically, you should pass nil.
+  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node's last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeContent: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -2307,6 +2307,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
+  /// Internal initializer used by swift-syntax to create string segments from existing syntax nodes.
+  ///
+  /// This initializer is not intended for direct use when creating string segments programmatically.
+  /// Instead, use the main initializer that accepts individual components.
+  ///
+  /// - Parameters:
+  ///   - node: An existing syntax node to convert. Must be of kind `.stringSegment`.
   public init?(_ node: __shared some SyntaxProtocol) {
     guard node.raw.kind == .stringSegment else {
       return nil


### PR DESCRIPTION
This resolves https://github.com/swiftlang/swift-syntax/issues/2906 for an initial set of types. To keep the PR relatively small, I have focused on improving docs of those types that I have personally needed & used for my first macro (which I haven't released yet, as it's not finished).

@ahoppen I didn't quite understand if your "I would" [in this comment](https://github.com/swiftlang/swift-syntax/issues/2906#issuecomment-2524190993) literally meant that it's something you would do after my PR is merged, of if it's something you suggested me to do.

In any case, I found it very confusing that all the types I searched for were inside a `generated` folder and the file names were suffixed by alphabetic characters like `QRS` in `SyntaxNodesQRS.swift`. I have a feeling that I added the documentation comments to the wrong place. But I couldn't find any mentions of `StringSegmentSyntax`, for example inside the `CodeGeneration` folder. In that particular case, I did find the text of the comment "A literal segment inside a string segment." inside the `ExprNodes.swift` file, but then again where to add the documentation comments for the initializer, which are very important when discovering APIs via code completion in Xcode? 🤔

I think I need some guidance here to adjust this PR properly. Thank you in advance for your patience!