### PR TITLE
[Syntax] Add `init(unsafeCasting: Syntax)` to concrete node types

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -50,6 +50,15 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
       )
 
+      DeclSyntax(
+        """
+        @_transparent
+        init(unsafeCasting node: Syntax) {
+          self._syntaxNode = node
+        }
+        """
+      )
+
       DeclSyntax("public static let syntaxKind = SyntaxKind.\(node.memberCallName)")
     }
   }

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -52,6 +52,15 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
           """
         )
 
+        DeclSyntax(
+          """
+          @_transparent
+          init(unsafeCasting node: Syntax) {
+            self._syntaxNode = node
+          }
+          """
+        )
+
         let initSignature = InitSignature(node)
 
         try! InitializerDeclSyntax(

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -215,7 +215,7 @@ public struct RawSyntax: Sendable {
   }
 
   var rawData: RawSyntaxData {
-    pointer.pointee
+    @_transparent unsafeAddress { pointer.pointer }
   }
 
   internal var arenaReference: SyntaxArenaRef {

--- a/Sources/SwiftSyntax/SyntaxArenaAllocatedBuffer.swift
+++ b/Sources/SwiftSyntax/SyntaxArenaAllocatedBuffer.swift
@@ -19,7 +19,7 @@
 /// conformance.
 @_spi(RawSyntax)
 public struct SyntaxArenaAllocatedPointer<Element: Sendable>: @unchecked Sendable {
-  private let pointer: UnsafePointer<Element>
+  let pointer: UnsafePointer<Element>
 
   /// Create a pointer from an `UnsafePointer` that was allocated inside a
   /// ``SyntaxArena``.
@@ -32,7 +32,7 @@ public struct SyntaxArenaAllocatedPointer<Element: Sendable>: @unchecked Sendabl
   }
 
   var pointee: Element {
-    return pointer.pointee
+    @_transparent unsafeAddress { pointer }
   }
 
   var unsafeRawPointer: UnsafeRawPointer {

--- a/Sources/SwiftSyntax/TokenSyntax.swift
+++ b/Sources/SwiftSyntax/TokenSyntax.swift
@@ -40,6 +40,11 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(node)
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// Construct a new token with the given `kind`, `leadingTrivia`,
   /// `trailingTrivia` and `presence`.
   public init(

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -31,6 +31,11 @@ public struct AccessorDeclListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.accessorDeclList
 }
 
@@ -51,6 +56,11 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.arrayElementList
@@ -193,6 +203,11 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.attributeList
 }
 
@@ -217,6 +232,11 @@ public struct AvailabilityArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.availabilityArgumentList
 }
 
@@ -237,6 +257,11 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.catchClauseList
@@ -261,6 +286,11 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.catchItemList
 }
 
@@ -283,6 +313,11 @@ public struct ClosureCaptureListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.closureCaptureList
 }
 
@@ -303,6 +338,11 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.closureParameterList
@@ -340,6 +380,11 @@ public struct ClosureShorthandParameterListSyntax: SyntaxCollection, SyntaxHasha
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.closureShorthandParameterList
 }
 
@@ -367,6 +412,11 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.codeBlockItemList
 }
 
@@ -387,6 +437,11 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.compositionTypeElementList
@@ -411,6 +466,11 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.conditionElementList
@@ -457,6 +517,11 @@ public struct DeclModifierListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.declModifierList
 }
 
@@ -477,6 +542,11 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.declNameArgumentList
@@ -501,6 +571,11 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.designatedTypeList
 }
 
@@ -523,6 +598,11 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.dictionaryElementList
 }
 
@@ -543,6 +623,11 @@ public struct DifferentiabilityArgumentListSyntax: SyntaxCollection, SyntaxHasha
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.differentiabilityArgumentList
@@ -569,6 +654,11 @@ public struct DocumentationAttributeArgumentListSyntax: SyntaxCollection, Syntax
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.documentationAttributeArgumentList
 }
 
@@ -591,6 +681,11 @@ public struct EffectsAttributeArgumentListSyntax: SyntaxCollection, SyntaxHashab
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.effectsAttributeArgumentList
@@ -617,6 +712,11 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.enumCaseElementList
 }
 
@@ -637,6 +737,11 @@ public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.enumCaseParameterList
@@ -661,6 +766,11 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.exprList
@@ -696,6 +806,11 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.functionParameterList
 }
 
@@ -716,6 +831,11 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.genericArgumentList
@@ -740,6 +860,11 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.genericParameterList
 }
 
@@ -760,6 +885,11 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.genericRequirementList
@@ -784,6 +914,11 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.ifConfigClauseList
 }
 
@@ -804,6 +939,11 @@ public struct ImportPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.importPathComponentList
@@ -828,6 +968,11 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.inheritedTypeList
 }
 
@@ -850,6 +995,11 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.keyPathComponentList
@@ -881,6 +1031,11 @@ public struct LabeledExprListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.labeledExprList
 }
 
@@ -904,6 +1059,11 @@ public struct LifetimeSpecifierArgumentListSyntax: SyntaxCollection, SyntaxHasha
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.lifetimeSpecifierArgumentList
 }
 
@@ -925,6 +1085,11 @@ public struct MemberBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.memberBlockItemList
@@ -952,6 +1117,11 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.multipleTrailingClosureElementList
 }
 
@@ -972,6 +1142,11 @@ public struct ObjCSelectorPieceListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.objCSelectorPieceList
@@ -996,6 +1171,11 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.patternBindingList
 }
 
@@ -1017,6 +1197,11 @@ public struct PlatformVersionItemListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.platformVersionItemList
@@ -1153,6 +1338,11 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.precedenceGroupAttributeList
 }
 
@@ -1173,6 +1363,11 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.precedenceGroupNameList
@@ -1197,6 +1392,11 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.primaryAssociatedTypeList
 }
 
@@ -1219,6 +1419,11 @@ public struct SimpleStringLiteralSegmentListSyntax: SyntaxCollection, SyntaxHash
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.simpleStringLiteralSegmentList
@@ -1394,6 +1599,11 @@ public struct SpecializeAttributeArgumentListSyntax: SyntaxCollection, SyntaxHas
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.specializeAttributeArgumentList
 }
 
@@ -1500,6 +1710,11 @@ public struct StringLiteralSegmentListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.stringLiteralSegmentList
 }
 
@@ -1520,6 +1735,11 @@ public struct SwitchCaseItemListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.switchCaseItemList
@@ -1623,6 +1843,11 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.switchCaseList
 }
 
@@ -1647,6 +1872,11 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.tuplePatternElementList
 }
 
@@ -1668,6 +1898,11 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.tupleTypeElementList
@@ -1792,6 +2027,11 @@ public struct TypeSpecifierListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.typeSpecifierList
 }
 
@@ -1810,6 +2050,11 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.unexpectedNodes
@@ -1834,6 +2079,11 @@ public struct VersionComponentListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   public static let syntaxKind = SyntaxKind.versionComponentList
 }
 
@@ -1854,6 +2104,11 @@ public struct YieldedExpressionListSyntax: SyntaxCollection, SyntaxHashable {
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   public static let syntaxKind = SyntaxKind.yieldedExpressionList

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -47,8 +47,7 @@ open class SyntaxRewriter {
 
   /// Rewrite `node`, keeping its parent unless `detach` is `true`.
   public func rewrite(_ node: some SyntaxProtocol, detach: Bool = false) -> Syntax {
-    var rewritten = Syntax(node)
-    self.dispatchVisit(&rewritten)
+    let rewritten = self.visitImpl(Syntax(node))
     if detach {
       return rewritten
     }
@@ -58,11 +57,16 @@ open class SyntaxRewriter {
     }
   }
 
-  /// Visit a ``TokenSyntax``.
-  ///   - Parameter token: the token that is being visited
+  /// Visit any Syntax node.
+  ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  open func visit(_ token: TokenSyntax) -> TokenSyntax {
-    return token
+  @available(*, deprecated, renamed: "rewrite(_:detach:)")
+  public func visit(_ node: Syntax) -> Syntax {
+    return visitImpl(node)
+  }
+
+  public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
+    visitImpl(Syntax(node)).cast(T.self)
   }
 
   /// The function called before visiting the node and its descendants.
@@ -90,20 +94,11 @@ open class SyntaxRewriter {
   open func visitPost(_ node: Syntax) {
   }
 
-  /// Visit any Syntax node.
-  ///   - Parameter node: the node that is being visited
+  /// Visit a ``TokenSyntax``.
+  ///   - Parameter token: the token that is being visited
   ///   - Returns: the rewritten node
-  @available(*, deprecated, renamed: "rewrite(_:detach:)")
-  public func visit(_ node: Syntax) -> Syntax {
-    var rewritten = node
-    dispatchVisit(&rewritten)
-    return rewritten
-  }
-
-  public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
-    var rewritten = Syntax(node)
-    dispatchVisit(&rewritten)
-    return rewritten.cast(T.self)
+  open func visit(_ token: TokenSyntax) -> TokenSyntax {
+    return token
   }
 
   /// Visit a `ABIAttributeArgumentsSyntax`.
@@ -113,595 +108,595 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: ABIAttributeArgumentsSyntax) -> ABIAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(ABIAttributeArgumentsSyntax.self)
+    return ABIAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AccessorBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorBlockSyntax) -> AccessorBlockSyntax {
-    return visitChildren(node._syntaxNode).cast(AccessorBlockSyntax.self)
+    return AccessorBlockSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AccessorDeclListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorDeclListSyntax) -> AccessorDeclListSyntax {
-    return visitChildren(node._syntaxNode).cast(AccessorDeclListSyntax.self)
+    return AccessorDeclListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AccessorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(AccessorDeclSyntax.self))
+    return DeclSyntax(AccessorDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``AccessorEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorEffectSpecifiersSyntax) -> AccessorEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode).cast(AccessorEffectSpecifiersSyntax.self)
+    return AccessorEffectSpecifiersSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AccessorParametersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AccessorParametersSyntax) -> AccessorParametersSyntax {
-    return visitChildren(node._syntaxNode).cast(AccessorParametersSyntax.self)
+    return AccessorParametersSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ActorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(ActorDeclSyntax.self))
+    return DeclSyntax(ActorDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ArrayElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayElementListSyntax) -> ArrayElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(ArrayElementListSyntax.self)
+    return ArrayElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ArrayElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayElementSyntax) -> ArrayElementSyntax {
-    return visitChildren(node._syntaxNode).cast(ArrayElementSyntax.self)
+    return ArrayElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ArrayExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(ArrayExprSyntax.self))
+    return ExprSyntax(ArrayExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ArrayTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrayTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(ArrayTypeSyntax.self))
+    return TypeSyntax(ArrayTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ArrowExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ArrowExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(ArrowExprSyntax.self))
+    return ExprSyntax(ArrowExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``AsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(AsExprSyntax.self))
+    return ExprSyntax(AsExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``AssignmentExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AssignmentExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(AssignmentExprSyntax.self))
+    return ExprSyntax(AssignmentExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``AssociatedTypeDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AssociatedTypeDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(AssociatedTypeDeclSyntax.self))
+    return DeclSyntax(AssociatedTypeDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``AttributeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributeListSyntax) -> AttributeListSyntax {
-    return visitChildren(node._syntaxNode).cast(AttributeListSyntax.self)
+    return AttributeListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AttributeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributeSyntax) -> AttributeSyntax {
-    return visitChildren(node._syntaxNode).cast(AttributeSyntax.self)
+    return AttributeSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AttributedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AttributedTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(AttributedTypeSyntax.self))
+    return TypeSyntax(AttributedTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``AvailabilityArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityArgumentListSyntax) -> AvailabilityArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(AvailabilityArgumentListSyntax.self)
+    return AvailabilityArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AvailabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityArgumentSyntax) -> AvailabilityArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(AvailabilityArgumentSyntax.self)
+    return AvailabilityArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AvailabilityConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityConditionSyntax) -> AvailabilityConditionSyntax {
-    return visitChildren(node._syntaxNode).cast(AvailabilityConditionSyntax.self)
+    return AvailabilityConditionSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AvailabilityLabeledArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AvailabilityLabeledArgumentSyntax) -> AvailabilityLabeledArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(AvailabilityLabeledArgumentSyntax.self)
+    return AvailabilityLabeledArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``AwaitExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: AwaitExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(AwaitExprSyntax.self))
+    return ExprSyntax(AwaitExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``BackDeployedAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BackDeployedAttributeArgumentsSyntax) -> BackDeployedAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(BackDeployedAttributeArgumentsSyntax.self)
+    return BackDeployedAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``BinaryOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BinaryOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(BinaryOperatorExprSyntax.self))
+    return ExprSyntax(BinaryOperatorExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``BooleanLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BooleanLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(BooleanLiteralExprSyntax.self))
+    return ExprSyntax(BooleanLiteralExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``BorrowExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BorrowExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(BorrowExprSyntax.self))
+    return ExprSyntax(BorrowExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``BreakStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: BreakStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(BreakStmtSyntax.self))
+    return StmtSyntax(BreakStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a `_CanImportExprSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: _CanImportExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(_CanImportExprSyntax.self))
+    return ExprSyntax(_CanImportExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a `_CanImportVersionInfoSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: _CanImportVersionInfoSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(_CanImportVersionInfoSyntax.self))
+    return ExprSyntax(_CanImportVersionInfoSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``CatchClauseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchClauseListSyntax) -> CatchClauseListSyntax {
-    return visitChildren(node._syntaxNode).cast(CatchClauseListSyntax.self)
+    return CatchClauseListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CatchClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchClauseSyntax) -> CatchClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(CatchClauseSyntax.self)
+    return CatchClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CatchItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchItemListSyntax) -> CatchItemListSyntax {
-    return visitChildren(node._syntaxNode).cast(CatchItemListSyntax.self)
+    return CatchItemListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CatchItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CatchItemSyntax) -> CatchItemSyntax {
-    return visitChildren(node._syntaxNode).cast(CatchItemSyntax.self)
+    return CatchItemSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClassDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(ClassDeclSyntax.self))
+    return DeclSyntax(ClassDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ClassRestrictionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClassRestrictionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(ClassRestrictionTypeSyntax.self))
+    return TypeSyntax(ClassRestrictionTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ClosureCaptureClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureClauseSyntax) -> ClosureCaptureClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureCaptureClauseSyntax.self)
+    return ClosureCaptureClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureCaptureListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureListSyntax) -> ClosureCaptureListSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureCaptureListSyntax.self)
+    return ClosureCaptureListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureCaptureSpecifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureSpecifierSyntax) -> ClosureCaptureSpecifierSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureCaptureSpecifierSyntax.self)
+    return ClosureCaptureSpecifierSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureCaptureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureCaptureSyntax) -> ClosureCaptureSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureCaptureSyntax.self)
+    return ClosureCaptureSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(ClosureExprSyntax.self))
+    return ExprSyntax(ClosureExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ClosureParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterClauseSyntax) -> ClosureParameterClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureParameterClauseSyntax.self)
+    return ClosureParameterClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterListSyntax) -> ClosureParameterListSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureParameterListSyntax.self)
+    return ClosureParameterListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureParameterSyntax) -> ClosureParameterSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureParameterSyntax.self)
+    return ClosureParameterSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureShorthandParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureShorthandParameterListSyntax) -> ClosureShorthandParameterListSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureShorthandParameterListSyntax.self)
+    return ClosureShorthandParameterListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureShorthandParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureShorthandParameterSyntax) -> ClosureShorthandParameterSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureShorthandParameterSyntax.self)
+    return ClosureShorthandParameterSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ClosureSignatureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
-    return visitChildren(node._syntaxNode).cast(ClosureSignatureSyntax.self)
+    return ClosureSignatureSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CodeBlockItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
-    return visitChildren(node._syntaxNode).cast(CodeBlockItemListSyntax.self)
+    return CodeBlockItemListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CodeBlockItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockItemSyntax) -> CodeBlockItemSyntax {
-    return visitChildren(node._syntaxNode).cast(CodeBlockItemSyntax.self)
+    return CodeBlockItemSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CodeBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CodeBlockSyntax) -> CodeBlockSyntax {
-    return visitChildren(node._syntaxNode).cast(CodeBlockSyntax.self)
+    return CodeBlockSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CompositionTypeElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeElementListSyntax) -> CompositionTypeElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(CompositionTypeElementListSyntax.self)
+    return CompositionTypeElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CompositionTypeElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeElementSyntax) -> CompositionTypeElementSyntax {
-    return visitChildren(node._syntaxNode).cast(CompositionTypeElementSyntax.self)
+    return CompositionTypeElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CompositionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CompositionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(CompositionTypeSyntax.self))
+    return TypeSyntax(CompositionTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ConditionElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConditionElementListSyntax) -> ConditionElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(ConditionElementListSyntax.self)
+    return ConditionElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ConditionElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConditionElementSyntax) -> ConditionElementSyntax {
-    return visitChildren(node._syntaxNode).cast(ConditionElementSyntax.self)
+    return ConditionElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ConformanceRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConformanceRequirementSyntax) -> ConformanceRequirementSyntax {
-    return visitChildren(node._syntaxNode).cast(ConformanceRequirementSyntax.self)
+    return ConformanceRequirementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ConsumeExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConsumeExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(ConsumeExprSyntax.self))
+    return ExprSyntax(ConsumeExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ContinueStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ContinueStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(ContinueStmtSyntax.self))
+    return StmtSyntax(ContinueStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ConventionAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConventionAttributeArgumentsSyntax) -> ConventionAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(ConventionAttributeArgumentsSyntax.self)
+    return ConventionAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ConventionWitnessMethodAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(ConventionWitnessMethodAttributeArgumentsSyntax.self)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``CopyExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CopyExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(CopyExprSyntax.self))
+    return ExprSyntax(CopyExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DeclModifierDetailSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierDetailSyntax) -> DeclModifierDetailSyntax {
-    return visitChildren(node._syntaxNode).cast(DeclModifierDetailSyntax.self)
+    return DeclModifierDetailSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DeclModifierListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierListSyntax) -> DeclModifierListSyntax {
-    return visitChildren(node._syntaxNode).cast(DeclModifierListSyntax.self)
+    return DeclModifierListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DeclModifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclModifierSyntax) -> DeclModifierSyntax {
-    return visitChildren(node._syntaxNode).cast(DeclModifierSyntax.self)
+    return DeclModifierSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DeclNameArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentListSyntax) -> DeclNameArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(DeclNameArgumentListSyntax.self)
+    return DeclNameArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DeclNameArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentSyntax) -> DeclNameArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(DeclNameArgumentSyntax.self)
+    return DeclNameArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DeclNameArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclNameArgumentsSyntax) -> DeclNameArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(DeclNameArgumentsSyntax.self)
+    return DeclNameArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DeclReferenceExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(DeclReferenceExprSyntax.self))
+    return ExprSyntax(DeclReferenceExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DeferStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeferStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(DeferStmtSyntax.self))
+    return StmtSyntax(DeferStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DeinitializerDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeinitializerDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(DeinitializerDeclSyntax.self))
+    return DeclSyntax(DeinitializerDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DeinitializerEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DeinitializerEffectSpecifiersSyntax) -> DeinitializerEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode).cast(DeinitializerEffectSpecifiersSyntax.self)
+    return DeinitializerEffectSpecifiersSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DerivativeAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DerivativeAttributeArgumentsSyntax) -> DerivativeAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(DerivativeAttributeArgumentsSyntax.self)
+    return DerivativeAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DesignatedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DesignatedTypeListSyntax) -> DesignatedTypeListSyntax {
-    return visitChildren(node._syntaxNode).cast(DesignatedTypeListSyntax.self)
+    return DesignatedTypeListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DesignatedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DesignatedTypeSyntax) -> DesignatedTypeSyntax {
-    return visitChildren(node._syntaxNode).cast(DesignatedTypeSyntax.self)
+    return DesignatedTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DictionaryElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryElementListSyntax) -> DictionaryElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(DictionaryElementListSyntax.self)
+    return DictionaryElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DictionaryElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryElementSyntax) -> DictionaryElementSyntax {
-    return visitChildren(node._syntaxNode).cast(DictionaryElementSyntax.self)
+    return DictionaryElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DictionaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(DictionaryExprSyntax.self))
+    return ExprSyntax(DictionaryExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DictionaryTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DictionaryTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(DictionaryTypeSyntax.self))
+    return TypeSyntax(DictionaryTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DifferentiabilityArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentListSyntax) -> DifferentiabilityArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(DifferentiabilityArgumentListSyntax.self)
+    return DifferentiabilityArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DifferentiabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentSyntax) -> DifferentiabilityArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(DifferentiabilityArgumentSyntax.self)
+    return DifferentiabilityArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DifferentiabilityArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityArgumentsSyntax) -> DifferentiabilityArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(DifferentiabilityArgumentsSyntax.self)
+    return DifferentiabilityArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DifferentiabilityWithRespectToArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiabilityWithRespectToArgumentSyntax) -> DifferentiabilityWithRespectToArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(DifferentiabilityWithRespectToArgumentSyntax.self)
+    return DifferentiabilityWithRespectToArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DifferentiableAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DifferentiableAttributeArgumentsSyntax) -> DifferentiableAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(DifferentiableAttributeArgumentsSyntax.self)
+    return DifferentiableAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DiscardAssignmentExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DiscardAssignmentExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(DiscardAssignmentExprSyntax.self))
+    return ExprSyntax(DiscardAssignmentExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DiscardStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DiscardStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(DiscardStmtSyntax.self))
+    return StmtSyntax(DiscardStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a `DoExprSyntax`.
@@ -711,532 +706,532 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: DoExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(DoExprSyntax.self))
+    return ExprSyntax(DoExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DoStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DoStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(DoStmtSyntax.self))
+    return StmtSyntax(DoStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``DocumentationAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DocumentationAttributeArgumentListSyntax) -> DocumentationAttributeArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(DocumentationAttributeArgumentListSyntax.self)
+    return DocumentationAttributeArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DocumentationAttributeArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DocumentationAttributeArgumentSyntax) -> DocumentationAttributeArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(DocumentationAttributeArgumentSyntax.self)
+    return DocumentationAttributeArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``DynamicReplacementAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: DynamicReplacementAttributeArgumentsSyntax) -> DynamicReplacementAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(DynamicReplacementAttributeArgumentsSyntax.self)
+    return DynamicReplacementAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``EditorPlaceholderDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EditorPlaceholderDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(EditorPlaceholderDeclSyntax.self))
+    return DeclSyntax(EditorPlaceholderDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``EditorPlaceholderExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EditorPlaceholderExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(EditorPlaceholderExprSyntax.self))
+    return ExprSyntax(EditorPlaceholderExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``EffectsAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EffectsAttributeArgumentListSyntax) -> EffectsAttributeArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(EffectsAttributeArgumentListSyntax.self)
+    return EffectsAttributeArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``EnumCaseDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(EnumCaseDeclSyntax.self))
+    return DeclSyntax(EnumCaseDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``EnumCaseElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseElementListSyntax) -> EnumCaseElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(EnumCaseElementListSyntax.self)
+    return EnumCaseElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``EnumCaseElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseElementSyntax) -> EnumCaseElementSyntax {
-    return visitChildren(node._syntaxNode).cast(EnumCaseElementSyntax.self)
+    return EnumCaseElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``EnumCaseParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterClauseSyntax) -> EnumCaseParameterClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(EnumCaseParameterClauseSyntax.self)
+    return EnumCaseParameterClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``EnumCaseParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterListSyntax) -> EnumCaseParameterListSyntax {
-    return visitChildren(node._syntaxNode).cast(EnumCaseParameterListSyntax.self)
+    return EnumCaseParameterListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``EnumCaseParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumCaseParameterSyntax) -> EnumCaseParameterSyntax {
-    return visitChildren(node._syntaxNode).cast(EnumCaseParameterSyntax.self)
+    return EnumCaseParameterSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``EnumDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(EnumDeclSyntax.self))
+    return DeclSyntax(EnumDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ExposeAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExposeAttributeArgumentsSyntax) -> ExposeAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(ExposeAttributeArgumentsSyntax.self)
+    return ExposeAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ExprListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExprListSyntax) -> ExprListSyntax {
-    return visitChildren(node._syntaxNode).cast(ExprListSyntax.self)
+    return ExprListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ExpressionPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode).cast(ExpressionPatternSyntax.self))
+    return PatternSyntax(ExpressionPatternSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ExpressionSegmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionSegmentSyntax) -> ExpressionSegmentSyntax {
-    return visitChildren(node._syntaxNode).cast(ExpressionSegmentSyntax.self)
+    return ExpressionSegmentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ExpressionStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExpressionStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(ExpressionStmtSyntax.self))
+    return StmtSyntax(ExpressionStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ExtensionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ExtensionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(ExtensionDeclSyntax.self))
+    return DeclSyntax(ExtensionDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``FallThroughStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FallThroughStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(FallThroughStmtSyntax.self))
+    return StmtSyntax(FallThroughStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``FloatLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FloatLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(FloatLiteralExprSyntax.self))
+    return ExprSyntax(FloatLiteralExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ForStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ForStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(ForStmtSyntax.self))
+    return StmtSyntax(ForStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ForceUnwrapExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ForceUnwrapExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(ForceUnwrapExprSyntax.self))
+    return ExprSyntax(ForceUnwrapExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``FunctionCallExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(FunctionCallExprSyntax.self))
+    return ExprSyntax(FunctionCallExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``FunctionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(FunctionDeclSyntax.self))
+    return DeclSyntax(FunctionDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``FunctionEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionEffectSpecifiersSyntax) -> FunctionEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode).cast(FunctionEffectSpecifiersSyntax.self)
+    return FunctionEffectSpecifiersSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``FunctionParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterClauseSyntax) -> FunctionParameterClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(FunctionParameterClauseSyntax.self)
+    return FunctionParameterClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``FunctionParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterListSyntax) -> FunctionParameterListSyntax {
-    return visitChildren(node._syntaxNode).cast(FunctionParameterListSyntax.self)
+    return FunctionParameterListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``FunctionParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionParameterSyntax) -> FunctionParameterSyntax {
-    return visitChildren(node._syntaxNode).cast(FunctionParameterSyntax.self)
+    return FunctionParameterSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``FunctionSignatureSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
-    return visitChildren(node._syntaxNode).cast(FunctionSignatureSyntax.self)
+    return FunctionSignatureSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``FunctionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(FunctionTypeSyntax.self))
+    return TypeSyntax(FunctionTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``GenericArgumentClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentClauseSyntax) -> GenericArgumentClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericArgumentClauseSyntax.self)
+    return GenericArgumentClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentListSyntax) -> GenericArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericArgumentListSyntax.self)
+    return GenericArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericArgumentSyntax) -> GenericArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericArgumentSyntax.self)
+    return GenericArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericParameterClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterClauseSyntax) -> GenericParameterClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericParameterClauseSyntax.self)
+    return GenericParameterClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericParameterListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterListSyntax) -> GenericParameterListSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericParameterListSyntax.self)
+    return GenericParameterListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericParameterSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericParameterSyntax) -> GenericParameterSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericParameterSyntax.self)
+    return GenericParameterSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericRequirementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericRequirementListSyntax) -> GenericRequirementListSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericRequirementListSyntax.self)
+    return GenericRequirementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericRequirementSyntax) -> GenericRequirementSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericRequirementSyntax.self)
+    return GenericRequirementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GenericSpecializationExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericSpecializationExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(GenericSpecializationExprSyntax.self))
+    return ExprSyntax(GenericSpecializationExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``GenericWhereClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GenericWhereClauseSyntax) -> GenericWhereClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(GenericWhereClauseSyntax.self)
+    return GenericWhereClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``GuardStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: GuardStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(GuardStmtSyntax.self))
+    return StmtSyntax(GuardStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``IdentifierPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IdentifierPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode).cast(IdentifierPatternSyntax.self))
+    return PatternSyntax(IdentifierPatternSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``IdentifierTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(IdentifierTypeSyntax.self))
+    return TypeSyntax(IdentifierTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``IfConfigClauseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigClauseListSyntax) -> IfConfigClauseListSyntax {
-    return visitChildren(node._syntaxNode).cast(IfConfigClauseListSyntax.self)
+    return IfConfigClauseListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``IfConfigClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigClauseSyntax) -> IfConfigClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(IfConfigClauseSyntax.self)
+    return IfConfigClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``IfConfigDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfConfigDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(IfConfigDeclSyntax.self))
+    return DeclSyntax(IfConfigDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``IfExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IfExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(IfExprSyntax.self))
+    return ExprSyntax(IfExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ImplementsAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImplementsAttributeArgumentsSyntax) -> ImplementsAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(ImplementsAttributeArgumentsSyntax.self)
+    return ImplementsAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ImplicitlyUnwrappedOptionalTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(ImplicitlyUnwrappedOptionalTypeSyntax.self))
+    return TypeSyntax(ImplicitlyUnwrappedOptionalTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ImportDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(ImportDeclSyntax.self))
+    return DeclSyntax(ImportDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ImportPathComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportPathComponentListSyntax) -> ImportPathComponentListSyntax {
-    return visitChildren(node._syntaxNode).cast(ImportPathComponentListSyntax.self)
+    return ImportPathComponentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ImportPathComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportPathComponentSyntax) -> ImportPathComponentSyntax {
-    return visitChildren(node._syntaxNode).cast(ImportPathComponentSyntax.self)
+    return ImportPathComponentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``InOutExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InOutExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(InOutExprSyntax.self))
+    return ExprSyntax(InOutExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``InfixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InfixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(InfixOperatorExprSyntax.self))
+    return ExprSyntax(InfixOperatorExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``InheritanceClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritanceClauseSyntax) -> InheritanceClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(InheritanceClauseSyntax.self)
+    return InheritanceClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``InheritedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritedTypeListSyntax) -> InheritedTypeListSyntax {
-    return visitChildren(node._syntaxNode).cast(InheritedTypeListSyntax.self)
+    return InheritedTypeListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``InheritedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InheritedTypeSyntax) -> InheritedTypeSyntax {
-    return visitChildren(node._syntaxNode).cast(InheritedTypeSyntax.self)
+    return InheritedTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``InitializerClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InitializerClauseSyntax) -> InitializerClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(InitializerClauseSyntax.self)
+    return InitializerClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``InitializerDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(InitializerDeclSyntax.self))
+    return DeclSyntax(InitializerDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``IntegerLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IntegerLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(IntegerLiteralExprSyntax.self))
+    return ExprSyntax(IntegerLiteralExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``IsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(IsExprSyntax.self))
+    return ExprSyntax(IsExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``IsTypePatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: IsTypePatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode).cast(IsTypePatternSyntax.self))
+    return PatternSyntax(IsTypePatternSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``KeyPathComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathComponentListSyntax) -> KeyPathComponentListSyntax {
-    return visitChildren(node._syntaxNode).cast(KeyPathComponentListSyntax.self)
+    return KeyPathComponentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``KeyPathComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathComponentSyntax) -> KeyPathComponentSyntax {
-    return visitChildren(node._syntaxNode).cast(KeyPathComponentSyntax.self)
+    return KeyPathComponentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``KeyPathExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(KeyPathExprSyntax.self))
+    return ExprSyntax(KeyPathExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``KeyPathOptionalComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathOptionalComponentSyntax) -> KeyPathOptionalComponentSyntax {
-    return visitChildren(node._syntaxNode).cast(KeyPathOptionalComponentSyntax.self)
+    return KeyPathOptionalComponentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``KeyPathPropertyComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathPropertyComponentSyntax) -> KeyPathPropertyComponentSyntax {
-    return visitChildren(node._syntaxNode).cast(KeyPathPropertyComponentSyntax.self)
+    return KeyPathPropertyComponentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``KeyPathSubscriptComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: KeyPathSubscriptComponentSyntax) -> KeyPathSubscriptComponentSyntax {
-    return visitChildren(node._syntaxNode).cast(KeyPathSubscriptComponentSyntax.self)
+    return KeyPathSubscriptComponentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``LabeledExprListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledExprListSyntax) -> LabeledExprListSyntax {
-    return visitChildren(node._syntaxNode).cast(LabeledExprListSyntax.self)
+    return LabeledExprListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``LabeledExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledExprSyntax) -> LabeledExprSyntax {
-    return visitChildren(node._syntaxNode).cast(LabeledExprSyntax.self)
+    return LabeledExprSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``LabeledSpecializeArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledSpecializeArgumentSyntax) -> LabeledSpecializeArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(LabeledSpecializeArgumentSyntax.self)
+    return LabeledSpecializeArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``LabeledStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LabeledStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(LabeledStmtSyntax.self))
+    return StmtSyntax(LabeledStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``LayoutRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: LayoutRequirementSyntax) -> LayoutRequirementSyntax {
-    return visitChildren(node._syntaxNode).cast(LayoutRequirementSyntax.self)
+    return LayoutRequirementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a `LifetimeSpecifierArgumentListSyntax`.
@@ -1246,7 +1241,7 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeSpecifierArgumentListSyntax) -> LifetimeSpecifierArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(LifetimeSpecifierArgumentListSyntax.self)
+    return LifetimeSpecifierArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a `LifetimeSpecifierArgumentSyntax`.
@@ -1256,7 +1251,7 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeSpecifierArgumentSyntax) -> LifetimeSpecifierArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(LifetimeSpecifierArgumentSyntax.self)
+    return LifetimeSpecifierArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a `LifetimeTypeSpecifierSyntax`.
@@ -1266,602 +1261,602 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: LifetimeTypeSpecifierSyntax) -> LifetimeTypeSpecifierSyntax {
-    return visitChildren(node._syntaxNode).cast(LifetimeTypeSpecifierSyntax.self)
+    return LifetimeTypeSpecifierSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``MacroDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(MacroDeclSyntax.self))
+    return DeclSyntax(MacroDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MacroExpansionDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroExpansionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(MacroExpansionDeclSyntax.self))
+    return DeclSyntax(MacroExpansionDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MacroExpansionExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MacroExpansionExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(MacroExpansionExprSyntax.self))
+    return ExprSyntax(MacroExpansionExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MatchingPatternConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MatchingPatternConditionSyntax) -> MatchingPatternConditionSyntax {
-    return visitChildren(node._syntaxNode).cast(MatchingPatternConditionSyntax.self)
+    return MatchingPatternConditionSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``MemberAccessExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(MemberAccessExprSyntax.self))
+    return ExprSyntax(MemberAccessExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MemberBlockItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockItemListSyntax) -> MemberBlockItemListSyntax {
-    return visitChildren(node._syntaxNode).cast(MemberBlockItemListSyntax.self)
+    return MemberBlockItemListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``MemberBlockItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockItemSyntax) -> MemberBlockItemSyntax {
-    return visitChildren(node._syntaxNode).cast(MemberBlockItemSyntax.self)
+    return MemberBlockItemSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``MemberBlockSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberBlockSyntax) -> MemberBlockSyntax {
-    return visitChildren(node._syntaxNode).cast(MemberBlockSyntax.self)
+    return MemberBlockSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``MemberTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MemberTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(MemberTypeSyntax.self))
+    return TypeSyntax(MemberTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MetatypeTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MetatypeTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(MetatypeTypeSyntax.self))
+    return TypeSyntax(MetatypeTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MissingDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(MissingDeclSyntax.self))
+    return DeclSyntax(MissingDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MissingExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(MissingExprSyntax.self))
+    return ExprSyntax(MissingExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MissingPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode).cast(MissingPatternSyntax.self))
+    return PatternSyntax(MissingPatternSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MissingStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(MissingStmtSyntax.self))
+    return StmtSyntax(MissingStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MissingSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingSyntax) -> Syntax {
-    return Syntax(visitChildren(node._syntaxNode).cast(MissingSyntax.self))
+    return Syntax(MissingSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MissingTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MissingTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(MissingTypeSyntax.self))
+    return TypeSyntax(MissingTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``MultipleTrailingClosureElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MultipleTrailingClosureElementListSyntax) -> MultipleTrailingClosureElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(MultipleTrailingClosureElementListSyntax.self)
+    return MultipleTrailingClosureElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``MultipleTrailingClosureElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: MultipleTrailingClosureElementSyntax) -> MultipleTrailingClosureElementSyntax {
-    return visitChildren(node._syntaxNode).cast(MultipleTrailingClosureElementSyntax.self)
+    return MultipleTrailingClosureElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``NamedOpaqueReturnTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: NamedOpaqueReturnTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(NamedOpaqueReturnTypeSyntax.self))
+    return TypeSyntax(NamedOpaqueReturnTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``NilLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: NilLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(NilLiteralExprSyntax.self))
+    return ExprSyntax(NilLiteralExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ObjCSelectorPieceListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ObjCSelectorPieceListSyntax) -> ObjCSelectorPieceListSyntax {
-    return visitChildren(node._syntaxNode).cast(ObjCSelectorPieceListSyntax.self)
+    return ObjCSelectorPieceListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ObjCSelectorPieceSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ObjCSelectorPieceSyntax) -> ObjCSelectorPieceSyntax {
-    return visitChildren(node._syntaxNode).cast(ObjCSelectorPieceSyntax.self)
+    return ObjCSelectorPieceSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``OpaqueReturnTypeOfAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(OpaqueReturnTypeOfAttributeArgumentsSyntax.self)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``OperatorDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OperatorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(OperatorDeclSyntax.self))
+    return DeclSyntax(OperatorDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``OperatorPrecedenceAndTypesSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OperatorPrecedenceAndTypesSyntax) -> OperatorPrecedenceAndTypesSyntax {
-    return visitChildren(node._syntaxNode).cast(OperatorPrecedenceAndTypesSyntax.self)
+    return OperatorPrecedenceAndTypesSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``OptionalBindingConditionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalBindingConditionSyntax) -> OptionalBindingConditionSyntax {
-    return visitChildren(node._syntaxNode).cast(OptionalBindingConditionSyntax.self)
+    return OptionalBindingConditionSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``OptionalChainingExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalChainingExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(OptionalChainingExprSyntax.self))
+    return ExprSyntax(OptionalChainingExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``OptionalTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OptionalTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(OptionalTypeSyntax.self))
+    return TypeSyntax(OptionalTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``OriginallyDefinedInAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> OriginallyDefinedInAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(OriginallyDefinedInAttributeArgumentsSyntax.self)
+    return OriginallyDefinedInAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PackElementExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackElementExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(PackElementExprSyntax.self))
+    return ExprSyntax(PackElementExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PackElementTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackElementTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(PackElementTypeSyntax.self))
+    return TypeSyntax(PackElementTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PackExpansionExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackExpansionExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(PackExpansionExprSyntax.self))
+    return ExprSyntax(PackExpansionExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PackExpansionTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PackExpansionTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(PackExpansionTypeSyntax.self))
+    return TypeSyntax(PackExpansionTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PatternBindingListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternBindingListSyntax) -> PatternBindingListSyntax {
-    return visitChildren(node._syntaxNode).cast(PatternBindingListSyntax.self)
+    return PatternBindingListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PatternBindingSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
-    return visitChildren(node._syntaxNode).cast(PatternBindingSyntax.self)
+    return PatternBindingSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PatternExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PatternExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(PatternExprSyntax.self))
+    return ExprSyntax(PatternExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PlatformVersionItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionItemListSyntax) -> PlatformVersionItemListSyntax {
-    return visitChildren(node._syntaxNode).cast(PlatformVersionItemListSyntax.self)
+    return PlatformVersionItemListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PlatformVersionItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionItemSyntax) -> PlatformVersionItemSyntax {
-    return visitChildren(node._syntaxNode).cast(PlatformVersionItemSyntax.self)
+    return PlatformVersionItemSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PlatformVersionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PlatformVersionSyntax) -> PlatformVersionSyntax {
-    return visitChildren(node._syntaxNode).cast(PlatformVersionSyntax.self)
+    return PlatformVersionSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PostfixIfConfigExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PostfixIfConfigExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(PostfixIfConfigExprSyntax.self))
+    return ExprSyntax(PostfixIfConfigExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PostfixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PostfixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(PostfixOperatorExprSyntax.self))
+    return ExprSyntax(PostfixOperatorExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PoundSourceLocationArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PoundSourceLocationArgumentsSyntax) -> PoundSourceLocationArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(PoundSourceLocationArgumentsSyntax.self)
+    return PoundSourceLocationArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PoundSourceLocationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PoundSourceLocationSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(PoundSourceLocationSyntax.self))
+    return DeclSyntax(PoundSourceLocationSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PrecedenceGroupAssignmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAssignmentSyntax) -> PrecedenceGroupAssignmentSyntax {
-    return visitChildren(node._syntaxNode).cast(PrecedenceGroupAssignmentSyntax.self)
+    return PrecedenceGroupAssignmentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrecedenceGroupAssociativitySyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAssociativitySyntax) -> PrecedenceGroupAssociativitySyntax {
-    return visitChildren(node._syntaxNode).cast(PrecedenceGroupAssociativitySyntax.self)
+    return PrecedenceGroupAssociativitySyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrecedenceGroupAttributeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupAttributeListSyntax) -> PrecedenceGroupAttributeListSyntax {
-    return visitChildren(node._syntaxNode).cast(PrecedenceGroupAttributeListSyntax.self)
+    return PrecedenceGroupAttributeListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrecedenceGroupDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(PrecedenceGroupDeclSyntax.self))
+    return DeclSyntax(PrecedenceGroupDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PrecedenceGroupNameListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupNameListSyntax) -> PrecedenceGroupNameListSyntax {
-    return visitChildren(node._syntaxNode).cast(PrecedenceGroupNameListSyntax.self)
+    return PrecedenceGroupNameListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrecedenceGroupNameSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupNameSyntax) -> PrecedenceGroupNameSyntax {
-    return visitChildren(node._syntaxNode).cast(PrecedenceGroupNameSyntax.self)
+    return PrecedenceGroupNameSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrecedenceGroupRelationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrecedenceGroupRelationSyntax) -> PrecedenceGroupRelationSyntax {
-    return visitChildren(node._syntaxNode).cast(PrecedenceGroupRelationSyntax.self)
+    return PrecedenceGroupRelationSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrefixOperatorExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrefixOperatorExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(PrefixOperatorExprSyntax.self))
+    return ExprSyntax(PrefixOperatorExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``PrimaryAssociatedTypeClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeClauseSyntax) -> PrimaryAssociatedTypeClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(PrimaryAssociatedTypeClauseSyntax.self)
+    return PrimaryAssociatedTypeClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrimaryAssociatedTypeListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeListSyntax) -> PrimaryAssociatedTypeListSyntax {
-    return visitChildren(node._syntaxNode).cast(PrimaryAssociatedTypeListSyntax.self)
+    return PrimaryAssociatedTypeListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``PrimaryAssociatedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeSyntax {
-    return visitChildren(node._syntaxNode).cast(PrimaryAssociatedTypeSyntax.self)
+    return PrimaryAssociatedTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ProtocolDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(ProtocolDeclSyntax.self))
+    return DeclSyntax(ProtocolDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``RegexLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: RegexLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(RegexLiteralExprSyntax.self))
+    return ExprSyntax(RegexLiteralExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``RepeatStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: RepeatStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(RepeatStmtSyntax.self))
+    return StmtSyntax(RepeatStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ReturnClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ReturnClauseSyntax) -> ReturnClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(ReturnClauseSyntax.self)
+    return ReturnClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``ReturnStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ReturnStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(ReturnStmtSyntax.self))
+    return StmtSyntax(ReturnStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SameTypeRequirementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SameTypeRequirementSyntax) -> SameTypeRequirementSyntax {
-    return visitChildren(node._syntaxNode).cast(SameTypeRequirementSyntax.self)
+    return SameTypeRequirementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SequenceExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SequenceExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(SequenceExprSyntax.self))
+    return ExprSyntax(SequenceExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SimpleStringLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleStringLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(SimpleStringLiteralExprSyntax.self))
+    return ExprSyntax(SimpleStringLiteralExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SimpleStringLiteralSegmentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleStringLiteralSegmentListSyntax) -> SimpleStringLiteralSegmentListSyntax {
-    return visitChildren(node._syntaxNode).cast(SimpleStringLiteralSegmentListSyntax.self)
+    return SimpleStringLiteralSegmentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SimpleTypeSpecifierSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SimpleTypeSpecifierSyntax) -> SimpleTypeSpecifierSyntax {
-    return visitChildren(node._syntaxNode).cast(SimpleTypeSpecifierSyntax.self)
+    return SimpleTypeSpecifierSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SomeOrAnyTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SomeOrAnyTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(SomeOrAnyTypeSyntax.self))
+    return TypeSyntax(SomeOrAnyTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SourceFileSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SourceFileSyntax) -> SourceFileSyntax {
-    return visitChildren(node._syntaxNode).cast(SourceFileSyntax.self)
+    return SourceFileSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SpecializeAttributeArgumentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeAttributeArgumentListSyntax) -> SpecializeAttributeArgumentListSyntax {
-    return visitChildren(node._syntaxNode).cast(SpecializeAttributeArgumentListSyntax.self)
+    return SpecializeAttributeArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SpecializeAvailabilityArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeAvailabilityArgumentSyntax) -> SpecializeAvailabilityArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(SpecializeAvailabilityArgumentSyntax.self)
+    return SpecializeAvailabilityArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SpecializeTargetFunctionArgumentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SpecializeTargetFunctionArgumentSyntax) -> SpecializeTargetFunctionArgumentSyntax {
-    return visitChildren(node._syntaxNode).cast(SpecializeTargetFunctionArgumentSyntax.self)
+    return SpecializeTargetFunctionArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``StringLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringLiteralExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(StringLiteralExprSyntax.self))
+    return ExprSyntax(StringLiteralExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``StringLiteralSegmentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringLiteralSegmentListSyntax) -> StringLiteralSegmentListSyntax {
-    return visitChildren(node._syntaxNode).cast(StringLiteralSegmentListSyntax.self)
+    return StringLiteralSegmentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``StringSegmentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StringSegmentSyntax) -> StringSegmentSyntax {
-    return visitChildren(node._syntaxNode).cast(StringSegmentSyntax.self)
+    return StringSegmentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``StructDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: StructDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(StructDeclSyntax.self))
+    return DeclSyntax(StructDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SubscriptCallExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SubscriptCallExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(SubscriptCallExprSyntax.self))
+    return ExprSyntax(SubscriptCallExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SubscriptDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(SubscriptDeclSyntax.self))
+    return DeclSyntax(SubscriptDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SuperExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SuperExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(SuperExprSyntax.self))
+    return ExprSyntax(SuperExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SuppressedTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SuppressedTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(SuppressedTypeSyntax.self))
+    return TypeSyntax(SuppressedTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``SwitchCaseItemListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseItemListSyntax) -> SwitchCaseItemListSyntax {
-    return visitChildren(node._syntaxNode).cast(SwitchCaseItemListSyntax.self)
+    return SwitchCaseItemListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SwitchCaseItemSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseItemSyntax) -> SwitchCaseItemSyntax {
-    return visitChildren(node._syntaxNode).cast(SwitchCaseItemSyntax.self)
+    return SwitchCaseItemSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SwitchCaseLabelSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseLabelSyntax) -> SwitchCaseLabelSyntax {
-    return visitChildren(node._syntaxNode).cast(SwitchCaseLabelSyntax.self)
+    return SwitchCaseLabelSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SwitchCaseListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseListSyntax) -> SwitchCaseListSyntax {
-    return visitChildren(node._syntaxNode).cast(SwitchCaseListSyntax.self)
+    return SwitchCaseListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SwitchCaseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
-    return visitChildren(node._syntaxNode).cast(SwitchCaseSyntax.self)
+    return SwitchCaseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SwitchDefaultLabelSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchDefaultLabelSyntax) -> SwitchDefaultLabelSyntax {
-    return visitChildren(node._syntaxNode).cast(SwitchDefaultLabelSyntax.self)
+    return SwitchDefaultLabelSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``SwitchExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(SwitchExprSyntax.self))
+    return ExprSyntax(SwitchExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``TernaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TernaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(TernaryExprSyntax.self))
+    return ExprSyntax(TernaryExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a `ThenStmtSyntax`.
@@ -1871,304 +1866,1705 @@ open class SyntaxRewriter {
   @_spi(ExperimentalLanguageFeatures)
   #endif
   open func visit(_ node: ThenStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(ThenStmtSyntax.self))
+    return StmtSyntax(ThenStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ThrowStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ThrowStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(ThrowStmtSyntax.self))
+    return StmtSyntax(ThrowStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ThrowsClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ThrowsClauseSyntax) -> ThrowsClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(ThrowsClauseSyntax.self)
+    return ThrowsClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(TryExprSyntax.self))
+    return ExprSyntax(TryExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``TupleExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(TupleExprSyntax.self))
+    return ExprSyntax(TupleExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``TuplePatternElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternElementListSyntax) -> TuplePatternElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(TuplePatternElementListSyntax.self)
+    return TuplePatternElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TuplePatternElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternElementSyntax) -> TuplePatternElementSyntax {
-    return visitChildren(node._syntaxNode).cast(TuplePatternElementSyntax.self)
+    return TuplePatternElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TuplePatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TuplePatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode).cast(TuplePatternSyntax.self))
+    return PatternSyntax(TuplePatternSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``TupleTypeElementListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeElementListSyntax) -> TupleTypeElementListSyntax {
-    return visitChildren(node._syntaxNode).cast(TupleTypeElementListSyntax.self)
+    return TupleTypeElementListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TupleTypeElementSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeElementSyntax) -> TupleTypeElementSyntax {
-    return visitChildren(node._syntaxNode).cast(TupleTypeElementSyntax.self)
+    return TupleTypeElementSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TupleTypeSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TupleTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(visitChildren(node._syntaxNode).cast(TupleTypeSyntax.self))
+    return TypeSyntax(TupleTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``TypeAliasDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeAliasDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(TypeAliasDeclSyntax.self))
+    return DeclSyntax(TypeAliasDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``TypeAnnotationSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeAnnotationSyntax) -> TypeAnnotationSyntax {
-    return visitChildren(node._syntaxNode).cast(TypeAnnotationSyntax.self)
+    return TypeAnnotationSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TypeEffectSpecifiersSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeEffectSpecifiersSyntax) -> TypeEffectSpecifiersSyntax {
-    return visitChildren(node._syntaxNode).cast(TypeEffectSpecifiersSyntax.self)
+    return TypeEffectSpecifiersSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TypeExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(TypeExprSyntax.self))
+    return ExprSyntax(TypeExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``TypeInitializerClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeInitializerClauseSyntax) -> TypeInitializerClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(TypeInitializerClauseSyntax.self)
+    return TypeInitializerClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``TypeSpecifierListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: TypeSpecifierListSyntax) -> TypeSpecifierListSyntax {
-    return visitChildren(node._syntaxNode).cast(TypeSpecifierListSyntax.self)
+    return TypeSpecifierListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``UnavailableFromAsyncAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnavailableFromAsyncAttributeArgumentsSyntax) -> UnavailableFromAsyncAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(UnavailableFromAsyncAttributeArgumentsSyntax.self)
+    return UnavailableFromAsyncAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``UnderscorePrivateAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnderscorePrivateAttributeArgumentsSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
-    return visitChildren(node._syntaxNode).cast(UnderscorePrivateAttributeArgumentsSyntax.self)
+    return UnderscorePrivateAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``UnexpectedNodesSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnexpectedNodesSyntax) -> UnexpectedNodesSyntax {
-    return visitChildren(node._syntaxNode).cast(UnexpectedNodesSyntax.self)
+    return UnexpectedNodesSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``UnresolvedAsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedAsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(UnresolvedAsExprSyntax.self))
+    return ExprSyntax(UnresolvedAsExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``UnresolvedIsExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedIsExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(UnresolvedIsExprSyntax.self))
+    return ExprSyntax(UnresolvedIsExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``UnresolvedTernaryExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnresolvedTernaryExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node._syntaxNode).cast(UnresolvedTernaryExprSyntax.self))
+    return ExprSyntax(UnresolvedTernaryExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``ValueBindingPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ValueBindingPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode).cast(ValueBindingPatternSyntax.self))
+    return PatternSyntax(ValueBindingPatternSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``VariableDeclSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(visitChildren(node._syntaxNode).cast(VariableDeclSyntax.self))
+    return DeclSyntax(VariableDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``VersionComponentListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionComponentListSyntax) -> VersionComponentListSyntax {
-    return visitChildren(node._syntaxNode).cast(VersionComponentListSyntax.self)
+    return VersionComponentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``VersionComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionComponentSyntax) -> VersionComponentSyntax {
-    return visitChildren(node._syntaxNode).cast(VersionComponentSyntax.self)
+    return VersionComponentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``VersionTupleSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: VersionTupleSyntax) -> VersionTupleSyntax {
-    return visitChildren(node._syntaxNode).cast(VersionTupleSyntax.self)
+    return VersionTupleSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``WhereClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WhereClauseSyntax) -> WhereClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(WhereClauseSyntax.self)
+    return WhereClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``WhileStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WhileStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(WhileStmtSyntax.self))
+    return StmtSyntax(WhileStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``WildcardPatternSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: WildcardPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(visitChildren(node._syntaxNode).cast(WildcardPatternSyntax.self))
+    return PatternSyntax(WildcardPatternSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``YieldStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node._syntaxNode).cast(YieldStmtSyntax.self))
+    return StmtSyntax(YieldStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
   /// Visit a ``YieldedExpressionListSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionListSyntax) -> YieldedExpressionListSyntax {
-    return visitChildren(node._syntaxNode).cast(YieldedExpressionListSyntax.self)
+    return YieldedExpressionListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``YieldedExpressionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionSyntax) -> YieldedExpressionSyntax {
-    return visitChildren(node._syntaxNode).cast(YieldedExpressionSyntax.self)
+    return YieldedExpressionSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit a ``YieldedExpressionsClauseSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldedExpressionsClauseSyntax) -> YieldedExpressionsClauseSyntax {
-    return visitChildren(node._syntaxNode).cast(YieldedExpressionsClauseSyntax.self)
+    return YieldedExpressionsClauseSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
 
   /// Visit any DeclSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: DeclSyntax) -> DeclSyntax {
-    var node: Syntax = Syntax(node)
-    dispatchVisit(&node)
-    return node.cast(DeclSyntax.self)
+    visitImpl(Syntax(node)).cast(DeclSyntax.self)
   }
 
   /// Visit any ExprSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: ExprSyntax) -> ExprSyntax {
-    var node: Syntax = Syntax(node)
-    dispatchVisit(&node)
-    return node.cast(ExprSyntax.self)
+    visitImpl(Syntax(node)).cast(ExprSyntax.self)
   }
 
   /// Visit any PatternSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: PatternSyntax) -> PatternSyntax {
-    var node: Syntax = Syntax(node)
-    dispatchVisit(&node)
-    return node.cast(PatternSyntax.self)
+    visitImpl(Syntax(node)).cast(PatternSyntax.self)
   }
 
   /// Visit any StmtSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: StmtSyntax) -> StmtSyntax {
-    var node: Syntax = Syntax(node)
-    dispatchVisit(&node)
-    return node.cast(StmtSyntax.self)
+    visitImpl(Syntax(node)).cast(StmtSyntax.self)
   }
 
   /// Visit any TypeSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: TypeSyntax) -> TypeSyntax {
-    var node: Syntax = Syntax(node)
-    dispatchVisit(&node)
-    return node.cast(TypeSyntax.self)
+    visitImpl(Syntax(node)).cast(TypeSyntax.self)
   }
 
-  /// Interpret `node` as a node of type `nodeType`, visit it, calling
-  /// the `visit` to transform the node.
-  @inline(__always)
-  private func visitImpl<NodeType: SyntaxProtocol>(
-    _ node: inout Syntax,
-    _ nodeType: NodeType.Type,
-    _ visit: (NodeType) -> some SyntaxProtocol
-  ) {
-    let origNode = node
-    visitPre(origNode)
-    node = visitAny(origNode) ?? Syntax(visit(origNode.cast(NodeType.self)))
-    visitPost(origNode)
+  @inline(never)
+  private func visitTokenSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TokenSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitABIAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ABIAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAccessorBlockSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AccessorBlockSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAccessorDeclListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AccessorDeclListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAccessorDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AccessorDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAccessorEffectSpecifiersSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AccessorEffectSpecifiersSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAccessorParametersSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AccessorParametersSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitActorDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ActorDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitArrayElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ArrayElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitArrayElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ArrayElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitArrayExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ArrayExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitArrayTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ArrayTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitArrowExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ArrowExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAsExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AsExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAssignmentExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AssignmentExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAssociatedTypeDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AssociatedTypeDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAttributeListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AttributeListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAttributeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AttributeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAttributedTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AttributedTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAvailabilityArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AvailabilityArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAvailabilityArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AvailabilityArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAvailabilityConditionSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AvailabilityConditionSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAvailabilityLabeledArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AvailabilityLabeledArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitAwaitExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(AwaitExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitBackDeployedAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(BackDeployedAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitBinaryOperatorExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(BinaryOperatorExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitBooleanLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(BooleanLiteralExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitBorrowExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(BorrowExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitBreakStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(BreakStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visit_CanImportExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(_CanImportExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visit_CanImportVersionInfoSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(_CanImportVersionInfoSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCatchClauseListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CatchClauseListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCatchClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CatchClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCatchItemListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CatchItemListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCatchItemSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CatchItemSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClassDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClassDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClassRestrictionTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClassRestrictionTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureCaptureClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureCaptureListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureSpecifierSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureCaptureSpecifierSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureCaptureSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureParameterClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureParameterClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureParameterListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureParameterListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureParameterSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureParameterSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureShorthandParameterListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureShorthandParameterListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureShorthandParameterSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureShorthandParameterSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitClosureSignatureSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ClosureSignatureSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCodeBlockItemListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CodeBlockItemListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCodeBlockItemSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CodeBlockItemSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCodeBlockSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CodeBlockSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCompositionTypeElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CompositionTypeElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCompositionTypeElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CompositionTypeElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCompositionTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CompositionTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitConditionElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ConditionElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitConditionElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ConditionElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitConformanceRequirementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ConformanceRequirementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitConsumeExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ConsumeExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitContinueStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ContinueStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitConventionAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ConventionAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitConventionWitnessMethodAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ConventionWitnessMethodAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitCopyExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(CopyExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeclModifierDetailSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeclModifierDetailSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeclModifierListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeclModifierListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeclModifierSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeclModifierSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeclNameArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeclNameArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeclNameArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeclNameArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeclNameArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeclNameArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeclReferenceExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeclReferenceExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeferStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeferStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeinitializerDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeinitializerDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDeinitializerEffectSpecifiersSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DeinitializerEffectSpecifiersSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDerivativeAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DerivativeAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDesignatedTypeListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DesignatedTypeListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDesignatedTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DesignatedTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDictionaryElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DictionaryElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDictionaryElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DictionaryElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDictionaryExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DictionaryExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDictionaryTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DictionaryTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DifferentiabilityArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DifferentiabilityArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DifferentiabilityArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityWithRespectToArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DifferentiabilityWithRespectToArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDifferentiableAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DifferentiableAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDiscardAssignmentExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DiscardAssignmentExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDiscardStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DiscardStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDoExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DoExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDoStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DoStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDocumentationAttributeArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DocumentationAttributeArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDocumentationAttributeArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DocumentationAttributeArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitDynamicReplacementAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(DynamicReplacementAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEditorPlaceholderDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EditorPlaceholderDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEditorPlaceholderExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EditorPlaceholderExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEffectsAttributeArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EffectsAttributeArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEnumCaseDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EnumCaseDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEnumCaseElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EnumCaseElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEnumCaseElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EnumCaseElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEnumCaseParameterClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EnumCaseParameterClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEnumCaseParameterListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EnumCaseParameterListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEnumCaseParameterSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EnumCaseParameterSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitEnumDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(EnumDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitExposeAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ExposeAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitExprListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ExprListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitExpressionPatternSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ExpressionPatternSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitExpressionSegmentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ExpressionSegmentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitExpressionStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ExpressionStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitExtensionDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ExtensionDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFallThroughStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FallThroughStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFloatLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FloatLiteralExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitForStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ForStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitForceUnwrapExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ForceUnwrapExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionCallExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionCallExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionEffectSpecifiersSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionEffectSpecifiersSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionParameterClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionParameterClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionParameterListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionParameterListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionParameterSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionParameterSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionSignatureSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionSignatureSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitFunctionTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(FunctionTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericArgumentClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericArgumentClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericParameterClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericParameterClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericParameterListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericParameterListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericParameterSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericParameterSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericRequirementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericRequirementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericRequirementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericRequirementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericSpecializationExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericSpecializationExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGenericWhereClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GenericWhereClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitGuardStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(GuardStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIdentifierPatternSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IdentifierPatternSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIdentifierTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IdentifierTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIfConfigClauseListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IfConfigClauseListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIfConfigClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IfConfigClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIfConfigDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IfConfigDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIfExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IfExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitImplementsAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ImplementsAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitImplicitlyUnwrappedOptionalTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ImplicitlyUnwrappedOptionalTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitImportDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ImportDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitImportPathComponentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ImportPathComponentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitImportPathComponentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ImportPathComponentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitInOutExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(InOutExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitInfixOperatorExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(InfixOperatorExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitInheritanceClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(InheritanceClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitInheritedTypeListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(InheritedTypeListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitInheritedTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(InheritedTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitInitializerClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(InitializerClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitInitializerDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(InitializerDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIntegerLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IntegerLiteralExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIsExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IsExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitIsTypePatternSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(IsTypePatternSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitKeyPathComponentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(KeyPathComponentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitKeyPathComponentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(KeyPathComponentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitKeyPathExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(KeyPathExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitKeyPathOptionalComponentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(KeyPathOptionalComponentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitKeyPathPropertyComponentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(KeyPathPropertyComponentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitKeyPathSubscriptComponentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(KeyPathSubscriptComponentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLabeledExprListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LabeledExprListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLabeledExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LabeledExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLabeledSpecializeArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LabeledSpecializeArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLabeledStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LabeledStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLayoutRequirementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LayoutRequirementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLifetimeSpecifierArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LifetimeSpecifierArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLifetimeSpecifierArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LifetimeSpecifierArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitLifetimeTypeSpecifierSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(LifetimeTypeSpecifierSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMacroDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MacroDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMacroExpansionDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MacroExpansionDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMacroExpansionExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MacroExpansionExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMatchingPatternConditionSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MatchingPatternConditionSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMemberAccessExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MemberAccessExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMemberBlockItemListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MemberBlockItemListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMemberBlockItemSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MemberBlockItemSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMemberBlockSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MemberBlockSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMemberTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MemberTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMetatypeTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MetatypeTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMissingDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MissingDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMissingExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MissingExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMissingPatternSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MissingPatternSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMissingStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MissingStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMissingSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MissingSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMissingTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MissingTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMultipleTrailingClosureElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MultipleTrailingClosureElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitMultipleTrailingClosureElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(MultipleTrailingClosureElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitNamedOpaqueReturnTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(NamedOpaqueReturnTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitNilLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(NilLiteralExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitObjCSelectorPieceListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ObjCSelectorPieceListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitObjCSelectorPieceSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ObjCSelectorPieceSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitOpaqueReturnTypeOfAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(OpaqueReturnTypeOfAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitOperatorDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(OperatorDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitOperatorPrecedenceAndTypesSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(OperatorPrecedenceAndTypesSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitOptionalBindingConditionSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(OptionalBindingConditionSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitOptionalChainingExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(OptionalChainingExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitOptionalTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(OptionalTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitOriginallyDefinedInAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(OriginallyDefinedInAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPackElementExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PackElementExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPackElementTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PackElementTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPackExpansionExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PackExpansionExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPackExpansionTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PackExpansionTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPatternBindingListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PatternBindingListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPatternBindingSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PatternBindingSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPatternExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PatternExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPlatformVersionItemListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PlatformVersionItemListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPlatformVersionItemSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PlatformVersionItemSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPlatformVersionSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PlatformVersionSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPostfixIfConfigExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PostfixIfConfigExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPostfixOperatorExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PostfixOperatorExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPoundSourceLocationArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PoundSourceLocationArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPoundSourceLocationSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PoundSourceLocationSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupAssignmentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrecedenceGroupAssignmentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupAssociativitySyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrecedenceGroupAssociativitySyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupAttributeListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrecedenceGroupAttributeListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrecedenceGroupDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupNameListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrecedenceGroupNameListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupNameSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrecedenceGroupNameSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupRelationSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrecedenceGroupRelationSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrefixOperatorExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrefixOperatorExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrimaryAssociatedTypeClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrimaryAssociatedTypeClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrimaryAssociatedTypeListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrimaryAssociatedTypeListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitPrimaryAssociatedTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(PrimaryAssociatedTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitProtocolDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ProtocolDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitRegexLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(RegexLiteralExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitRepeatStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(RepeatStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitReturnClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ReturnClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitReturnStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ReturnStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSameTypeRequirementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SameTypeRequirementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSequenceExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SequenceExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSimpleStringLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SimpleStringLiteralExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSimpleStringLiteralSegmentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SimpleStringLiteralSegmentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSimpleTypeSpecifierSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SimpleTypeSpecifierSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSomeOrAnyTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SomeOrAnyTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSourceFileSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SourceFileSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSpecializeAttributeArgumentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SpecializeAttributeArgumentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSpecializeAvailabilityArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SpecializeAvailabilityArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSpecializeTargetFunctionArgumentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SpecializeTargetFunctionArgumentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitStringLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(StringLiteralExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitStringLiteralSegmentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(StringLiteralSegmentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitStringSegmentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(StringSegmentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitStructDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(StructDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSubscriptCallExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SubscriptCallExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSubscriptDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SubscriptDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSuperExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SuperExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSuppressedTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SuppressedTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseItemListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SwitchCaseItemListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseItemSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SwitchCaseItemSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseLabelSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SwitchCaseLabelSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SwitchCaseListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SwitchCaseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSwitchDefaultLabelSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SwitchDefaultLabelSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitSwitchExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(SwitchExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTernaryExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TernaryExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitThenStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ThenStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitThrowStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ThrowStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitThrowsClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ThrowsClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTryExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TryExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTupleExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TupleExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTuplePatternElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TuplePatternElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTuplePatternElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TuplePatternElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTuplePatternSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TuplePatternSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTupleTypeElementListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TupleTypeElementListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTupleTypeElementSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TupleTypeElementSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTupleTypeSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TupleTypeSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTypeAliasDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TypeAliasDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTypeAnnotationSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TypeAnnotationSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTypeEffectSpecifiersSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TypeEffectSpecifiersSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTypeExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TypeExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTypeInitializerClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TypeInitializerClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitTypeSpecifierListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(TypeSpecifierListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitUnavailableFromAsyncAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(UnavailableFromAsyncAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitUnderscorePrivateAttributeArgumentsSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(UnderscorePrivateAttributeArgumentsSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitUnexpectedNodesSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(UnexpectedNodesSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitUnresolvedAsExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(UnresolvedAsExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitUnresolvedIsExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(UnresolvedIsExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitUnresolvedTernaryExprSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(UnresolvedTernaryExprSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitValueBindingPatternSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(ValueBindingPatternSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitVariableDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(VariableDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitVersionComponentListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(VersionComponentListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitVersionComponentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(VersionComponentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitVersionTupleSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(VersionTupleSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitWhereClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(WhereClauseSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitWhileStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(WhileStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitWildcardPatternSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(WildcardPatternSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitYieldStmtSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(YieldStmtSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitYieldedExpressionListSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(YieldedExpressionListSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitYieldedExpressionSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(YieldedExpressionSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
+  private func visitYieldedExpressionsClauseSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(YieldedExpressionsClauseSyntax(unsafeCasting: node)))
   }
 
   // SwiftSyntax requires a lot of stack space in debug builds for syntax tree
@@ -2195,1729 +3591,1167 @@ open class SyntaxRewriter {
   /// that determines the correct visitation function will be popped of the
   /// stack before the function is being called, making the switch's stack
   /// space transient instead of having it linger in the call stack.
-  private func visitationFunc(for node: Syntax) -> ((inout Syntax) -> Void) {
+  private func visitationFunc(for node: Syntax) -> (Syntax) -> Syntax {
     switch node.raw.kind {
     case .token:
-      return {
-        self.visitImpl(&$0, TokenSyntax.self, self.visit)
-      }
+      return self.visitTokenSyntaxImpl(_:)
     case .abiAttributeArguments:
-      return {
-        self.visitImpl(&$0, ABIAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitABIAttributeArgumentsSyntaxImpl(_:)
     case .accessorBlock:
-      return {
-        self.visitImpl(&$0, AccessorBlockSyntax.self, self.visit)
-      }
+      return self.visitAccessorBlockSyntaxImpl(_:)
     case .accessorDeclList:
-      return {
-        self.visitImpl(&$0, AccessorDeclListSyntax.self, self.visit)
-      }
+      return self.visitAccessorDeclListSyntaxImpl(_:)
     case .accessorDecl:
-      return {
-        self.visitImpl(&$0, AccessorDeclSyntax.self, self.visit)
-      }
+      return self.visitAccessorDeclSyntaxImpl(_:)
     case .accessorEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, AccessorEffectSpecifiersSyntax.self, self.visit)
-      }
+      return self.visitAccessorEffectSpecifiersSyntaxImpl(_:)
     case .accessorParameters:
-      return {
-        self.visitImpl(&$0, AccessorParametersSyntax.self, self.visit)
-      }
+      return self.visitAccessorParametersSyntaxImpl(_:)
     case .actorDecl:
-      return {
-        self.visitImpl(&$0, ActorDeclSyntax.self, self.visit)
-      }
+      return self.visitActorDeclSyntaxImpl(_:)
     case .arrayElementList:
-      return {
-        self.visitImpl(&$0, ArrayElementListSyntax.self, self.visit)
-      }
+      return self.visitArrayElementListSyntaxImpl(_:)
     case .arrayElement:
-      return {
-        self.visitImpl(&$0, ArrayElementSyntax.self, self.visit)
-      }
+      return self.visitArrayElementSyntaxImpl(_:)
     case .arrayExpr:
-      return {
-        self.visitImpl(&$0, ArrayExprSyntax.self, self.visit)
-      }
+      return self.visitArrayExprSyntaxImpl(_:)
     case .arrayType:
-      return {
-        self.visitImpl(&$0, ArrayTypeSyntax.self, self.visit)
-      }
+      return self.visitArrayTypeSyntaxImpl(_:)
     case .arrowExpr:
-      return {
-        self.visitImpl(&$0, ArrowExprSyntax.self, self.visit)
-      }
+      return self.visitArrowExprSyntaxImpl(_:)
     case .asExpr:
-      return {
-        self.visitImpl(&$0, AsExprSyntax.self, self.visit)
-      }
+      return self.visitAsExprSyntaxImpl(_:)
     case .assignmentExpr:
-      return {
-        self.visitImpl(&$0, AssignmentExprSyntax.self, self.visit)
-      }
+      return self.visitAssignmentExprSyntaxImpl(_:)
     case .associatedTypeDecl:
-      return {
-        self.visitImpl(&$0, AssociatedTypeDeclSyntax.self, self.visit)
-      }
+      return self.visitAssociatedTypeDeclSyntaxImpl(_:)
     case .attributeList:
-      return {
-        self.visitImpl(&$0, AttributeListSyntax.self, self.visit)
-      }
+      return self.visitAttributeListSyntaxImpl(_:)
     case .attribute:
-      return {
-        self.visitImpl(&$0, AttributeSyntax.self, self.visit)
-      }
+      return self.visitAttributeSyntaxImpl(_:)
     case .attributedType:
-      return {
-        self.visitImpl(&$0, AttributedTypeSyntax.self, self.visit)
-      }
+      return self.visitAttributedTypeSyntaxImpl(_:)
     case .availabilityArgumentList:
-      return {
-        self.visitImpl(&$0, AvailabilityArgumentListSyntax.self, self.visit)
-      }
+      return self.visitAvailabilityArgumentListSyntaxImpl(_:)
     case .availabilityArgument:
-      return {
-        self.visitImpl(&$0, AvailabilityArgumentSyntax.self, self.visit)
-      }
+      return self.visitAvailabilityArgumentSyntaxImpl(_:)
     case .availabilityCondition:
-      return {
-        self.visitImpl(&$0, AvailabilityConditionSyntax.self, self.visit)
-      }
+      return self.visitAvailabilityConditionSyntaxImpl(_:)
     case .availabilityLabeledArgument:
-      return {
-        self.visitImpl(&$0, AvailabilityLabeledArgumentSyntax.self, self.visit)
-      }
+      return self.visitAvailabilityLabeledArgumentSyntaxImpl(_:)
     case .awaitExpr:
-      return {
-        self.visitImpl(&$0, AwaitExprSyntax.self, self.visit)
-      }
+      return self.visitAwaitExprSyntaxImpl(_:)
     case .backDeployedAttributeArguments:
-      return {
-        self.visitImpl(&$0, BackDeployedAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitBackDeployedAttributeArgumentsSyntaxImpl(_:)
     case .binaryOperatorExpr:
-      return {
-        self.visitImpl(&$0, BinaryOperatorExprSyntax.self, self.visit)
-      }
+      return self.visitBinaryOperatorExprSyntaxImpl(_:)
     case .booleanLiteralExpr:
-      return {
-        self.visitImpl(&$0, BooleanLiteralExprSyntax.self, self.visit)
-      }
+      return self.visitBooleanLiteralExprSyntaxImpl(_:)
     case .borrowExpr:
-      return {
-        self.visitImpl(&$0, BorrowExprSyntax.self, self.visit)
-      }
+      return self.visitBorrowExprSyntaxImpl(_:)
     case .breakStmt:
-      return {
-        self.visitImpl(&$0, BreakStmtSyntax.self, self.visit)
-      }
+      return self.visitBreakStmtSyntaxImpl(_:)
     case ._canImportExpr:
-      return {
-        self.visitImpl(&$0, _CanImportExprSyntax.self, self.visit)
-      }
+      return self.visit_CanImportExprSyntaxImpl(_:)
     case ._canImportVersionInfo:
-      return {
-        self.visitImpl(&$0, _CanImportVersionInfoSyntax.self, self.visit)
-      }
+      return self.visit_CanImportVersionInfoSyntaxImpl(_:)
     case .catchClauseList:
-      return {
-        self.visitImpl(&$0, CatchClauseListSyntax.self, self.visit)
-      }
+      return self.visitCatchClauseListSyntaxImpl(_:)
     case .catchClause:
-      return {
-        self.visitImpl(&$0, CatchClauseSyntax.self, self.visit)
-      }
+      return self.visitCatchClauseSyntaxImpl(_:)
     case .catchItemList:
-      return {
-        self.visitImpl(&$0, CatchItemListSyntax.self, self.visit)
-      }
+      return self.visitCatchItemListSyntaxImpl(_:)
     case .catchItem:
-      return {
-        self.visitImpl(&$0, CatchItemSyntax.self, self.visit)
-      }
+      return self.visitCatchItemSyntaxImpl(_:)
     case .classDecl:
-      return {
-        self.visitImpl(&$0, ClassDeclSyntax.self, self.visit)
-      }
+      return self.visitClassDeclSyntaxImpl(_:)
     case .classRestrictionType:
-      return {
-        self.visitImpl(&$0, ClassRestrictionTypeSyntax.self, self.visit)
-      }
+      return self.visitClassRestrictionTypeSyntaxImpl(_:)
     case .closureCaptureClause:
-      return {
-        self.visitImpl(&$0, ClosureCaptureClauseSyntax.self, self.visit)
-      }
+      return self.visitClosureCaptureClauseSyntaxImpl(_:)
     case .closureCaptureList:
-      return {
-        self.visitImpl(&$0, ClosureCaptureListSyntax.self, self.visit)
-      }
+      return self.visitClosureCaptureListSyntaxImpl(_:)
     case .closureCaptureSpecifier:
-      return {
-        self.visitImpl(&$0, ClosureCaptureSpecifierSyntax.self, self.visit)
-      }
+      return self.visitClosureCaptureSpecifierSyntaxImpl(_:)
     case .closureCapture:
-      return {
-        self.visitImpl(&$0, ClosureCaptureSyntax.self, self.visit)
-      }
+      return self.visitClosureCaptureSyntaxImpl(_:)
     case .closureExpr:
-      return {
-        self.visitImpl(&$0, ClosureExprSyntax.self, self.visit)
-      }
+      return self.visitClosureExprSyntaxImpl(_:)
     case .closureParameterClause:
-      return {
-        self.visitImpl(&$0, ClosureParameterClauseSyntax.self, self.visit)
-      }
+      return self.visitClosureParameterClauseSyntaxImpl(_:)
     case .closureParameterList:
-      return {
-        self.visitImpl(&$0, ClosureParameterListSyntax.self, self.visit)
-      }
+      return self.visitClosureParameterListSyntaxImpl(_:)
     case .closureParameter:
-      return {
-        self.visitImpl(&$0, ClosureParameterSyntax.self, self.visit)
-      }
+      return self.visitClosureParameterSyntaxImpl(_:)
     case .closureShorthandParameterList:
-      return {
-        self.visitImpl(&$0, ClosureShorthandParameterListSyntax.self, self.visit)
-      }
+      return self.visitClosureShorthandParameterListSyntaxImpl(_:)
     case .closureShorthandParameter:
-      return {
-        self.visitImpl(&$0, ClosureShorthandParameterSyntax.self, self.visit)
-      }
+      return self.visitClosureShorthandParameterSyntaxImpl(_:)
     case .closureSignature:
-      return {
-        self.visitImpl(&$0, ClosureSignatureSyntax.self, self.visit)
-      }
+      return self.visitClosureSignatureSyntaxImpl(_:)
     case .codeBlockItemList:
-      return {
-        self.visitImpl(&$0, CodeBlockItemListSyntax.self, self.visit)
-      }
+      return self.visitCodeBlockItemListSyntaxImpl(_:)
     case .codeBlockItem:
-      return {
-        self.visitImpl(&$0, CodeBlockItemSyntax.self, self.visit)
-      }
+      return self.visitCodeBlockItemSyntaxImpl(_:)
     case .codeBlock:
-      return {
-        self.visitImpl(&$0, CodeBlockSyntax.self, self.visit)
-      }
+      return self.visitCodeBlockSyntaxImpl(_:)
     case .compositionTypeElementList:
-      return {
-        self.visitImpl(&$0, CompositionTypeElementListSyntax.self, self.visit)
-      }
+      return self.visitCompositionTypeElementListSyntaxImpl(_:)
     case .compositionTypeElement:
-      return {
-        self.visitImpl(&$0, CompositionTypeElementSyntax.self, self.visit)
-      }
+      return self.visitCompositionTypeElementSyntaxImpl(_:)
     case .compositionType:
-      return {
-        self.visitImpl(&$0, CompositionTypeSyntax.self, self.visit)
-      }
+      return self.visitCompositionTypeSyntaxImpl(_:)
     case .conditionElementList:
-      return {
-        self.visitImpl(&$0, ConditionElementListSyntax.self, self.visit)
-      }
+      return self.visitConditionElementListSyntaxImpl(_:)
     case .conditionElement:
-      return {
-        self.visitImpl(&$0, ConditionElementSyntax.self, self.visit)
-      }
+      return self.visitConditionElementSyntaxImpl(_:)
     case .conformanceRequirement:
-      return {
-        self.visitImpl(&$0, ConformanceRequirementSyntax.self, self.visit)
-      }
+      return self.visitConformanceRequirementSyntaxImpl(_:)
     case .consumeExpr:
-      return {
-        self.visitImpl(&$0, ConsumeExprSyntax.self, self.visit)
-      }
+      return self.visitConsumeExprSyntaxImpl(_:)
     case .continueStmt:
-      return {
-        self.visitImpl(&$0, ContinueStmtSyntax.self, self.visit)
-      }
+      return self.visitContinueStmtSyntaxImpl(_:)
     case .conventionAttributeArguments:
-      return {
-        self.visitImpl(&$0, ConventionAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitConventionAttributeArgumentsSyntaxImpl(_:)
     case .conventionWitnessMethodAttributeArguments:
-      return {
-        self.visitImpl(&$0, ConventionWitnessMethodAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitConventionWitnessMethodAttributeArgumentsSyntaxImpl(_:)
     case .copyExpr:
-      return {
-        self.visitImpl(&$0, CopyExprSyntax.self, self.visit)
-      }
+      return self.visitCopyExprSyntaxImpl(_:)
     case .declModifierDetail:
-      return {
-        self.visitImpl(&$0, DeclModifierDetailSyntax.self, self.visit)
-      }
+      return self.visitDeclModifierDetailSyntaxImpl(_:)
     case .declModifierList:
-      return {
-        self.visitImpl(&$0, DeclModifierListSyntax.self, self.visit)
-      }
+      return self.visitDeclModifierListSyntaxImpl(_:)
     case .declModifier:
-      return {
-        self.visitImpl(&$0, DeclModifierSyntax.self, self.visit)
-      }
+      return self.visitDeclModifierSyntaxImpl(_:)
     case .declNameArgumentList:
-      return {
-        self.visitImpl(&$0, DeclNameArgumentListSyntax.self, self.visit)
-      }
+      return self.visitDeclNameArgumentListSyntaxImpl(_:)
     case .declNameArgument:
-      return {
-        self.visitImpl(&$0, DeclNameArgumentSyntax.self, self.visit)
-      }
+      return self.visitDeclNameArgumentSyntaxImpl(_:)
     case .declNameArguments:
-      return {
-        self.visitImpl(&$0, DeclNameArgumentsSyntax.self, self.visit)
-      }
+      return self.visitDeclNameArgumentsSyntaxImpl(_:)
     case .declReferenceExpr:
-      return {
-        self.visitImpl(&$0, DeclReferenceExprSyntax.self, self.visit)
-      }
+      return self.visitDeclReferenceExprSyntaxImpl(_:)
     case .deferStmt:
-      return {
-        self.visitImpl(&$0, DeferStmtSyntax.self, self.visit)
-      }
+      return self.visitDeferStmtSyntaxImpl(_:)
     case .deinitializerDecl:
-      return {
-        self.visitImpl(&$0, DeinitializerDeclSyntax.self, self.visit)
-      }
+      return self.visitDeinitializerDeclSyntaxImpl(_:)
     case .deinitializerEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, DeinitializerEffectSpecifiersSyntax.self, self.visit)
-      }
+      return self.visitDeinitializerEffectSpecifiersSyntaxImpl(_:)
     case .derivativeAttributeArguments:
-      return {
-        self.visitImpl(&$0, DerivativeAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitDerivativeAttributeArgumentsSyntaxImpl(_:)
     case .designatedTypeList:
-      return {
-        self.visitImpl(&$0, DesignatedTypeListSyntax.self, self.visit)
-      }
+      return self.visitDesignatedTypeListSyntaxImpl(_:)
     case .designatedType:
-      return {
-        self.visitImpl(&$0, DesignatedTypeSyntax.self, self.visit)
-      }
+      return self.visitDesignatedTypeSyntaxImpl(_:)
     case .dictionaryElementList:
-      return {
-        self.visitImpl(&$0, DictionaryElementListSyntax.self, self.visit)
-      }
+      return self.visitDictionaryElementListSyntaxImpl(_:)
     case .dictionaryElement:
-      return {
-        self.visitImpl(&$0, DictionaryElementSyntax.self, self.visit)
-      }
+      return self.visitDictionaryElementSyntaxImpl(_:)
     case .dictionaryExpr:
-      return {
-        self.visitImpl(&$0, DictionaryExprSyntax.self, self.visit)
-      }
+      return self.visitDictionaryExprSyntaxImpl(_:)
     case .dictionaryType:
-      return {
-        self.visitImpl(&$0, DictionaryTypeSyntax.self, self.visit)
-      }
+      return self.visitDictionaryTypeSyntaxImpl(_:)
     case .differentiabilityArgumentList:
-      return {
-        self.visitImpl(&$0, DifferentiabilityArgumentListSyntax.self, self.visit)
-      }
+      return self.visitDifferentiabilityArgumentListSyntaxImpl(_:)
     case .differentiabilityArgument:
-      return {
-        self.visitImpl(&$0, DifferentiabilityArgumentSyntax.self, self.visit)
-      }
+      return self.visitDifferentiabilityArgumentSyntaxImpl(_:)
     case .differentiabilityArguments:
-      return {
-        self.visitImpl(&$0, DifferentiabilityArgumentsSyntax.self, self.visit)
-      }
+      return self.visitDifferentiabilityArgumentsSyntaxImpl(_:)
     case .differentiabilityWithRespectToArgument:
-      return {
-        self.visitImpl(&$0, DifferentiabilityWithRespectToArgumentSyntax.self, self.visit)
-      }
+      return self.visitDifferentiabilityWithRespectToArgumentSyntaxImpl(_:)
     case .differentiableAttributeArguments:
-      return {
-        self.visitImpl(&$0, DifferentiableAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitDifferentiableAttributeArgumentsSyntaxImpl(_:)
     case .discardAssignmentExpr:
-      return {
-        self.visitImpl(&$0, DiscardAssignmentExprSyntax.self, self.visit)
-      }
+      return self.visitDiscardAssignmentExprSyntaxImpl(_:)
     case .discardStmt:
-      return {
-        self.visitImpl(&$0, DiscardStmtSyntax.self, self.visit)
-      }
+      return self.visitDiscardStmtSyntaxImpl(_:)
     case .doExpr:
-      return {
-        self.visitImpl(&$0, DoExprSyntax.self, self.visit)
-      }
+      return self.visitDoExprSyntaxImpl(_:)
     case .doStmt:
-      return {
-        self.visitImpl(&$0, DoStmtSyntax.self, self.visit)
-      }
+      return self.visitDoStmtSyntaxImpl(_:)
     case .documentationAttributeArgumentList:
-      return {
-        self.visitImpl(&$0, DocumentationAttributeArgumentListSyntax.self, self.visit)
-      }
+      return self.visitDocumentationAttributeArgumentListSyntaxImpl(_:)
     case .documentationAttributeArgument:
-      return {
-        self.visitImpl(&$0, DocumentationAttributeArgumentSyntax.self, self.visit)
-      }
+      return self.visitDocumentationAttributeArgumentSyntaxImpl(_:)
     case .dynamicReplacementAttributeArguments:
-      return {
-        self.visitImpl(&$0, DynamicReplacementAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitDynamicReplacementAttributeArgumentsSyntaxImpl(_:)
     case .editorPlaceholderDecl:
-      return {
-        self.visitImpl(&$0, EditorPlaceholderDeclSyntax.self, self.visit)
-      }
+      return self.visitEditorPlaceholderDeclSyntaxImpl(_:)
     case .editorPlaceholderExpr:
-      return {
-        self.visitImpl(&$0, EditorPlaceholderExprSyntax.self, self.visit)
-      }
+      return self.visitEditorPlaceholderExprSyntaxImpl(_:)
     case .effectsAttributeArgumentList:
-      return {
-        self.visitImpl(&$0, EffectsAttributeArgumentListSyntax.self, self.visit)
-      }
+      return self.visitEffectsAttributeArgumentListSyntaxImpl(_:)
     case .enumCaseDecl:
-      return {
-        self.visitImpl(&$0, EnumCaseDeclSyntax.self, self.visit)
-      }
+      return self.visitEnumCaseDeclSyntaxImpl(_:)
     case .enumCaseElementList:
-      return {
-        self.visitImpl(&$0, EnumCaseElementListSyntax.self, self.visit)
-      }
+      return self.visitEnumCaseElementListSyntaxImpl(_:)
     case .enumCaseElement:
-      return {
-        self.visitImpl(&$0, EnumCaseElementSyntax.self, self.visit)
-      }
+      return self.visitEnumCaseElementSyntaxImpl(_:)
     case .enumCaseParameterClause:
-      return {
-        self.visitImpl(&$0, EnumCaseParameterClauseSyntax.self, self.visit)
-      }
+      return self.visitEnumCaseParameterClauseSyntaxImpl(_:)
     case .enumCaseParameterList:
-      return {
-        self.visitImpl(&$0, EnumCaseParameterListSyntax.self, self.visit)
-      }
+      return self.visitEnumCaseParameterListSyntaxImpl(_:)
     case .enumCaseParameter:
-      return {
-        self.visitImpl(&$0, EnumCaseParameterSyntax.self, self.visit)
-      }
+      return self.visitEnumCaseParameterSyntaxImpl(_:)
     case .enumDecl:
-      return {
-        self.visitImpl(&$0, EnumDeclSyntax.self, self.visit)
-      }
+      return self.visitEnumDeclSyntaxImpl(_:)
     case .exposeAttributeArguments:
-      return {
-        self.visitImpl(&$0, ExposeAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitExposeAttributeArgumentsSyntaxImpl(_:)
     case .exprList:
-      return {
-        self.visitImpl(&$0, ExprListSyntax.self, self.visit)
-      }
+      return self.visitExprListSyntaxImpl(_:)
     case .expressionPattern:
-      return {
-        self.visitImpl(&$0, ExpressionPatternSyntax.self, self.visit)
-      }
+      return self.visitExpressionPatternSyntaxImpl(_:)
     case .expressionSegment:
-      return {
-        self.visitImpl(&$0, ExpressionSegmentSyntax.self, self.visit)
-      }
+      return self.visitExpressionSegmentSyntaxImpl(_:)
     case .expressionStmt:
-      return {
-        self.visitImpl(&$0, ExpressionStmtSyntax.self, self.visit)
-      }
+      return self.visitExpressionStmtSyntaxImpl(_:)
     case .extensionDecl:
-      return {
-        self.visitImpl(&$0, ExtensionDeclSyntax.self, self.visit)
-      }
+      return self.visitExtensionDeclSyntaxImpl(_:)
     case .fallThroughStmt:
-      return {
-        self.visitImpl(&$0, FallThroughStmtSyntax.self, self.visit)
-      }
+      return self.visitFallThroughStmtSyntaxImpl(_:)
     case .floatLiteralExpr:
-      return {
-        self.visitImpl(&$0, FloatLiteralExprSyntax.self, self.visit)
-      }
+      return self.visitFloatLiteralExprSyntaxImpl(_:)
     case .forStmt:
-      return {
-        self.visitImpl(&$0, ForStmtSyntax.self, self.visit)
-      }
+      return self.visitForStmtSyntaxImpl(_:)
     case .forceUnwrapExpr:
-      return {
-        self.visitImpl(&$0, ForceUnwrapExprSyntax.self, self.visit)
-      }
+      return self.visitForceUnwrapExprSyntaxImpl(_:)
     case .functionCallExpr:
-      return {
-        self.visitImpl(&$0, FunctionCallExprSyntax.self, self.visit)
-      }
+      return self.visitFunctionCallExprSyntaxImpl(_:)
     case .functionDecl:
-      return {
-        self.visitImpl(&$0, FunctionDeclSyntax.self, self.visit)
-      }
+      return self.visitFunctionDeclSyntaxImpl(_:)
     case .functionEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, FunctionEffectSpecifiersSyntax.self, self.visit)
-      }
+      return self.visitFunctionEffectSpecifiersSyntaxImpl(_:)
     case .functionParameterClause:
-      return {
-        self.visitImpl(&$0, FunctionParameterClauseSyntax.self, self.visit)
-      }
+      return self.visitFunctionParameterClauseSyntaxImpl(_:)
     case .functionParameterList:
-      return {
-        self.visitImpl(&$0, FunctionParameterListSyntax.self, self.visit)
-      }
+      return self.visitFunctionParameterListSyntaxImpl(_:)
     case .functionParameter:
-      return {
-        self.visitImpl(&$0, FunctionParameterSyntax.self, self.visit)
-      }
+      return self.visitFunctionParameterSyntaxImpl(_:)
     case .functionSignature:
-      return {
-        self.visitImpl(&$0, FunctionSignatureSyntax.self, self.visit)
-      }
+      return self.visitFunctionSignatureSyntaxImpl(_:)
     case .functionType:
-      return {
-        self.visitImpl(&$0, FunctionTypeSyntax.self, self.visit)
-      }
+      return self.visitFunctionTypeSyntaxImpl(_:)
     case .genericArgumentClause:
-      return {
-        self.visitImpl(&$0, GenericArgumentClauseSyntax.self, self.visit)
-      }
+      return self.visitGenericArgumentClauseSyntaxImpl(_:)
     case .genericArgumentList:
-      return {
-        self.visitImpl(&$0, GenericArgumentListSyntax.self, self.visit)
-      }
+      return self.visitGenericArgumentListSyntaxImpl(_:)
     case .genericArgument:
-      return {
-        self.visitImpl(&$0, GenericArgumentSyntax.self, self.visit)
-      }
+      return self.visitGenericArgumentSyntaxImpl(_:)
     case .genericParameterClause:
-      return {
-        self.visitImpl(&$0, GenericParameterClauseSyntax.self, self.visit)
-      }
+      return self.visitGenericParameterClauseSyntaxImpl(_:)
     case .genericParameterList:
-      return {
-        self.visitImpl(&$0, GenericParameterListSyntax.self, self.visit)
-      }
+      return self.visitGenericParameterListSyntaxImpl(_:)
     case .genericParameter:
-      return {
-        self.visitImpl(&$0, GenericParameterSyntax.self, self.visit)
-      }
+      return self.visitGenericParameterSyntaxImpl(_:)
     case .genericRequirementList:
-      return {
-        self.visitImpl(&$0, GenericRequirementListSyntax.self, self.visit)
-      }
+      return self.visitGenericRequirementListSyntaxImpl(_:)
     case .genericRequirement:
-      return {
-        self.visitImpl(&$0, GenericRequirementSyntax.self, self.visit)
-      }
+      return self.visitGenericRequirementSyntaxImpl(_:)
     case .genericSpecializationExpr:
-      return {
-        self.visitImpl(&$0, GenericSpecializationExprSyntax.self, self.visit)
-      }
+      return self.visitGenericSpecializationExprSyntaxImpl(_:)
     case .genericWhereClause:
-      return {
-        self.visitImpl(&$0, GenericWhereClauseSyntax.self, self.visit)
-      }
+      return self.visitGenericWhereClauseSyntaxImpl(_:)
     case .guardStmt:
-      return {
-        self.visitImpl(&$0, GuardStmtSyntax.self, self.visit)
-      }
+      return self.visitGuardStmtSyntaxImpl(_:)
     case .identifierPattern:
-      return {
-        self.visitImpl(&$0, IdentifierPatternSyntax.self, self.visit)
-      }
+      return self.visitIdentifierPatternSyntaxImpl(_:)
     case .identifierType:
-      return {
-        self.visitImpl(&$0, IdentifierTypeSyntax.self, self.visit)
-      }
+      return self.visitIdentifierTypeSyntaxImpl(_:)
     case .ifConfigClauseList:
-      return {
-        self.visitImpl(&$0, IfConfigClauseListSyntax.self, self.visit)
-      }
+      return self.visitIfConfigClauseListSyntaxImpl(_:)
     case .ifConfigClause:
-      return {
-        self.visitImpl(&$0, IfConfigClauseSyntax.self, self.visit)
-      }
+      return self.visitIfConfigClauseSyntaxImpl(_:)
     case .ifConfigDecl:
-      return {
-        self.visitImpl(&$0, IfConfigDeclSyntax.self, self.visit)
-      }
+      return self.visitIfConfigDeclSyntaxImpl(_:)
     case .ifExpr:
-      return {
-        self.visitImpl(&$0, IfExprSyntax.self, self.visit)
-      }
+      return self.visitIfExprSyntaxImpl(_:)
     case .implementsAttributeArguments:
-      return {
-        self.visitImpl(&$0, ImplementsAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitImplementsAttributeArgumentsSyntaxImpl(_:)
     case .implicitlyUnwrappedOptionalType:
-      return {
-        self.visitImpl(&$0, ImplicitlyUnwrappedOptionalTypeSyntax.self, self.visit)
-      }
+      return self.visitImplicitlyUnwrappedOptionalTypeSyntaxImpl(_:)
     case .importDecl:
-      return {
-        self.visitImpl(&$0, ImportDeclSyntax.self, self.visit)
-      }
+      return self.visitImportDeclSyntaxImpl(_:)
     case .importPathComponentList:
-      return {
-        self.visitImpl(&$0, ImportPathComponentListSyntax.self, self.visit)
-      }
+      return self.visitImportPathComponentListSyntaxImpl(_:)
     case .importPathComponent:
-      return {
-        self.visitImpl(&$0, ImportPathComponentSyntax.self, self.visit)
-      }
+      return self.visitImportPathComponentSyntaxImpl(_:)
     case .inOutExpr:
-      return {
-        self.visitImpl(&$0, InOutExprSyntax.self, self.visit)
-      }
+      return self.visitInOutExprSyntaxImpl(_:)
     case .infixOperatorExpr:
-      return {
-        self.visitImpl(&$0, InfixOperatorExprSyntax.self, self.visit)
-      }
+      return self.visitInfixOperatorExprSyntaxImpl(_:)
     case .inheritanceClause:
-      return {
-        self.visitImpl(&$0, InheritanceClauseSyntax.self, self.visit)
-      }
+      return self.visitInheritanceClauseSyntaxImpl(_:)
     case .inheritedTypeList:
-      return {
-        self.visitImpl(&$0, InheritedTypeListSyntax.self, self.visit)
-      }
+      return self.visitInheritedTypeListSyntaxImpl(_:)
     case .inheritedType:
-      return {
-        self.visitImpl(&$0, InheritedTypeSyntax.self, self.visit)
-      }
+      return self.visitInheritedTypeSyntaxImpl(_:)
     case .initializerClause:
-      return {
-        self.visitImpl(&$0, InitializerClauseSyntax.self, self.visit)
-      }
+      return self.visitInitializerClauseSyntaxImpl(_:)
     case .initializerDecl:
-      return {
-        self.visitImpl(&$0, InitializerDeclSyntax.self, self.visit)
-      }
+      return self.visitInitializerDeclSyntaxImpl(_:)
     case .integerLiteralExpr:
-      return {
-        self.visitImpl(&$0, IntegerLiteralExprSyntax.self, self.visit)
-      }
+      return self.visitIntegerLiteralExprSyntaxImpl(_:)
     case .isExpr:
-      return {
-        self.visitImpl(&$0, IsExprSyntax.self, self.visit)
-      }
+      return self.visitIsExprSyntaxImpl(_:)
     case .isTypePattern:
-      return {
-        self.visitImpl(&$0, IsTypePatternSyntax.self, self.visit)
-      }
+      return self.visitIsTypePatternSyntaxImpl(_:)
     case .keyPathComponentList:
-      return {
-        self.visitImpl(&$0, KeyPathComponentListSyntax.self, self.visit)
-      }
+      return self.visitKeyPathComponentListSyntaxImpl(_:)
     case .keyPathComponent:
-      return {
-        self.visitImpl(&$0, KeyPathComponentSyntax.self, self.visit)
-      }
+      return self.visitKeyPathComponentSyntaxImpl(_:)
     case .keyPathExpr:
-      return {
-        self.visitImpl(&$0, KeyPathExprSyntax.self, self.visit)
-      }
+      return self.visitKeyPathExprSyntaxImpl(_:)
     case .keyPathOptionalComponent:
-      return {
-        self.visitImpl(&$0, KeyPathOptionalComponentSyntax.self, self.visit)
-      }
+      return self.visitKeyPathOptionalComponentSyntaxImpl(_:)
     case .keyPathPropertyComponent:
-      return {
-        self.visitImpl(&$0, KeyPathPropertyComponentSyntax.self, self.visit)
-      }
+      return self.visitKeyPathPropertyComponentSyntaxImpl(_:)
     case .keyPathSubscriptComponent:
-      return {
-        self.visitImpl(&$0, KeyPathSubscriptComponentSyntax.self, self.visit)
-      }
+      return self.visitKeyPathSubscriptComponentSyntaxImpl(_:)
     case .labeledExprList:
-      return {
-        self.visitImpl(&$0, LabeledExprListSyntax.self, self.visit)
-      }
+      return self.visitLabeledExprListSyntaxImpl(_:)
     case .labeledExpr:
-      return {
-        self.visitImpl(&$0, LabeledExprSyntax.self, self.visit)
-      }
+      return self.visitLabeledExprSyntaxImpl(_:)
     case .labeledSpecializeArgument:
-      return {
-        self.visitImpl(&$0, LabeledSpecializeArgumentSyntax.self, self.visit)
-      }
+      return self.visitLabeledSpecializeArgumentSyntaxImpl(_:)
     case .labeledStmt:
-      return {
-        self.visitImpl(&$0, LabeledStmtSyntax.self, self.visit)
-      }
+      return self.visitLabeledStmtSyntaxImpl(_:)
     case .layoutRequirement:
-      return {
-        self.visitImpl(&$0, LayoutRequirementSyntax.self, self.visit)
-      }
+      return self.visitLayoutRequirementSyntaxImpl(_:)
     case .lifetimeSpecifierArgumentList:
-      return {
-        self.visitImpl(&$0, LifetimeSpecifierArgumentListSyntax.self, self.visit)
-      }
+      return self.visitLifetimeSpecifierArgumentListSyntaxImpl(_:)
     case .lifetimeSpecifierArgument:
-      return {
-        self.visitImpl(&$0, LifetimeSpecifierArgumentSyntax.self, self.visit)
-      }
+      return self.visitLifetimeSpecifierArgumentSyntaxImpl(_:)
     case .lifetimeTypeSpecifier:
-      return {
-        self.visitImpl(&$0, LifetimeTypeSpecifierSyntax.self, self.visit)
-      }
+      return self.visitLifetimeTypeSpecifierSyntaxImpl(_:)
     case .macroDecl:
-      return {
-        self.visitImpl(&$0, MacroDeclSyntax.self, self.visit)
-      }
+      return self.visitMacroDeclSyntaxImpl(_:)
     case .macroExpansionDecl:
-      return {
-        self.visitImpl(&$0, MacroExpansionDeclSyntax.self, self.visit)
-      }
+      return self.visitMacroExpansionDeclSyntaxImpl(_:)
     case .macroExpansionExpr:
-      return {
-        self.visitImpl(&$0, MacroExpansionExprSyntax.self, self.visit)
-      }
+      return self.visitMacroExpansionExprSyntaxImpl(_:)
     case .matchingPatternCondition:
-      return {
-        self.visitImpl(&$0, MatchingPatternConditionSyntax.self, self.visit)
-      }
+      return self.visitMatchingPatternConditionSyntaxImpl(_:)
     case .memberAccessExpr:
-      return {
-        self.visitImpl(&$0, MemberAccessExprSyntax.self, self.visit)
-      }
+      return self.visitMemberAccessExprSyntaxImpl(_:)
     case .memberBlockItemList:
-      return {
-        self.visitImpl(&$0, MemberBlockItemListSyntax.self, self.visit)
-      }
+      return self.visitMemberBlockItemListSyntaxImpl(_:)
     case .memberBlockItem:
-      return {
-        self.visitImpl(&$0, MemberBlockItemSyntax.self, self.visit)
-      }
+      return self.visitMemberBlockItemSyntaxImpl(_:)
     case .memberBlock:
-      return {
-        self.visitImpl(&$0, MemberBlockSyntax.self, self.visit)
-      }
+      return self.visitMemberBlockSyntaxImpl(_:)
     case .memberType:
-      return {
-        self.visitImpl(&$0, MemberTypeSyntax.self, self.visit)
-      }
+      return self.visitMemberTypeSyntaxImpl(_:)
     case .metatypeType:
-      return {
-        self.visitImpl(&$0, MetatypeTypeSyntax.self, self.visit)
-      }
+      return self.visitMetatypeTypeSyntaxImpl(_:)
     case .missingDecl:
-      return {
-        self.visitImpl(&$0, MissingDeclSyntax.self, self.visit)
-      }
+      return self.visitMissingDeclSyntaxImpl(_:)
     case .missingExpr:
-      return {
-        self.visitImpl(&$0, MissingExprSyntax.self, self.visit)
-      }
+      return self.visitMissingExprSyntaxImpl(_:)
     case .missingPattern:
-      return {
-        self.visitImpl(&$0, MissingPatternSyntax.self, self.visit)
-      }
+      return self.visitMissingPatternSyntaxImpl(_:)
     case .missingStmt:
-      return {
-        self.visitImpl(&$0, MissingStmtSyntax.self, self.visit)
-      }
+      return self.visitMissingStmtSyntaxImpl(_:)
     case .missing:
-      return {
-        self.visitImpl(&$0, MissingSyntax.self, self.visit)
-      }
+      return self.visitMissingSyntaxImpl(_:)
     case .missingType:
-      return {
-        self.visitImpl(&$0, MissingTypeSyntax.self, self.visit)
-      }
+      return self.visitMissingTypeSyntaxImpl(_:)
     case .multipleTrailingClosureElementList:
-      return {
-        self.visitImpl(&$0, MultipleTrailingClosureElementListSyntax.self, self.visit)
-      }
+      return self.visitMultipleTrailingClosureElementListSyntaxImpl(_:)
     case .multipleTrailingClosureElement:
-      return {
-        self.visitImpl(&$0, MultipleTrailingClosureElementSyntax.self, self.visit)
-      }
+      return self.visitMultipleTrailingClosureElementSyntaxImpl(_:)
     case .namedOpaqueReturnType:
-      return {
-        self.visitImpl(&$0, NamedOpaqueReturnTypeSyntax.self, self.visit)
-      }
+      return self.visitNamedOpaqueReturnTypeSyntaxImpl(_:)
     case .nilLiteralExpr:
-      return {
-        self.visitImpl(&$0, NilLiteralExprSyntax.self, self.visit)
-      }
+      return self.visitNilLiteralExprSyntaxImpl(_:)
     case .objCSelectorPieceList:
-      return {
-        self.visitImpl(&$0, ObjCSelectorPieceListSyntax.self, self.visit)
-      }
+      return self.visitObjCSelectorPieceListSyntaxImpl(_:)
     case .objCSelectorPiece:
-      return {
-        self.visitImpl(&$0, ObjCSelectorPieceSyntax.self, self.visit)
-      }
+      return self.visitObjCSelectorPieceSyntaxImpl(_:)
     case .opaqueReturnTypeOfAttributeArguments:
-      return {
-        self.visitImpl(&$0, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitOpaqueReturnTypeOfAttributeArgumentsSyntaxImpl(_:)
     case .operatorDecl:
-      return {
-        self.visitImpl(&$0, OperatorDeclSyntax.self, self.visit)
-      }
+      return self.visitOperatorDeclSyntaxImpl(_:)
     case .operatorPrecedenceAndTypes:
-      return {
-        self.visitImpl(&$0, OperatorPrecedenceAndTypesSyntax.self, self.visit)
-      }
+      return self.visitOperatorPrecedenceAndTypesSyntaxImpl(_:)
     case .optionalBindingCondition:
-      return {
-        self.visitImpl(&$0, OptionalBindingConditionSyntax.self, self.visit)
-      }
+      return self.visitOptionalBindingConditionSyntaxImpl(_:)
     case .optionalChainingExpr:
-      return {
-        self.visitImpl(&$0, OptionalChainingExprSyntax.self, self.visit)
-      }
+      return self.visitOptionalChainingExprSyntaxImpl(_:)
     case .optionalType:
-      return {
-        self.visitImpl(&$0, OptionalTypeSyntax.self, self.visit)
-      }
+      return self.visitOptionalTypeSyntaxImpl(_:)
     case .originallyDefinedInAttributeArguments:
-      return {
-        self.visitImpl(&$0, OriginallyDefinedInAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitOriginallyDefinedInAttributeArgumentsSyntaxImpl(_:)
     case .packElementExpr:
-      return {
-        self.visitImpl(&$0, PackElementExprSyntax.self, self.visit)
-      }
+      return self.visitPackElementExprSyntaxImpl(_:)
     case .packElementType:
-      return {
-        self.visitImpl(&$0, PackElementTypeSyntax.self, self.visit)
-      }
+      return self.visitPackElementTypeSyntaxImpl(_:)
     case .packExpansionExpr:
-      return {
-        self.visitImpl(&$0, PackExpansionExprSyntax.self, self.visit)
-      }
+      return self.visitPackExpansionExprSyntaxImpl(_:)
     case .packExpansionType:
-      return {
-        self.visitImpl(&$0, PackExpansionTypeSyntax.self, self.visit)
-      }
+      return self.visitPackExpansionTypeSyntaxImpl(_:)
     case .patternBindingList:
-      return {
-        self.visitImpl(&$0, PatternBindingListSyntax.self, self.visit)
-      }
+      return self.visitPatternBindingListSyntaxImpl(_:)
     case .patternBinding:
-      return {
-        self.visitImpl(&$0, PatternBindingSyntax.self, self.visit)
-      }
+      return self.visitPatternBindingSyntaxImpl(_:)
     case .patternExpr:
-      return {
-        self.visitImpl(&$0, PatternExprSyntax.self, self.visit)
-      }
+      return self.visitPatternExprSyntaxImpl(_:)
     case .platformVersionItemList:
-      return {
-        self.visitImpl(&$0, PlatformVersionItemListSyntax.self, self.visit)
-      }
+      return self.visitPlatformVersionItemListSyntaxImpl(_:)
     case .platformVersionItem:
-      return {
-        self.visitImpl(&$0, PlatformVersionItemSyntax.self, self.visit)
-      }
+      return self.visitPlatformVersionItemSyntaxImpl(_:)
     case .platformVersion:
-      return {
-        self.visitImpl(&$0, PlatformVersionSyntax.self, self.visit)
-      }
+      return self.visitPlatformVersionSyntaxImpl(_:)
     case .postfixIfConfigExpr:
-      return {
-        self.visitImpl(&$0, PostfixIfConfigExprSyntax.self, self.visit)
-      }
+      return self.visitPostfixIfConfigExprSyntaxImpl(_:)
     case .postfixOperatorExpr:
-      return {
-        self.visitImpl(&$0, PostfixOperatorExprSyntax.self, self.visit)
-      }
+      return self.visitPostfixOperatorExprSyntaxImpl(_:)
     case .poundSourceLocationArguments:
-      return {
-        self.visitImpl(&$0, PoundSourceLocationArgumentsSyntax.self, self.visit)
-      }
+      return self.visitPoundSourceLocationArgumentsSyntaxImpl(_:)
     case .poundSourceLocation:
-      return {
-        self.visitImpl(&$0, PoundSourceLocationSyntax.self, self.visit)
-      }
+      return self.visitPoundSourceLocationSyntaxImpl(_:)
     case .precedenceGroupAssignment:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupAssignmentSyntax.self, self.visit)
-      }
+      return self.visitPrecedenceGroupAssignmentSyntaxImpl(_:)
     case .precedenceGroupAssociativity:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupAssociativitySyntax.self, self.visit)
-      }
+      return self.visitPrecedenceGroupAssociativitySyntaxImpl(_:)
     case .precedenceGroupAttributeList:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupAttributeListSyntax.self, self.visit)
-      }
+      return self.visitPrecedenceGroupAttributeListSyntaxImpl(_:)
     case .precedenceGroupDecl:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupDeclSyntax.self, self.visit)
-      }
+      return self.visitPrecedenceGroupDeclSyntaxImpl(_:)
     case .precedenceGroupNameList:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupNameListSyntax.self, self.visit)
-      }
+      return self.visitPrecedenceGroupNameListSyntaxImpl(_:)
     case .precedenceGroupName:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupNameSyntax.self, self.visit)
-      }
+      return self.visitPrecedenceGroupNameSyntaxImpl(_:)
     case .precedenceGroupRelation:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupRelationSyntax.self, self.visit)
-      }
+      return self.visitPrecedenceGroupRelationSyntaxImpl(_:)
     case .prefixOperatorExpr:
-      return {
-        self.visitImpl(&$0, PrefixOperatorExprSyntax.self, self.visit)
-      }
+      return self.visitPrefixOperatorExprSyntaxImpl(_:)
     case .primaryAssociatedTypeClause:
-      return {
-        self.visitImpl(&$0, PrimaryAssociatedTypeClauseSyntax.self, self.visit)
-      }
+      return self.visitPrimaryAssociatedTypeClauseSyntaxImpl(_:)
     case .primaryAssociatedTypeList:
-      return {
-        self.visitImpl(&$0, PrimaryAssociatedTypeListSyntax.self, self.visit)
-      }
+      return self.visitPrimaryAssociatedTypeListSyntaxImpl(_:)
     case .primaryAssociatedType:
-      return {
-        self.visitImpl(&$0, PrimaryAssociatedTypeSyntax.self, self.visit)
-      }
+      return self.visitPrimaryAssociatedTypeSyntaxImpl(_:)
     case .protocolDecl:
-      return {
-        self.visitImpl(&$0, ProtocolDeclSyntax.self, self.visit)
-      }
+      return self.visitProtocolDeclSyntaxImpl(_:)
     case .regexLiteralExpr:
-      return {
-        self.visitImpl(&$0, RegexLiteralExprSyntax.self, self.visit)
-      }
+      return self.visitRegexLiteralExprSyntaxImpl(_:)
     case .repeatStmt:
-      return {
-        self.visitImpl(&$0, RepeatStmtSyntax.self, self.visit)
-      }
+      return self.visitRepeatStmtSyntaxImpl(_:)
     case .returnClause:
-      return {
-        self.visitImpl(&$0, ReturnClauseSyntax.self, self.visit)
-      }
+      return self.visitReturnClauseSyntaxImpl(_:)
     case .returnStmt:
-      return {
-        self.visitImpl(&$0, ReturnStmtSyntax.self, self.visit)
-      }
+      return self.visitReturnStmtSyntaxImpl(_:)
     case .sameTypeRequirement:
-      return {
-        self.visitImpl(&$0, SameTypeRequirementSyntax.self, self.visit)
-      }
+      return self.visitSameTypeRequirementSyntaxImpl(_:)
     case .sequenceExpr:
-      return {
-        self.visitImpl(&$0, SequenceExprSyntax.self, self.visit)
-      }
+      return self.visitSequenceExprSyntaxImpl(_:)
     case .simpleStringLiteralExpr:
-      return {
-        self.visitImpl(&$0, SimpleStringLiteralExprSyntax.self, self.visit)
-      }
+      return self.visitSimpleStringLiteralExprSyntaxImpl(_:)
     case .simpleStringLiteralSegmentList:
-      return {
-        self.visitImpl(&$0, SimpleStringLiteralSegmentListSyntax.self, self.visit)
-      }
+      return self.visitSimpleStringLiteralSegmentListSyntaxImpl(_:)
     case .simpleTypeSpecifier:
-      return {
-        self.visitImpl(&$0, SimpleTypeSpecifierSyntax.self, self.visit)
-      }
+      return self.visitSimpleTypeSpecifierSyntaxImpl(_:)
     case .someOrAnyType:
-      return {
-        self.visitImpl(&$0, SomeOrAnyTypeSyntax.self, self.visit)
-      }
+      return self.visitSomeOrAnyTypeSyntaxImpl(_:)
     case .sourceFile:
-      return {
-        self.visitImpl(&$0, SourceFileSyntax.self, self.visit)
-      }
+      return self.visitSourceFileSyntaxImpl(_:)
     case .specializeAttributeArgumentList:
-      return {
-        self.visitImpl(&$0, SpecializeAttributeArgumentListSyntax.self, self.visit)
-      }
+      return self.visitSpecializeAttributeArgumentListSyntaxImpl(_:)
     case .specializeAvailabilityArgument:
-      return {
-        self.visitImpl(&$0, SpecializeAvailabilityArgumentSyntax.self, self.visit)
-      }
+      return self.visitSpecializeAvailabilityArgumentSyntaxImpl(_:)
     case .specializeTargetFunctionArgument:
-      return {
-        self.visitImpl(&$0, SpecializeTargetFunctionArgumentSyntax.self, self.visit)
-      }
+      return self.visitSpecializeTargetFunctionArgumentSyntaxImpl(_:)
     case .stringLiteralExpr:
-      return {
-        self.visitImpl(&$0, StringLiteralExprSyntax.self, self.visit)
-      }
+      return self.visitStringLiteralExprSyntaxImpl(_:)
     case .stringLiteralSegmentList:
-      return {
-        self.visitImpl(&$0, StringLiteralSegmentListSyntax.self, self.visit)
-      }
+      return self.visitStringLiteralSegmentListSyntaxImpl(_:)
     case .stringSegment:
-      return {
-        self.visitImpl(&$0, StringSegmentSyntax.self, self.visit)
-      }
+      return self.visitStringSegmentSyntaxImpl(_:)
     case .structDecl:
-      return {
-        self.visitImpl(&$0, StructDeclSyntax.self, self.visit)
-      }
+      return self.visitStructDeclSyntaxImpl(_:)
     case .subscriptCallExpr:
-      return {
-        self.visitImpl(&$0, SubscriptCallExprSyntax.self, self.visit)
-      }
+      return self.visitSubscriptCallExprSyntaxImpl(_:)
     case .subscriptDecl:
-      return {
-        self.visitImpl(&$0, SubscriptDeclSyntax.self, self.visit)
-      }
+      return self.visitSubscriptDeclSyntaxImpl(_:)
     case .superExpr:
-      return {
-        self.visitImpl(&$0, SuperExprSyntax.self, self.visit)
-      }
+      return self.visitSuperExprSyntaxImpl(_:)
     case .suppressedType:
-      return {
-        self.visitImpl(&$0, SuppressedTypeSyntax.self, self.visit)
-      }
+      return self.visitSuppressedTypeSyntaxImpl(_:)
     case .switchCaseItemList:
-      return {
-        self.visitImpl(&$0, SwitchCaseItemListSyntax.self, self.visit)
-      }
+      return self.visitSwitchCaseItemListSyntaxImpl(_:)
     case .switchCaseItem:
-      return {
-        self.visitImpl(&$0, SwitchCaseItemSyntax.self, self.visit)
-      }
+      return self.visitSwitchCaseItemSyntaxImpl(_:)
     case .switchCaseLabel:
-      return {
-        self.visitImpl(&$0, SwitchCaseLabelSyntax.self, self.visit)
-      }
+      return self.visitSwitchCaseLabelSyntaxImpl(_:)
     case .switchCaseList:
-      return {
-        self.visitImpl(&$0, SwitchCaseListSyntax.self, self.visit)
-      }
+      return self.visitSwitchCaseListSyntaxImpl(_:)
     case .switchCase:
-      return {
-        self.visitImpl(&$0, SwitchCaseSyntax.self, self.visit)
-      }
+      return self.visitSwitchCaseSyntaxImpl(_:)
     case .switchDefaultLabel:
-      return {
-        self.visitImpl(&$0, SwitchDefaultLabelSyntax.self, self.visit)
-      }
+      return self.visitSwitchDefaultLabelSyntaxImpl(_:)
     case .switchExpr:
-      return {
-        self.visitImpl(&$0, SwitchExprSyntax.self, self.visit)
-      }
+      return self.visitSwitchExprSyntaxImpl(_:)
     case .ternaryExpr:
-      return {
-        self.visitImpl(&$0, TernaryExprSyntax.self, self.visit)
-      }
+      return self.visitTernaryExprSyntaxImpl(_:)
     case .thenStmt:
-      return {
-        self.visitImpl(&$0, ThenStmtSyntax.self, self.visit)
-      }
+      return self.visitThenStmtSyntaxImpl(_:)
     case .throwStmt:
-      return {
-        self.visitImpl(&$0, ThrowStmtSyntax.self, self.visit)
-      }
+      return self.visitThrowStmtSyntaxImpl(_:)
     case .throwsClause:
-      return {
-        self.visitImpl(&$0, ThrowsClauseSyntax.self, self.visit)
-      }
+      return self.visitThrowsClauseSyntaxImpl(_:)
     case .tryExpr:
-      return {
-        self.visitImpl(&$0, TryExprSyntax.self, self.visit)
-      }
+      return self.visitTryExprSyntaxImpl(_:)
     case .tupleExpr:
-      return {
-        self.visitImpl(&$0, TupleExprSyntax.self, self.visit)
-      }
+      return self.visitTupleExprSyntaxImpl(_:)
     case .tuplePatternElementList:
-      return {
-        self.visitImpl(&$0, TuplePatternElementListSyntax.self, self.visit)
-      }
+      return self.visitTuplePatternElementListSyntaxImpl(_:)
     case .tuplePatternElement:
-      return {
-        self.visitImpl(&$0, TuplePatternElementSyntax.self, self.visit)
-      }
+      return self.visitTuplePatternElementSyntaxImpl(_:)
     case .tuplePattern:
-      return {
-        self.visitImpl(&$0, TuplePatternSyntax.self, self.visit)
-      }
+      return self.visitTuplePatternSyntaxImpl(_:)
     case .tupleTypeElementList:
-      return {
-        self.visitImpl(&$0, TupleTypeElementListSyntax.self, self.visit)
-      }
+      return self.visitTupleTypeElementListSyntaxImpl(_:)
     case .tupleTypeElement:
-      return {
-        self.visitImpl(&$0, TupleTypeElementSyntax.self, self.visit)
-      }
+      return self.visitTupleTypeElementSyntaxImpl(_:)
     case .tupleType:
-      return {
-        self.visitImpl(&$0, TupleTypeSyntax.self, self.visit)
-      }
+      return self.visitTupleTypeSyntaxImpl(_:)
     case .typeAliasDecl:
-      return {
-        self.visitImpl(&$0, TypeAliasDeclSyntax.self, self.visit)
-      }
+      return self.visitTypeAliasDeclSyntaxImpl(_:)
     case .typeAnnotation:
-      return {
-        self.visitImpl(&$0, TypeAnnotationSyntax.self, self.visit)
-      }
+      return self.visitTypeAnnotationSyntaxImpl(_:)
     case .typeEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, TypeEffectSpecifiersSyntax.self, self.visit)
-      }
+      return self.visitTypeEffectSpecifiersSyntaxImpl(_:)
     case .typeExpr:
-      return {
-        self.visitImpl(&$0, TypeExprSyntax.self, self.visit)
-      }
+      return self.visitTypeExprSyntaxImpl(_:)
     case .typeInitializerClause:
-      return {
-        self.visitImpl(&$0, TypeInitializerClauseSyntax.self, self.visit)
-      }
+      return self.visitTypeInitializerClauseSyntaxImpl(_:)
     case .typeSpecifierList:
-      return {
-        self.visitImpl(&$0, TypeSpecifierListSyntax.self, self.visit)
-      }
+      return self.visitTypeSpecifierListSyntaxImpl(_:)
     case .unavailableFromAsyncAttributeArguments:
-      return {
-        self.visitImpl(&$0, UnavailableFromAsyncAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitUnavailableFromAsyncAttributeArgumentsSyntaxImpl(_:)
     case .underscorePrivateAttributeArguments:
-      return {
-        self.visitImpl(&$0, UnderscorePrivateAttributeArgumentsSyntax.self, self.visit)
-      }
+      return self.visitUnderscorePrivateAttributeArgumentsSyntaxImpl(_:)
     case .unexpectedNodes:
-      return {
-        self.visitImpl(&$0, UnexpectedNodesSyntax.self, self.visit)
-      }
+      return self.visitUnexpectedNodesSyntaxImpl(_:)
     case .unresolvedAsExpr:
-      return {
-        self.visitImpl(&$0, UnresolvedAsExprSyntax.self, self.visit)
-      }
+      return self.visitUnresolvedAsExprSyntaxImpl(_:)
     case .unresolvedIsExpr:
-      return {
-        self.visitImpl(&$0, UnresolvedIsExprSyntax.self, self.visit)
-      }
+      return self.visitUnresolvedIsExprSyntaxImpl(_:)
     case .unresolvedTernaryExpr:
-      return {
-        self.visitImpl(&$0, UnresolvedTernaryExprSyntax.self, self.visit)
-      }
+      return self.visitUnresolvedTernaryExprSyntaxImpl(_:)
     case .valueBindingPattern:
-      return {
-        self.visitImpl(&$0, ValueBindingPatternSyntax.self, self.visit)
-      }
+      return self.visitValueBindingPatternSyntaxImpl(_:)
     case .variableDecl:
-      return {
-        self.visitImpl(&$0, VariableDeclSyntax.self, self.visit)
-      }
+      return self.visitVariableDeclSyntaxImpl(_:)
     case .versionComponentList:
-      return {
-        self.visitImpl(&$0, VersionComponentListSyntax.self, self.visit)
-      }
+      return self.visitVersionComponentListSyntaxImpl(_:)
     case .versionComponent:
-      return {
-        self.visitImpl(&$0, VersionComponentSyntax.self, self.visit)
-      }
+      return self.visitVersionComponentSyntaxImpl(_:)
     case .versionTuple:
-      return {
-        self.visitImpl(&$0, VersionTupleSyntax.self, self.visit)
-      }
+      return self.visitVersionTupleSyntaxImpl(_:)
     case .whereClause:
-      return {
-        self.visitImpl(&$0, WhereClauseSyntax.self, self.visit)
-      }
+      return self.visitWhereClauseSyntaxImpl(_:)
     case .whileStmt:
-      return {
-        self.visitImpl(&$0, WhileStmtSyntax.self, self.visit)
-      }
+      return self.visitWhileStmtSyntaxImpl(_:)
     case .wildcardPattern:
-      return {
-        self.visitImpl(&$0, WildcardPatternSyntax.self, self.visit)
-      }
+      return self.visitWildcardPatternSyntaxImpl(_:)
     case .yieldStmt:
-      return {
-        self.visitImpl(&$0, YieldStmtSyntax.self, self.visit)
-      }
+      return self.visitYieldStmtSyntaxImpl(_:)
     case .yieldedExpressionList:
-      return {
-        self.visitImpl(&$0, YieldedExpressionListSyntax.self, self.visit)
-      }
+      return self.visitYieldedExpressionListSyntaxImpl(_:)
     case .yieldedExpression:
-      return {
-        self.visitImpl(&$0, YieldedExpressionSyntax.self, self.visit)
-      }
+      return self.visitYieldedExpressionSyntaxImpl(_:)
     case .yieldedExpressionsClause:
-      return {
-        self.visitImpl(&$0, YieldedExpressionsClauseSyntax.self, self.visit)
-      }
+      return self.visitYieldedExpressionsClauseSyntaxImpl(_:)
     }
   }
-  private func dispatchVisit(_ node: inout Syntax) {
-    visitationFunc(for: node)(&node)
+  private func dispatchVisit(_ node: Syntax) -> Syntax {
+    visitationFunc(for: node)(node)
   }
   #else
-  private func dispatchVisit(_ node: inout Syntax) {
+  private func dispatchVisit(_ node: Syntax) -> Syntax {
     switch node.raw.kind {
     case .token:
-      return visitImpl(&node, TokenSyntax.self, visit)
+      return visitTokenSyntaxImpl(node)
     case .abiAttributeArguments:
-      return visitImpl(&node, ABIAttributeArgumentsSyntax.self, visit)
+      return visitABIAttributeArgumentsSyntaxImpl(node)
     case .accessorBlock:
-      return visitImpl(&node, AccessorBlockSyntax.self, visit)
+      return visitAccessorBlockSyntaxImpl(node)
     case .accessorDeclList:
-      return visitImpl(&node, AccessorDeclListSyntax.self, visit)
+      return visitAccessorDeclListSyntaxImpl(node)
     case .accessorDecl:
-      return visitImpl(&node, AccessorDeclSyntax.self, visit)
+      return visitAccessorDeclSyntaxImpl(node)
     case .accessorEffectSpecifiers:
-      return visitImpl(&node, AccessorEffectSpecifiersSyntax.self, visit)
+      return visitAccessorEffectSpecifiersSyntaxImpl(node)
     case .accessorParameters:
-      return visitImpl(&node, AccessorParametersSyntax.self, visit)
+      return visitAccessorParametersSyntaxImpl(node)
     case .actorDecl:
-      return visitImpl(&node, ActorDeclSyntax.self, visit)
+      return visitActorDeclSyntaxImpl(node)
     case .arrayElementList:
-      return visitImpl(&node, ArrayElementListSyntax.self, visit)
+      return visitArrayElementListSyntaxImpl(node)
     case .arrayElement:
-      return visitImpl(&node, ArrayElementSyntax.self, visit)
+      return visitArrayElementSyntaxImpl(node)
     case .arrayExpr:
-      return visitImpl(&node, ArrayExprSyntax.self, visit)
+      return visitArrayExprSyntaxImpl(node)
     case .arrayType:
-      return visitImpl(&node, ArrayTypeSyntax.self, visit)
+      return visitArrayTypeSyntaxImpl(node)
     case .arrowExpr:
-      return visitImpl(&node, ArrowExprSyntax.self, visit)
+      return visitArrowExprSyntaxImpl(node)
     case .asExpr:
-      return visitImpl(&node, AsExprSyntax.self, visit)
+      return visitAsExprSyntaxImpl(node)
     case .assignmentExpr:
-      return visitImpl(&node, AssignmentExprSyntax.self, visit)
+      return visitAssignmentExprSyntaxImpl(node)
     case .associatedTypeDecl:
-      return visitImpl(&node, AssociatedTypeDeclSyntax.self, visit)
+      return visitAssociatedTypeDeclSyntaxImpl(node)
     case .attributeList:
-      return visitImpl(&node, AttributeListSyntax.self, visit)
+      return visitAttributeListSyntaxImpl(node)
     case .attribute:
-      return visitImpl(&node, AttributeSyntax.self, visit)
+      return visitAttributeSyntaxImpl(node)
     case .attributedType:
-      return visitImpl(&node, AttributedTypeSyntax.self, visit)
+      return visitAttributedTypeSyntaxImpl(node)
     case .availabilityArgumentList:
-      return visitImpl(&node, AvailabilityArgumentListSyntax.self, visit)
+      return visitAvailabilityArgumentListSyntaxImpl(node)
     case .availabilityArgument:
-      return visitImpl(&node, AvailabilityArgumentSyntax.self, visit)
+      return visitAvailabilityArgumentSyntaxImpl(node)
     case .availabilityCondition:
-      return visitImpl(&node, AvailabilityConditionSyntax.self, visit)
+      return visitAvailabilityConditionSyntaxImpl(node)
     case .availabilityLabeledArgument:
-      return visitImpl(&node, AvailabilityLabeledArgumentSyntax.self, visit)
+      return visitAvailabilityLabeledArgumentSyntaxImpl(node)
     case .awaitExpr:
-      return visitImpl(&node, AwaitExprSyntax.self, visit)
+      return visitAwaitExprSyntaxImpl(node)
     case .backDeployedAttributeArguments:
-      return visitImpl(&node, BackDeployedAttributeArgumentsSyntax.self, visit)
+      return visitBackDeployedAttributeArgumentsSyntaxImpl(node)
     case .binaryOperatorExpr:
-      return visitImpl(&node, BinaryOperatorExprSyntax.self, visit)
+      return visitBinaryOperatorExprSyntaxImpl(node)
     case .booleanLiteralExpr:
-      return visitImpl(&node, BooleanLiteralExprSyntax.self, visit)
+      return visitBooleanLiteralExprSyntaxImpl(node)
     case .borrowExpr:
-      return visitImpl(&node, BorrowExprSyntax.self, visit)
+      return visitBorrowExprSyntaxImpl(node)
     case .breakStmt:
-      return visitImpl(&node, BreakStmtSyntax.self, visit)
+      return visitBreakStmtSyntaxImpl(node)
     case ._canImportExpr:
-      return visitImpl(&node, _CanImportExprSyntax.self, visit)
+      return visit_CanImportExprSyntaxImpl(node)
     case ._canImportVersionInfo:
-      return visitImpl(&node, _CanImportVersionInfoSyntax.self, visit)
+      return visit_CanImportVersionInfoSyntaxImpl(node)
     case .catchClauseList:
-      return visitImpl(&node, CatchClauseListSyntax.self, visit)
+      return visitCatchClauseListSyntaxImpl(node)
     case .catchClause:
-      return visitImpl(&node, CatchClauseSyntax.self, visit)
+      return visitCatchClauseSyntaxImpl(node)
     case .catchItemList:
-      return visitImpl(&node, CatchItemListSyntax.self, visit)
+      return visitCatchItemListSyntaxImpl(node)
     case .catchItem:
-      return visitImpl(&node, CatchItemSyntax.self, visit)
+      return visitCatchItemSyntaxImpl(node)
     case .classDecl:
-      return visitImpl(&node, ClassDeclSyntax.self, visit)
+      return visitClassDeclSyntaxImpl(node)
     case .classRestrictionType:
-      return visitImpl(&node, ClassRestrictionTypeSyntax.self, visit)
+      return visitClassRestrictionTypeSyntaxImpl(node)
     case .closureCaptureClause:
-      return visitImpl(&node, ClosureCaptureClauseSyntax.self, visit)
+      return visitClosureCaptureClauseSyntaxImpl(node)
     case .closureCaptureList:
-      return visitImpl(&node, ClosureCaptureListSyntax.self, visit)
+      return visitClosureCaptureListSyntaxImpl(node)
     case .closureCaptureSpecifier:
-      return visitImpl(&node, ClosureCaptureSpecifierSyntax.self, visit)
+      return visitClosureCaptureSpecifierSyntaxImpl(node)
     case .closureCapture:
-      return visitImpl(&node, ClosureCaptureSyntax.self, visit)
+      return visitClosureCaptureSyntaxImpl(node)
     case .closureExpr:
-      return visitImpl(&node, ClosureExprSyntax.self, visit)
+      return visitClosureExprSyntaxImpl(node)
     case .closureParameterClause:
-      return visitImpl(&node, ClosureParameterClauseSyntax.self, visit)
+      return visitClosureParameterClauseSyntaxImpl(node)
     case .closureParameterList:
-      return visitImpl(&node, ClosureParameterListSyntax.self, visit)
+      return visitClosureParameterListSyntaxImpl(node)
     case .closureParameter:
-      return visitImpl(&node, ClosureParameterSyntax.self, visit)
+      return visitClosureParameterSyntaxImpl(node)
     case .closureShorthandParameterList:
-      return visitImpl(&node, ClosureShorthandParameterListSyntax.self, visit)
+      return visitClosureShorthandParameterListSyntaxImpl(node)
     case .closureShorthandParameter:
-      return visitImpl(&node, ClosureShorthandParameterSyntax.self, visit)
+      return visitClosureShorthandParameterSyntaxImpl(node)
     case .closureSignature:
-      return visitImpl(&node, ClosureSignatureSyntax.self, visit)
+      return visitClosureSignatureSyntaxImpl(node)
     case .codeBlockItemList:
-      return visitImpl(&node, CodeBlockItemListSyntax.self, visit)
+      return visitCodeBlockItemListSyntaxImpl(node)
     case .codeBlockItem:
-      return visitImpl(&node, CodeBlockItemSyntax.self, visit)
+      return visitCodeBlockItemSyntaxImpl(node)
     case .codeBlock:
-      return visitImpl(&node, CodeBlockSyntax.self, visit)
+      return visitCodeBlockSyntaxImpl(node)
     case .compositionTypeElementList:
-      return visitImpl(&node, CompositionTypeElementListSyntax.self, visit)
+      return visitCompositionTypeElementListSyntaxImpl(node)
     case .compositionTypeElement:
-      return visitImpl(&node, CompositionTypeElementSyntax.self, visit)
+      return visitCompositionTypeElementSyntaxImpl(node)
     case .compositionType:
-      return visitImpl(&node, CompositionTypeSyntax.self, visit)
+      return visitCompositionTypeSyntaxImpl(node)
     case .conditionElementList:
-      return visitImpl(&node, ConditionElementListSyntax.self, visit)
+      return visitConditionElementListSyntaxImpl(node)
     case .conditionElement:
-      return visitImpl(&node, ConditionElementSyntax.self, visit)
+      return visitConditionElementSyntaxImpl(node)
     case .conformanceRequirement:
-      return visitImpl(&node, ConformanceRequirementSyntax.self, visit)
+      return visitConformanceRequirementSyntaxImpl(node)
     case .consumeExpr:
-      return visitImpl(&node, ConsumeExprSyntax.self, visit)
+      return visitConsumeExprSyntaxImpl(node)
     case .continueStmt:
-      return visitImpl(&node, ContinueStmtSyntax.self, visit)
+      return visitContinueStmtSyntaxImpl(node)
     case .conventionAttributeArguments:
-      return visitImpl(&node, ConventionAttributeArgumentsSyntax.self, visit)
+      return visitConventionAttributeArgumentsSyntaxImpl(node)
     case .conventionWitnessMethodAttributeArguments:
-      return visitImpl(&node, ConventionWitnessMethodAttributeArgumentsSyntax.self, visit)
+      return visitConventionWitnessMethodAttributeArgumentsSyntaxImpl(node)
     case .copyExpr:
-      return visitImpl(&node, CopyExprSyntax.self, visit)
+      return visitCopyExprSyntaxImpl(node)
     case .declModifierDetail:
-      return visitImpl(&node, DeclModifierDetailSyntax.self, visit)
+      return visitDeclModifierDetailSyntaxImpl(node)
     case .declModifierList:
-      return visitImpl(&node, DeclModifierListSyntax.self, visit)
+      return visitDeclModifierListSyntaxImpl(node)
     case .declModifier:
-      return visitImpl(&node, DeclModifierSyntax.self, visit)
+      return visitDeclModifierSyntaxImpl(node)
     case .declNameArgumentList:
-      return visitImpl(&node, DeclNameArgumentListSyntax.self, visit)
+      return visitDeclNameArgumentListSyntaxImpl(node)
     case .declNameArgument:
-      return visitImpl(&node, DeclNameArgumentSyntax.self, visit)
+      return visitDeclNameArgumentSyntaxImpl(node)
     case .declNameArguments:
-      return visitImpl(&node, DeclNameArgumentsSyntax.self, visit)
+      return visitDeclNameArgumentsSyntaxImpl(node)
     case .declReferenceExpr:
-      return visitImpl(&node, DeclReferenceExprSyntax.self, visit)
+      return visitDeclReferenceExprSyntaxImpl(node)
     case .deferStmt:
-      return visitImpl(&node, DeferStmtSyntax.self, visit)
+      return visitDeferStmtSyntaxImpl(node)
     case .deinitializerDecl:
-      return visitImpl(&node, DeinitializerDeclSyntax.self, visit)
+      return visitDeinitializerDeclSyntaxImpl(node)
     case .deinitializerEffectSpecifiers:
-      return visitImpl(&node, DeinitializerEffectSpecifiersSyntax.self, visit)
+      return visitDeinitializerEffectSpecifiersSyntaxImpl(node)
     case .derivativeAttributeArguments:
-      return visitImpl(&node, DerivativeAttributeArgumentsSyntax.self, visit)
+      return visitDerivativeAttributeArgumentsSyntaxImpl(node)
     case .designatedTypeList:
-      return visitImpl(&node, DesignatedTypeListSyntax.self, visit)
+      return visitDesignatedTypeListSyntaxImpl(node)
     case .designatedType:
-      return visitImpl(&node, DesignatedTypeSyntax.self, visit)
+      return visitDesignatedTypeSyntaxImpl(node)
     case .dictionaryElementList:
-      return visitImpl(&node, DictionaryElementListSyntax.self, visit)
+      return visitDictionaryElementListSyntaxImpl(node)
     case .dictionaryElement:
-      return visitImpl(&node, DictionaryElementSyntax.self, visit)
+      return visitDictionaryElementSyntaxImpl(node)
     case .dictionaryExpr:
-      return visitImpl(&node, DictionaryExprSyntax.self, visit)
+      return visitDictionaryExprSyntaxImpl(node)
     case .dictionaryType:
-      return visitImpl(&node, DictionaryTypeSyntax.self, visit)
+      return visitDictionaryTypeSyntaxImpl(node)
     case .differentiabilityArgumentList:
-      return visitImpl(&node, DifferentiabilityArgumentListSyntax.self, visit)
+      return visitDifferentiabilityArgumentListSyntaxImpl(node)
     case .differentiabilityArgument:
-      return visitImpl(&node, DifferentiabilityArgumentSyntax.self, visit)
+      return visitDifferentiabilityArgumentSyntaxImpl(node)
     case .differentiabilityArguments:
-      return visitImpl(&node, DifferentiabilityArgumentsSyntax.self, visit)
+      return visitDifferentiabilityArgumentsSyntaxImpl(node)
     case .differentiabilityWithRespectToArgument:
-      return visitImpl(&node, DifferentiabilityWithRespectToArgumentSyntax.self, visit)
+      return visitDifferentiabilityWithRespectToArgumentSyntaxImpl(node)
     case .differentiableAttributeArguments:
-      return visitImpl(&node, DifferentiableAttributeArgumentsSyntax.self, visit)
+      return visitDifferentiableAttributeArgumentsSyntaxImpl(node)
     case .discardAssignmentExpr:
-      return visitImpl(&node, DiscardAssignmentExprSyntax.self, visit)
+      return visitDiscardAssignmentExprSyntaxImpl(node)
     case .discardStmt:
-      return visitImpl(&node, DiscardStmtSyntax.self, visit)
+      return visitDiscardStmtSyntaxImpl(node)
     case .doExpr:
-      return visitImpl(&node, DoExprSyntax.self, visit)
+      return visitDoExprSyntaxImpl(node)
     case .doStmt:
-      return visitImpl(&node, DoStmtSyntax.self, visit)
+      return visitDoStmtSyntaxImpl(node)
     case .documentationAttributeArgumentList:
-      return visitImpl(&node, DocumentationAttributeArgumentListSyntax.self, visit)
+      return visitDocumentationAttributeArgumentListSyntaxImpl(node)
     case .documentationAttributeArgument:
-      return visitImpl(&node, DocumentationAttributeArgumentSyntax.self, visit)
+      return visitDocumentationAttributeArgumentSyntaxImpl(node)
     case .dynamicReplacementAttributeArguments:
-      return visitImpl(&node, DynamicReplacementAttributeArgumentsSyntax.self, visit)
+      return visitDynamicReplacementAttributeArgumentsSyntaxImpl(node)
     case .editorPlaceholderDecl:
-      return visitImpl(&node, EditorPlaceholderDeclSyntax.self, visit)
+      return visitEditorPlaceholderDeclSyntaxImpl(node)
     case .editorPlaceholderExpr:
-      return visitImpl(&node, EditorPlaceholderExprSyntax.self, visit)
+      return visitEditorPlaceholderExprSyntaxImpl(node)
     case .effectsAttributeArgumentList:
-      return visitImpl(&node, EffectsAttributeArgumentListSyntax.self, visit)
+      return visitEffectsAttributeArgumentListSyntaxImpl(node)
     case .enumCaseDecl:
-      return visitImpl(&node, EnumCaseDeclSyntax.self, visit)
+      return visitEnumCaseDeclSyntaxImpl(node)
     case .enumCaseElementList:
-      return visitImpl(&node, EnumCaseElementListSyntax.self, visit)
+      return visitEnumCaseElementListSyntaxImpl(node)
     case .enumCaseElement:
-      return visitImpl(&node, EnumCaseElementSyntax.self, visit)
+      return visitEnumCaseElementSyntaxImpl(node)
     case .enumCaseParameterClause:
-      return visitImpl(&node, EnumCaseParameterClauseSyntax.self, visit)
+      return visitEnumCaseParameterClauseSyntaxImpl(node)
     case .enumCaseParameterList:
-      return visitImpl(&node, EnumCaseParameterListSyntax.self, visit)
+      return visitEnumCaseParameterListSyntaxImpl(node)
     case .enumCaseParameter:
-      return visitImpl(&node, EnumCaseParameterSyntax.self, visit)
+      return visitEnumCaseParameterSyntaxImpl(node)
     case .enumDecl:
-      return visitImpl(&node, EnumDeclSyntax.self, visit)
+      return visitEnumDeclSyntaxImpl(node)
     case .exposeAttributeArguments:
-      return visitImpl(&node, ExposeAttributeArgumentsSyntax.self, visit)
+      return visitExposeAttributeArgumentsSyntaxImpl(node)
     case .exprList:
-      return visitImpl(&node, ExprListSyntax.self, visit)
+      return visitExprListSyntaxImpl(node)
     case .expressionPattern:
-      return visitImpl(&node, ExpressionPatternSyntax.self, visit)
+      return visitExpressionPatternSyntaxImpl(node)
     case .expressionSegment:
-      return visitImpl(&node, ExpressionSegmentSyntax.self, visit)
+      return visitExpressionSegmentSyntaxImpl(node)
     case .expressionStmt:
-      return visitImpl(&node, ExpressionStmtSyntax.self, visit)
+      return visitExpressionStmtSyntaxImpl(node)
     case .extensionDecl:
-      return visitImpl(&node, ExtensionDeclSyntax.self, visit)
+      return visitExtensionDeclSyntaxImpl(node)
     case .fallThroughStmt:
-      return visitImpl(&node, FallThroughStmtSyntax.self, visit)
+      return visitFallThroughStmtSyntaxImpl(node)
     case .floatLiteralExpr:
-      return visitImpl(&node, FloatLiteralExprSyntax.self, visit)
+      return visitFloatLiteralExprSyntaxImpl(node)
     case .forStmt:
-      return visitImpl(&node, ForStmtSyntax.self, visit)
+      return visitForStmtSyntaxImpl(node)
     case .forceUnwrapExpr:
-      return visitImpl(&node, ForceUnwrapExprSyntax.self, visit)
+      return visitForceUnwrapExprSyntaxImpl(node)
     case .functionCallExpr:
-      return visitImpl(&node, FunctionCallExprSyntax.self, visit)
+      return visitFunctionCallExprSyntaxImpl(node)
     case .functionDecl:
-      return visitImpl(&node, FunctionDeclSyntax.self, visit)
+      return visitFunctionDeclSyntaxImpl(node)
     case .functionEffectSpecifiers:
-      return visitImpl(&node, FunctionEffectSpecifiersSyntax.self, visit)
+      return visitFunctionEffectSpecifiersSyntaxImpl(node)
     case .functionParameterClause:
-      return visitImpl(&node, FunctionParameterClauseSyntax.self, visit)
+      return visitFunctionParameterClauseSyntaxImpl(node)
     case .functionParameterList:
-      return visitImpl(&node, FunctionParameterListSyntax.self, visit)
+      return visitFunctionParameterListSyntaxImpl(node)
     case .functionParameter:
-      return visitImpl(&node, FunctionParameterSyntax.self, visit)
+      return visitFunctionParameterSyntaxImpl(node)
     case .functionSignature:
-      return visitImpl(&node, FunctionSignatureSyntax.self, visit)
+      return visitFunctionSignatureSyntaxImpl(node)
     case .functionType:
-      return visitImpl(&node, FunctionTypeSyntax.self, visit)
+      return visitFunctionTypeSyntaxImpl(node)
     case .genericArgumentClause:
-      return visitImpl(&node, GenericArgumentClauseSyntax.self, visit)
+      return visitGenericArgumentClauseSyntaxImpl(node)
     case .genericArgumentList:
-      return visitImpl(&node, GenericArgumentListSyntax.self, visit)
+      return visitGenericArgumentListSyntaxImpl(node)
     case .genericArgument:
-      return visitImpl(&node, GenericArgumentSyntax.self, visit)
+      return visitGenericArgumentSyntaxImpl(node)
     case .genericParameterClause:
-      return visitImpl(&node, GenericParameterClauseSyntax.self, visit)
+      return visitGenericParameterClauseSyntaxImpl(node)
     case .genericParameterList:
-      return visitImpl(&node, GenericParameterListSyntax.self, visit)
+      return visitGenericParameterListSyntaxImpl(node)
     case .genericParameter:
-      return visitImpl(&node, GenericParameterSyntax.self, visit)
+      return visitGenericParameterSyntaxImpl(node)
     case .genericRequirementList:
-      return visitImpl(&node, GenericRequirementListSyntax.self, visit)
+      return visitGenericRequirementListSyntaxImpl(node)
     case .genericRequirement:
-      return visitImpl(&node, GenericRequirementSyntax.self, visit)
+      return visitGenericRequirementSyntaxImpl(node)
     case .genericSpecializationExpr:
-      return visitImpl(&node, GenericSpecializationExprSyntax.self, visit)
+      return visitGenericSpecializationExprSyntaxImpl(node)
     case .genericWhereClause:
-      return visitImpl(&node, GenericWhereClauseSyntax.self, visit)
+      return visitGenericWhereClauseSyntaxImpl(node)
     case .guardStmt:
-      return visitImpl(&node, GuardStmtSyntax.self, visit)
+      return visitGuardStmtSyntaxImpl(node)
     case .identifierPattern:
-      return visitImpl(&node, IdentifierPatternSyntax.self, visit)
+      return visitIdentifierPatternSyntaxImpl(node)
     case .identifierType:
-      return visitImpl(&node, IdentifierTypeSyntax.self, visit)
+      return visitIdentifierTypeSyntaxImpl(node)
     case .ifConfigClauseList:
-      return visitImpl(&node, IfConfigClauseListSyntax.self, visit)
+      return visitIfConfigClauseListSyntaxImpl(node)
     case .ifConfigClause:
-      return visitImpl(&node, IfConfigClauseSyntax.self, visit)
+      return visitIfConfigClauseSyntaxImpl(node)
     case .ifConfigDecl:
-      return visitImpl(&node, IfConfigDeclSyntax.self, visit)
+      return visitIfConfigDeclSyntaxImpl(node)
     case .ifExpr:
-      return visitImpl(&node, IfExprSyntax.self, visit)
+      return visitIfExprSyntaxImpl(node)
     case .implementsAttributeArguments:
-      return visitImpl(&node, ImplementsAttributeArgumentsSyntax.self, visit)
+      return visitImplementsAttributeArgumentsSyntaxImpl(node)
     case .implicitlyUnwrappedOptionalType:
-      return visitImpl(&node, ImplicitlyUnwrappedOptionalTypeSyntax.self, visit)
+      return visitImplicitlyUnwrappedOptionalTypeSyntaxImpl(node)
     case .importDecl:
-      return visitImpl(&node, ImportDeclSyntax.self, visit)
+      return visitImportDeclSyntaxImpl(node)
     case .importPathComponentList:
-      return visitImpl(&node, ImportPathComponentListSyntax.self, visit)
+      return visitImportPathComponentListSyntaxImpl(node)
     case .importPathComponent:
-      return visitImpl(&node, ImportPathComponentSyntax.self, visit)
+      return visitImportPathComponentSyntaxImpl(node)
     case .inOutExpr:
-      return visitImpl(&node, InOutExprSyntax.self, visit)
+      return visitInOutExprSyntaxImpl(node)
     case .infixOperatorExpr:
-      return visitImpl(&node, InfixOperatorExprSyntax.self, visit)
+      return visitInfixOperatorExprSyntaxImpl(node)
     case .inheritanceClause:
-      return visitImpl(&node, InheritanceClauseSyntax.self, visit)
+      return visitInheritanceClauseSyntaxImpl(node)
     case .inheritedTypeList:
-      return visitImpl(&node, InheritedTypeListSyntax.self, visit)
+      return visitInheritedTypeListSyntaxImpl(node)
     case .inheritedType:
-      return visitImpl(&node, InheritedTypeSyntax.self, visit)
+      return visitInheritedTypeSyntaxImpl(node)
     case .initializerClause:
-      return visitImpl(&node, InitializerClauseSyntax.self, visit)
+      return visitInitializerClauseSyntaxImpl(node)
     case .initializerDecl:
-      return visitImpl(&node, InitializerDeclSyntax.self, visit)
+      return visitInitializerDeclSyntaxImpl(node)
     case .integerLiteralExpr:
-      return visitImpl(&node, IntegerLiteralExprSyntax.self, visit)
+      return visitIntegerLiteralExprSyntaxImpl(node)
     case .isExpr:
-      return visitImpl(&node, IsExprSyntax.self, visit)
+      return visitIsExprSyntaxImpl(node)
     case .isTypePattern:
-      return visitImpl(&node, IsTypePatternSyntax.self, visit)
+      return visitIsTypePatternSyntaxImpl(node)
     case .keyPathComponentList:
-      return visitImpl(&node, KeyPathComponentListSyntax.self, visit)
+      return visitKeyPathComponentListSyntaxImpl(node)
     case .keyPathComponent:
-      return visitImpl(&node, KeyPathComponentSyntax.self, visit)
+      return visitKeyPathComponentSyntaxImpl(node)
     case .keyPathExpr:
-      return visitImpl(&node, KeyPathExprSyntax.self, visit)
+      return visitKeyPathExprSyntaxImpl(node)
     case .keyPathOptionalComponent:
-      return visitImpl(&node, KeyPathOptionalComponentSyntax.self, visit)
+      return visitKeyPathOptionalComponentSyntaxImpl(node)
     case .keyPathPropertyComponent:
-      return visitImpl(&node, KeyPathPropertyComponentSyntax.self, visit)
+      return visitKeyPathPropertyComponentSyntaxImpl(node)
     case .keyPathSubscriptComponent:
-      return visitImpl(&node, KeyPathSubscriptComponentSyntax.self, visit)
+      return visitKeyPathSubscriptComponentSyntaxImpl(node)
     case .labeledExprList:
-      return visitImpl(&node, LabeledExprListSyntax.self, visit)
+      return visitLabeledExprListSyntaxImpl(node)
     case .labeledExpr:
-      return visitImpl(&node, LabeledExprSyntax.self, visit)
+      return visitLabeledExprSyntaxImpl(node)
     case .labeledSpecializeArgument:
-      return visitImpl(&node, LabeledSpecializeArgumentSyntax.self, visit)
+      return visitLabeledSpecializeArgumentSyntaxImpl(node)
     case .labeledStmt:
-      return visitImpl(&node, LabeledStmtSyntax.self, visit)
+      return visitLabeledStmtSyntaxImpl(node)
     case .layoutRequirement:
-      return visitImpl(&node, LayoutRequirementSyntax.self, visit)
+      return visitLayoutRequirementSyntaxImpl(node)
     case .lifetimeSpecifierArgumentList:
-      return visitImpl(&node, LifetimeSpecifierArgumentListSyntax.self, visit)
+      return visitLifetimeSpecifierArgumentListSyntaxImpl(node)
     case .lifetimeSpecifierArgument:
-      return visitImpl(&node, LifetimeSpecifierArgumentSyntax.self, visit)
+      return visitLifetimeSpecifierArgumentSyntaxImpl(node)
     case .lifetimeTypeSpecifier:
-      return visitImpl(&node, LifetimeTypeSpecifierSyntax.self, visit)
+      return visitLifetimeTypeSpecifierSyntaxImpl(node)
     case .macroDecl:
-      return visitImpl(&node, MacroDeclSyntax.self, visit)
+      return visitMacroDeclSyntaxImpl(node)
     case .macroExpansionDecl:
-      return visitImpl(&node, MacroExpansionDeclSyntax.self, visit)
+      return visitMacroExpansionDeclSyntaxImpl(node)
     case .macroExpansionExpr:
-      return visitImpl(&node, MacroExpansionExprSyntax.self, visit)
+      return visitMacroExpansionExprSyntaxImpl(node)
     case .matchingPatternCondition:
-      return visitImpl(&node, MatchingPatternConditionSyntax.self, visit)
+      return visitMatchingPatternConditionSyntaxImpl(node)
     case .memberAccessExpr:
-      return visitImpl(&node, MemberAccessExprSyntax.self, visit)
+      return visitMemberAccessExprSyntaxImpl(node)
     case .memberBlockItemList:
-      return visitImpl(&node, MemberBlockItemListSyntax.self, visit)
+      return visitMemberBlockItemListSyntaxImpl(node)
     case .memberBlockItem:
-      return visitImpl(&node, MemberBlockItemSyntax.self, visit)
+      return visitMemberBlockItemSyntaxImpl(node)
     case .memberBlock:
-      return visitImpl(&node, MemberBlockSyntax.self, visit)
+      return visitMemberBlockSyntaxImpl(node)
     case .memberType:
-      return visitImpl(&node, MemberTypeSyntax.self, visit)
+      return visitMemberTypeSyntaxImpl(node)
     case .metatypeType:
-      return visitImpl(&node, MetatypeTypeSyntax.self, visit)
+      return visitMetatypeTypeSyntaxImpl(node)
     case .missingDecl:
-      return visitImpl(&node, MissingDeclSyntax.self, visit)
+      return visitMissingDeclSyntaxImpl(node)
     case .missingExpr:
-      return visitImpl(&node, MissingExprSyntax.self, visit)
+      return visitMissingExprSyntaxImpl(node)
     case .missingPattern:
-      return visitImpl(&node, MissingPatternSyntax.self, visit)
+      return visitMissingPatternSyntaxImpl(node)
     case .missingStmt:
-      return visitImpl(&node, MissingStmtSyntax.self, visit)
+      return visitMissingStmtSyntaxImpl(node)
     case .missing:
-      return visitImpl(&node, MissingSyntax.self, visit)
+      return visitMissingSyntaxImpl(node)
     case .missingType:
-      return visitImpl(&node, MissingTypeSyntax.self, visit)
+      return visitMissingTypeSyntaxImpl(node)
     case .multipleTrailingClosureElementList:
-      return visitImpl(&node, MultipleTrailingClosureElementListSyntax.self, visit)
+      return visitMultipleTrailingClosureElementListSyntaxImpl(node)
     case .multipleTrailingClosureElement:
-      return visitImpl(&node, MultipleTrailingClosureElementSyntax.self, visit)
+      return visitMultipleTrailingClosureElementSyntaxImpl(node)
     case .namedOpaqueReturnType:
-      return visitImpl(&node, NamedOpaqueReturnTypeSyntax.self, visit)
+      return visitNamedOpaqueReturnTypeSyntaxImpl(node)
     case .nilLiteralExpr:
-      return visitImpl(&node, NilLiteralExprSyntax.self, visit)
+      return visitNilLiteralExprSyntaxImpl(node)
     case .objCSelectorPieceList:
-      return visitImpl(&node, ObjCSelectorPieceListSyntax.self, visit)
+      return visitObjCSelectorPieceListSyntaxImpl(node)
     case .objCSelectorPiece:
-      return visitImpl(&node, ObjCSelectorPieceSyntax.self, visit)
+      return visitObjCSelectorPieceSyntaxImpl(node)
     case .opaqueReturnTypeOfAttributeArguments:
-      return visitImpl(&node, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, visit)
+      return visitOpaqueReturnTypeOfAttributeArgumentsSyntaxImpl(node)
     case .operatorDecl:
-      return visitImpl(&node, OperatorDeclSyntax.self, visit)
+      return visitOperatorDeclSyntaxImpl(node)
     case .operatorPrecedenceAndTypes:
-      return visitImpl(&node, OperatorPrecedenceAndTypesSyntax.self, visit)
+      return visitOperatorPrecedenceAndTypesSyntaxImpl(node)
     case .optionalBindingCondition:
-      return visitImpl(&node, OptionalBindingConditionSyntax.self, visit)
+      return visitOptionalBindingConditionSyntaxImpl(node)
     case .optionalChainingExpr:
-      return visitImpl(&node, OptionalChainingExprSyntax.self, visit)
+      return visitOptionalChainingExprSyntaxImpl(node)
     case .optionalType:
-      return visitImpl(&node, OptionalTypeSyntax.self, visit)
+      return visitOptionalTypeSyntaxImpl(node)
     case .originallyDefinedInAttributeArguments:
-      return visitImpl(&node, OriginallyDefinedInAttributeArgumentsSyntax.self, visit)
+      return visitOriginallyDefinedInAttributeArgumentsSyntaxImpl(node)
     case .packElementExpr:
-      return visitImpl(&node, PackElementExprSyntax.self, visit)
+      return visitPackElementExprSyntaxImpl(node)
     case .packElementType:
-      return visitImpl(&node, PackElementTypeSyntax.self, visit)
+      return visitPackElementTypeSyntaxImpl(node)
     case .packExpansionExpr:
-      return visitImpl(&node, PackExpansionExprSyntax.self, visit)
+      return visitPackExpansionExprSyntaxImpl(node)
     case .packExpansionType:
-      return visitImpl(&node, PackExpansionTypeSyntax.self, visit)
+      return visitPackExpansionTypeSyntaxImpl(node)
     case .patternBindingList:
-      return visitImpl(&node, PatternBindingListSyntax.self, visit)
+      return visitPatternBindingListSyntaxImpl(node)
     case .patternBinding:
-      return visitImpl(&node, PatternBindingSyntax.self, visit)
+      return visitPatternBindingSyntaxImpl(node)
     case .patternExpr:
-      return visitImpl(&node, PatternExprSyntax.self, visit)
+      return visitPatternExprSyntaxImpl(node)
     case .platformVersionItemList:
-      return visitImpl(&node, PlatformVersionItemListSyntax.self, visit)
+      return visitPlatformVersionItemListSyntaxImpl(node)
     case .platformVersionItem:
-      return visitImpl(&node, PlatformVersionItemSyntax.self, visit)
+      return visitPlatformVersionItemSyntaxImpl(node)
     case .platformVersion:
-      return visitImpl(&node, PlatformVersionSyntax.self, visit)
+      return visitPlatformVersionSyntaxImpl(node)
     case .postfixIfConfigExpr:
-      return visitImpl(&node, PostfixIfConfigExprSyntax.self, visit)
+      return visitPostfixIfConfigExprSyntaxImpl(node)
     case .postfixOperatorExpr:
-      return visitImpl(&node, PostfixOperatorExprSyntax.self, visit)
+      return visitPostfixOperatorExprSyntaxImpl(node)
     case .poundSourceLocationArguments:
-      return visitImpl(&node, PoundSourceLocationArgumentsSyntax.self, visit)
+      return visitPoundSourceLocationArgumentsSyntaxImpl(node)
     case .poundSourceLocation:
-      return visitImpl(&node, PoundSourceLocationSyntax.self, visit)
+      return visitPoundSourceLocationSyntaxImpl(node)
     case .precedenceGroupAssignment:
-      return visitImpl(&node, PrecedenceGroupAssignmentSyntax.self, visit)
+      return visitPrecedenceGroupAssignmentSyntaxImpl(node)
     case .precedenceGroupAssociativity:
-      return visitImpl(&node, PrecedenceGroupAssociativitySyntax.self, visit)
+      return visitPrecedenceGroupAssociativitySyntaxImpl(node)
     case .precedenceGroupAttributeList:
-      return visitImpl(&node, PrecedenceGroupAttributeListSyntax.self, visit)
+      return visitPrecedenceGroupAttributeListSyntaxImpl(node)
     case .precedenceGroupDecl:
-      return visitImpl(&node, PrecedenceGroupDeclSyntax.self, visit)
+      return visitPrecedenceGroupDeclSyntaxImpl(node)
     case .precedenceGroupNameList:
-      return visitImpl(&node, PrecedenceGroupNameListSyntax.self, visit)
+      return visitPrecedenceGroupNameListSyntaxImpl(node)
     case .precedenceGroupName:
-      return visitImpl(&node, PrecedenceGroupNameSyntax.self, visit)
+      return visitPrecedenceGroupNameSyntaxImpl(node)
     case .precedenceGroupRelation:
-      return visitImpl(&node, PrecedenceGroupRelationSyntax.self, visit)
+      return visitPrecedenceGroupRelationSyntaxImpl(node)
     case .prefixOperatorExpr:
-      return visitImpl(&node, PrefixOperatorExprSyntax.self, visit)
+      return visitPrefixOperatorExprSyntaxImpl(node)
     case .primaryAssociatedTypeClause:
-      return visitImpl(&node, PrimaryAssociatedTypeClauseSyntax.self, visit)
+      return visitPrimaryAssociatedTypeClauseSyntaxImpl(node)
     case .primaryAssociatedTypeList:
-      return visitImpl(&node, PrimaryAssociatedTypeListSyntax.self, visit)
+      return visitPrimaryAssociatedTypeListSyntaxImpl(node)
     case .primaryAssociatedType:
-      return visitImpl(&node, PrimaryAssociatedTypeSyntax.self, visit)
+      return visitPrimaryAssociatedTypeSyntaxImpl(node)
     case .protocolDecl:
-      return visitImpl(&node, ProtocolDeclSyntax.self, visit)
+      return visitProtocolDeclSyntaxImpl(node)
     case .regexLiteralExpr:
-      return visitImpl(&node, RegexLiteralExprSyntax.self, visit)
+      return visitRegexLiteralExprSyntaxImpl(node)
     case .repeatStmt:
-      return visitImpl(&node, RepeatStmtSyntax.self, visit)
+      return visitRepeatStmtSyntaxImpl(node)
     case .returnClause:
-      return visitImpl(&node, ReturnClauseSyntax.self, visit)
+      return visitReturnClauseSyntaxImpl(node)
     case .returnStmt:
-      return visitImpl(&node, ReturnStmtSyntax.self, visit)
+      return visitReturnStmtSyntaxImpl(node)
     case .sameTypeRequirement:
-      return visitImpl(&node, SameTypeRequirementSyntax.self, visit)
+      return visitSameTypeRequirementSyntaxImpl(node)
     case .sequenceExpr:
-      return visitImpl(&node, SequenceExprSyntax.self, visit)
+      return visitSequenceExprSyntaxImpl(node)
     case .simpleStringLiteralExpr:
-      return visitImpl(&node, SimpleStringLiteralExprSyntax.self, visit)
+      return visitSimpleStringLiteralExprSyntaxImpl(node)
     case .simpleStringLiteralSegmentList:
-      return visitImpl(&node, SimpleStringLiteralSegmentListSyntax.self, visit)
+      return visitSimpleStringLiteralSegmentListSyntaxImpl(node)
     case .simpleTypeSpecifier:
-      return visitImpl(&node, SimpleTypeSpecifierSyntax.self, visit)
+      return visitSimpleTypeSpecifierSyntaxImpl(node)
     case .someOrAnyType:
-      return visitImpl(&node, SomeOrAnyTypeSyntax.self, visit)
+      return visitSomeOrAnyTypeSyntaxImpl(node)
     case .sourceFile:
-      return visitImpl(&node, SourceFileSyntax.self, visit)
+      return visitSourceFileSyntaxImpl(node)
     case .specializeAttributeArgumentList:
-      return visitImpl(&node, SpecializeAttributeArgumentListSyntax.self, visit)
+      return visitSpecializeAttributeArgumentListSyntaxImpl(node)
     case .specializeAvailabilityArgument:
-      return visitImpl(&node, SpecializeAvailabilityArgumentSyntax.self, visit)
+      return visitSpecializeAvailabilityArgumentSyntaxImpl(node)
     case .specializeTargetFunctionArgument:
-      return visitImpl(&node, SpecializeTargetFunctionArgumentSyntax.self, visit)
+      return visitSpecializeTargetFunctionArgumentSyntaxImpl(node)
     case .stringLiteralExpr:
-      return visitImpl(&node, StringLiteralExprSyntax.self, visit)
+      return visitStringLiteralExprSyntaxImpl(node)
     case .stringLiteralSegmentList:
-      return visitImpl(&node, StringLiteralSegmentListSyntax.self, visit)
+      return visitStringLiteralSegmentListSyntaxImpl(node)
     case .stringSegment:
-      return visitImpl(&node, StringSegmentSyntax.self, visit)
+      return visitStringSegmentSyntaxImpl(node)
     case .structDecl:
-      return visitImpl(&node, StructDeclSyntax.self, visit)
+      return visitStructDeclSyntaxImpl(node)
     case .subscriptCallExpr:
-      return visitImpl(&node, SubscriptCallExprSyntax.self, visit)
+      return visitSubscriptCallExprSyntaxImpl(node)
     case .subscriptDecl:
-      return visitImpl(&node, SubscriptDeclSyntax.self, visit)
+      return visitSubscriptDeclSyntaxImpl(node)
     case .superExpr:
-      return visitImpl(&node, SuperExprSyntax.self, visit)
+      return visitSuperExprSyntaxImpl(node)
     case .suppressedType:
-      return visitImpl(&node, SuppressedTypeSyntax.self, visit)
+      return visitSuppressedTypeSyntaxImpl(node)
     case .switchCaseItemList:
-      return visitImpl(&node, SwitchCaseItemListSyntax.self, visit)
+      return visitSwitchCaseItemListSyntaxImpl(node)
     case .switchCaseItem:
-      return visitImpl(&node, SwitchCaseItemSyntax.self, visit)
+      return visitSwitchCaseItemSyntaxImpl(node)
     case .switchCaseLabel:
-      return visitImpl(&node, SwitchCaseLabelSyntax.self, visit)
+      return visitSwitchCaseLabelSyntaxImpl(node)
     case .switchCaseList:
-      return visitImpl(&node, SwitchCaseListSyntax.self, visit)
+      return visitSwitchCaseListSyntaxImpl(node)
     case .switchCase:
-      return visitImpl(&node, SwitchCaseSyntax.self, visit)
+      return visitSwitchCaseSyntaxImpl(node)
     case .switchDefaultLabel:
-      return visitImpl(&node, SwitchDefaultLabelSyntax.self, visit)
+      return visitSwitchDefaultLabelSyntaxImpl(node)
     case .switchExpr:
-      return visitImpl(&node, SwitchExprSyntax.self, visit)
+      return visitSwitchExprSyntaxImpl(node)
     case .ternaryExpr:
-      return visitImpl(&node, TernaryExprSyntax.self, visit)
+      return visitTernaryExprSyntaxImpl(node)
     case .thenStmt:
-      return visitImpl(&node, ThenStmtSyntax.self, visit)
+      return visitThenStmtSyntaxImpl(node)
     case .throwStmt:
-      return visitImpl(&node, ThrowStmtSyntax.self, visit)
+      return visitThrowStmtSyntaxImpl(node)
     case .throwsClause:
-      return visitImpl(&node, ThrowsClauseSyntax.self, visit)
+      return visitThrowsClauseSyntaxImpl(node)
     case .tryExpr:
-      return visitImpl(&node, TryExprSyntax.self, visit)
+      return visitTryExprSyntaxImpl(node)
     case .tupleExpr:
-      return visitImpl(&node, TupleExprSyntax.self, visit)
+      return visitTupleExprSyntaxImpl(node)
     case .tuplePatternElementList:
-      return visitImpl(&node, TuplePatternElementListSyntax.self, visit)
+      return visitTuplePatternElementListSyntaxImpl(node)
     case .tuplePatternElement:
-      return visitImpl(&node, TuplePatternElementSyntax.self, visit)
+      return visitTuplePatternElementSyntaxImpl(node)
     case .tuplePattern:
-      return visitImpl(&node, TuplePatternSyntax.self, visit)
+      return visitTuplePatternSyntaxImpl(node)
     case .tupleTypeElementList:
-      return visitImpl(&node, TupleTypeElementListSyntax.self, visit)
+      return visitTupleTypeElementListSyntaxImpl(node)
     case .tupleTypeElement:
-      return visitImpl(&node, TupleTypeElementSyntax.self, visit)
+      return visitTupleTypeElementSyntaxImpl(node)
     case .tupleType:
-      return visitImpl(&node, TupleTypeSyntax.self, visit)
+      return visitTupleTypeSyntaxImpl(node)
     case .typeAliasDecl:
-      return visitImpl(&node, TypeAliasDeclSyntax.self, visit)
+      return visitTypeAliasDeclSyntaxImpl(node)
     case .typeAnnotation:
-      return visitImpl(&node, TypeAnnotationSyntax.self, visit)
+      return visitTypeAnnotationSyntaxImpl(node)
     case .typeEffectSpecifiers:
-      return visitImpl(&node, TypeEffectSpecifiersSyntax.self, visit)
+      return visitTypeEffectSpecifiersSyntaxImpl(node)
     case .typeExpr:
-      return visitImpl(&node, TypeExprSyntax.self, visit)
+      return visitTypeExprSyntaxImpl(node)
     case .typeInitializerClause:
-      return visitImpl(&node, TypeInitializerClauseSyntax.self, visit)
+      return visitTypeInitializerClauseSyntaxImpl(node)
     case .typeSpecifierList:
-      return visitImpl(&node, TypeSpecifierListSyntax.self, visit)
+      return visitTypeSpecifierListSyntaxImpl(node)
     case .unavailableFromAsyncAttributeArguments:
-      return visitImpl(&node, UnavailableFromAsyncAttributeArgumentsSyntax.self, visit)
+      return visitUnavailableFromAsyncAttributeArgumentsSyntaxImpl(node)
     case .underscorePrivateAttributeArguments:
-      return visitImpl(&node, UnderscorePrivateAttributeArgumentsSyntax.self, visit)
+      return visitUnderscorePrivateAttributeArgumentsSyntaxImpl(node)
     case .unexpectedNodes:
-      return visitImpl(&node, UnexpectedNodesSyntax.self, visit)
+      return visitUnexpectedNodesSyntaxImpl(node)
     case .unresolvedAsExpr:
-      return visitImpl(&node, UnresolvedAsExprSyntax.self, visit)
+      return visitUnresolvedAsExprSyntaxImpl(node)
     case .unresolvedIsExpr:
-      return visitImpl(&node, UnresolvedIsExprSyntax.self, visit)
+      return visitUnresolvedIsExprSyntaxImpl(node)
     case .unresolvedTernaryExpr:
-      return visitImpl(&node, UnresolvedTernaryExprSyntax.self, visit)
+      return visitUnresolvedTernaryExprSyntaxImpl(node)
     case .valueBindingPattern:
-      return visitImpl(&node, ValueBindingPatternSyntax.self, visit)
+      return visitValueBindingPatternSyntaxImpl(node)
     case .variableDecl:
-      return visitImpl(&node, VariableDeclSyntax.self, visit)
+      return visitVariableDeclSyntaxImpl(node)
     case .versionComponentList:
-      return visitImpl(&node, VersionComponentListSyntax.self, visit)
+      return visitVersionComponentListSyntaxImpl(node)
     case .versionComponent:
-      return visitImpl(&node, VersionComponentSyntax.self, visit)
+      return visitVersionComponentSyntaxImpl(node)
     case .versionTuple:
-      return visitImpl(&node, VersionTupleSyntax.self, visit)
+      return visitVersionTupleSyntaxImpl(node)
     case .whereClause:
-      return visitImpl(&node, WhereClauseSyntax.self, visit)
+      return visitWhereClauseSyntaxImpl(node)
     case .whileStmt:
-      return visitImpl(&node, WhileStmtSyntax.self, visit)
+      return visitWhileStmtSyntaxImpl(node)
     case .wildcardPattern:
-      return visitImpl(&node, WildcardPatternSyntax.self, visit)
+      return visitWildcardPatternSyntaxImpl(node)
     case .yieldStmt:
-      return visitImpl(&node, YieldStmtSyntax.self, visit)
+      return visitYieldStmtSyntaxImpl(node)
     case .yieldedExpressionList:
-      return visitImpl(&node, YieldedExpressionListSyntax.self, visit)
+      return visitYieldedExpressionListSyntaxImpl(node)
     case .yieldedExpression:
-      return visitImpl(&node, YieldedExpressionSyntax.self, visit)
+      return visitYieldedExpressionSyntaxImpl(node)
     case .yieldedExpressionsClause:
-      return visitImpl(&node, YieldedExpressionsClauseSyntax.self, visit)
+      return visitYieldedExpressionsClauseSyntaxImpl(node)
     }
   }
   #endif
+
+  private func visitImpl(_ node: Syntax) -> Syntax {
+    visitPre(node)
+    defer {
+      visitPost(node)
+    }
+    return visitAny(node) ?? dispatchVisit(node)
+  }
 
   private func visitChildren(_ node: Syntax) -> Syntax {
     // Walk over all children of this node and rewrite them. Don't store any
@@ -3938,9 +4772,7 @@ open class SyntaxRewriter {
     for case let (child?, info) in RawSyntaxChildren(node) where viewMode.shouldTraverse(node: child) {
 
       // Build the Syntax node to rewrite
-      var childNode = nodeFactory.create(parent: node, raw: child, absoluteInfo: info)
-
-      dispatchVisit(&childNode)
+      var childNode = visitImpl(nodeFactory.create(parent: node, raw: child, absoluteInfo: info))
       if childNode.raw.id != child.id {
         // The node was rewritten, let's handle it
 

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -34,8 +34,7 @@ open class SyntaxVisitor {
   /// Walk all nodes of the given syntax tree, calling the corresponding `visit`
   /// function for every node that is being visited.
   public func walk(_ node: some SyntaxProtocol) {
-    var syntaxNode = Syntax(node)
-    visit(&syntaxNode)
+    dispatchVisit(Syntax(node))
   }
 
   /// Visiting `ABIAttributeArgumentsSyntax` specifically.
@@ -3494,30 +3493,2283 @@ open class SyntaxVisitor {
   open func visitPost(_ node: TokenSyntax) {
   }
 
-  /// Cast `node` to a node of type `nodeType`, visit it, calling
-  /// the `visit` and `visitPost` functions during visitation.
-  ///
-  /// - Note: node is an `inout` parameter so that callers don't have to retain it before passing it to `visitImpl`.
-  ///   With it being an `inout` parameter, the caller and `visitImpl` can work on the same reference of `node` without
-  ///   any reference counting.
-  /// - Note: Inline so that the optimizer can look through the calles to `visit` and `visitPost`, which means it
-  ///   doesn't need to retain `self` when forming closures to the unapplied function references on `self`.
-  @inline(__always)
-  private func visitImpl<NodeType: SyntaxProtocol>(
-    _ node: inout Syntax,
-    _ nodeType: NodeType.Type,
-    _ visit: (NodeType) -> SyntaxVisitorContinueKind,
-    _ visitPost: (NodeType) -> Void
-  ) {
-    let castedNode = node.cast(NodeType.self)
-    // We retain castedNode.info here before passing it to visit.
-    // I don't think that's necessary because castedNode is already retained but don't know how to prevent it.
-    let needsChildren = (visit(castedNode) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && !node.raw.layoutView!.children.isEmpty {
-      visitChildren(&node)
+  @inline(never)
+  private func visitTokenSyntaxImpl(_ node: Syntax) {
+    _ = visit(TokenSyntax(unsafeCasting: node))
+    // No children to visit.
+    visitPost(TokenSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitABIAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(ABIAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
     }
-    visitPost(castedNode)
+    visitPost(ABIAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAccessorBlockSyntaxImpl(_ node: Syntax) {
+    if visit(AccessorBlockSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AccessorBlockSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAccessorDeclListSyntaxImpl(_ node: Syntax) {
+    if visit(AccessorDeclListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AccessorDeclListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAccessorDeclSyntaxImpl(_ node: Syntax) {
+    if visit(AccessorDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AccessorDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAccessorEffectSpecifiersSyntaxImpl(_ node: Syntax) {
+    if visit(AccessorEffectSpecifiersSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AccessorEffectSpecifiersSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAccessorParametersSyntaxImpl(_ node: Syntax) {
+    if visit(AccessorParametersSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AccessorParametersSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitActorDeclSyntaxImpl(_ node: Syntax) {
+    if visit(ActorDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ActorDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitArrayElementListSyntaxImpl(_ node: Syntax) {
+    if visit(ArrayElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ArrayElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitArrayElementSyntaxImpl(_ node: Syntax) {
+    if visit(ArrayElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ArrayElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitArrayExprSyntaxImpl(_ node: Syntax) {
+    if visit(ArrayExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ArrayExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitArrayTypeSyntaxImpl(_ node: Syntax) {
+    if visit(ArrayTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ArrayTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitArrowExprSyntaxImpl(_ node: Syntax) {
+    if visit(ArrowExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ArrowExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAsExprSyntaxImpl(_ node: Syntax) {
+    if visit(AsExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AsExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAssignmentExprSyntaxImpl(_ node: Syntax) {
+    if visit(AssignmentExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AssignmentExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAssociatedTypeDeclSyntaxImpl(_ node: Syntax) {
+    if visit(AssociatedTypeDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AssociatedTypeDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAttributeListSyntaxImpl(_ node: Syntax) {
+    if visit(AttributeListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AttributeListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAttributeSyntaxImpl(_ node: Syntax) {
+    if visit(AttributeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AttributeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAttributedTypeSyntaxImpl(_ node: Syntax) {
+    if visit(AttributedTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AttributedTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAvailabilityArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(AvailabilityArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AvailabilityArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAvailabilityArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(AvailabilityArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AvailabilityArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAvailabilityConditionSyntaxImpl(_ node: Syntax) {
+    if visit(AvailabilityConditionSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AvailabilityConditionSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAvailabilityLabeledArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(AvailabilityLabeledArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AvailabilityLabeledArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitAwaitExprSyntaxImpl(_ node: Syntax) {
+    if visit(AwaitExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(AwaitExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitBackDeployedAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(BackDeployedAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(BackDeployedAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitBinaryOperatorExprSyntaxImpl(_ node: Syntax) {
+    if visit(BinaryOperatorExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(BinaryOperatorExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitBooleanLiteralExprSyntaxImpl(_ node: Syntax) {
+    if visit(BooleanLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(BooleanLiteralExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitBorrowExprSyntaxImpl(_ node: Syntax) {
+    if visit(BorrowExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(BorrowExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitBreakStmtSyntaxImpl(_ node: Syntax) {
+    if visit(BreakStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(BreakStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visit_CanImportExprSyntaxImpl(_ node: Syntax) {
+    if visit(_CanImportExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(_CanImportExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visit_CanImportVersionInfoSyntaxImpl(_ node: Syntax) {
+    if visit(_CanImportVersionInfoSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(_CanImportVersionInfoSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCatchClauseListSyntaxImpl(_ node: Syntax) {
+    if visit(CatchClauseListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CatchClauseListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCatchClauseSyntaxImpl(_ node: Syntax) {
+    if visit(CatchClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CatchClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCatchItemListSyntaxImpl(_ node: Syntax) {
+    if visit(CatchItemListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CatchItemListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCatchItemSyntaxImpl(_ node: Syntax) {
+    if visit(CatchItemSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CatchItemSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClassDeclSyntaxImpl(_ node: Syntax) {
+    if visit(ClassDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClassDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClassRestrictionTypeSyntaxImpl(_ node: Syntax) {
+    if visit(ClassRestrictionTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClassRestrictionTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureClauseSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureCaptureClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureCaptureClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureListSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureCaptureListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureCaptureListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureSpecifierSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureCaptureSpecifierSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureCaptureSpecifierSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureCaptureSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureCaptureSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureCaptureSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureExprSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureParameterClauseSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureParameterClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureParameterClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureParameterListSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureParameterListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureParameterListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureParameterSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureParameterSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureParameterSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureShorthandParameterListSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureShorthandParameterListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureShorthandParameterListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureShorthandParameterSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureShorthandParameterSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureShorthandParameterSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitClosureSignatureSyntaxImpl(_ node: Syntax) {
+    if visit(ClosureSignatureSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ClosureSignatureSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCodeBlockItemListSyntaxImpl(_ node: Syntax) {
+    if visit(CodeBlockItemListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CodeBlockItemListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCodeBlockItemSyntaxImpl(_ node: Syntax) {
+    if visit(CodeBlockItemSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CodeBlockItemSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCodeBlockSyntaxImpl(_ node: Syntax) {
+    if visit(CodeBlockSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CodeBlockSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCompositionTypeElementListSyntaxImpl(_ node: Syntax) {
+    if visit(CompositionTypeElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CompositionTypeElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCompositionTypeElementSyntaxImpl(_ node: Syntax) {
+    if visit(CompositionTypeElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CompositionTypeElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCompositionTypeSyntaxImpl(_ node: Syntax) {
+    if visit(CompositionTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CompositionTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitConditionElementListSyntaxImpl(_ node: Syntax) {
+    if visit(ConditionElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ConditionElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitConditionElementSyntaxImpl(_ node: Syntax) {
+    if visit(ConditionElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ConditionElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitConformanceRequirementSyntaxImpl(_ node: Syntax) {
+    if visit(ConformanceRequirementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ConformanceRequirementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitConsumeExprSyntaxImpl(_ node: Syntax) {
+    if visit(ConsumeExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ConsumeExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitContinueStmtSyntaxImpl(_ node: Syntax) {
+    if visit(ContinueStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ContinueStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitConventionAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(ConventionAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ConventionAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitConventionWitnessMethodAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(ConventionWitnessMethodAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ConventionWitnessMethodAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitCopyExprSyntaxImpl(_ node: Syntax) {
+    if visit(CopyExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(CopyExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeclModifierDetailSyntaxImpl(_ node: Syntax) {
+    if visit(DeclModifierDetailSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeclModifierDetailSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeclModifierListSyntaxImpl(_ node: Syntax) {
+    if visit(DeclModifierListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeclModifierListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeclModifierSyntaxImpl(_ node: Syntax) {
+    if visit(DeclModifierSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeclModifierSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeclNameArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(DeclNameArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeclNameArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeclNameArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(DeclNameArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeclNameArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeclNameArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(DeclNameArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeclNameArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeclReferenceExprSyntaxImpl(_ node: Syntax) {
+    if visit(DeclReferenceExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeclReferenceExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeferStmtSyntaxImpl(_ node: Syntax) {
+    if visit(DeferStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeferStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeinitializerDeclSyntaxImpl(_ node: Syntax) {
+    if visit(DeinitializerDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeinitializerDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDeinitializerEffectSpecifiersSyntaxImpl(_ node: Syntax) {
+    if visit(DeinitializerEffectSpecifiersSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DeinitializerEffectSpecifiersSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDerivativeAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(DerivativeAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DerivativeAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDesignatedTypeListSyntaxImpl(_ node: Syntax) {
+    if visit(DesignatedTypeListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DesignatedTypeListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDesignatedTypeSyntaxImpl(_ node: Syntax) {
+    if visit(DesignatedTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DesignatedTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDictionaryElementListSyntaxImpl(_ node: Syntax) {
+    if visit(DictionaryElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DictionaryElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDictionaryElementSyntaxImpl(_ node: Syntax) {
+    if visit(DictionaryElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DictionaryElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDictionaryExprSyntaxImpl(_ node: Syntax) {
+    if visit(DictionaryExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DictionaryExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDictionaryTypeSyntaxImpl(_ node: Syntax) {
+    if visit(DictionaryTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DictionaryTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(DifferentiabilityArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DifferentiabilityArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(DifferentiabilityArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DifferentiabilityArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(DifferentiabilityArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DifferentiabilityArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDifferentiabilityWithRespectToArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(DifferentiabilityWithRespectToArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DifferentiabilityWithRespectToArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDifferentiableAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(DifferentiableAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DifferentiableAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDiscardAssignmentExprSyntaxImpl(_ node: Syntax) {
+    if visit(DiscardAssignmentExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DiscardAssignmentExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDiscardStmtSyntaxImpl(_ node: Syntax) {
+    if visit(DiscardStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DiscardStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDoExprSyntaxImpl(_ node: Syntax) {
+    if visit(DoExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DoExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDoStmtSyntaxImpl(_ node: Syntax) {
+    if visit(DoStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DoStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDocumentationAttributeArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(DocumentationAttributeArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DocumentationAttributeArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDocumentationAttributeArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(DocumentationAttributeArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DocumentationAttributeArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitDynamicReplacementAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(DynamicReplacementAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(DynamicReplacementAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEditorPlaceholderDeclSyntaxImpl(_ node: Syntax) {
+    if visit(EditorPlaceholderDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EditorPlaceholderDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEditorPlaceholderExprSyntaxImpl(_ node: Syntax) {
+    if visit(EditorPlaceholderExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EditorPlaceholderExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEffectsAttributeArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(EffectsAttributeArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EffectsAttributeArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEnumCaseDeclSyntaxImpl(_ node: Syntax) {
+    if visit(EnumCaseDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EnumCaseDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEnumCaseElementListSyntaxImpl(_ node: Syntax) {
+    if visit(EnumCaseElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EnumCaseElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEnumCaseElementSyntaxImpl(_ node: Syntax) {
+    if visit(EnumCaseElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EnumCaseElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEnumCaseParameterClauseSyntaxImpl(_ node: Syntax) {
+    if visit(EnumCaseParameterClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EnumCaseParameterClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEnumCaseParameterListSyntaxImpl(_ node: Syntax) {
+    if visit(EnumCaseParameterListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EnumCaseParameterListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEnumCaseParameterSyntaxImpl(_ node: Syntax) {
+    if visit(EnumCaseParameterSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EnumCaseParameterSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitEnumDeclSyntaxImpl(_ node: Syntax) {
+    if visit(EnumDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(EnumDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitExposeAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(ExposeAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ExposeAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitExprListSyntaxImpl(_ node: Syntax) {
+    if visit(ExprListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ExprListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitExpressionPatternSyntaxImpl(_ node: Syntax) {
+    if visit(ExpressionPatternSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ExpressionPatternSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitExpressionSegmentSyntaxImpl(_ node: Syntax) {
+    if visit(ExpressionSegmentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ExpressionSegmentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitExpressionStmtSyntaxImpl(_ node: Syntax) {
+    if visit(ExpressionStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ExpressionStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitExtensionDeclSyntaxImpl(_ node: Syntax) {
+    if visit(ExtensionDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ExtensionDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFallThroughStmtSyntaxImpl(_ node: Syntax) {
+    if visit(FallThroughStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FallThroughStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFloatLiteralExprSyntaxImpl(_ node: Syntax) {
+    if visit(FloatLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FloatLiteralExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitForStmtSyntaxImpl(_ node: Syntax) {
+    if visit(ForStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ForStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitForceUnwrapExprSyntaxImpl(_ node: Syntax) {
+    if visit(ForceUnwrapExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ForceUnwrapExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionCallExprSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionCallExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionCallExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionDeclSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionEffectSpecifiersSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionEffectSpecifiersSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionEffectSpecifiersSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionParameterClauseSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionParameterClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionParameterClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionParameterListSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionParameterListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionParameterListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionParameterSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionParameterSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionParameterSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionSignatureSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionSignatureSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionSignatureSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitFunctionTypeSyntaxImpl(_ node: Syntax) {
+    if visit(FunctionTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(FunctionTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericArgumentClauseSyntaxImpl(_ node: Syntax) {
+    if visit(GenericArgumentClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericArgumentClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(GenericArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(GenericArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericParameterClauseSyntaxImpl(_ node: Syntax) {
+    if visit(GenericParameterClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericParameterClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericParameterListSyntaxImpl(_ node: Syntax) {
+    if visit(GenericParameterListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericParameterListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericParameterSyntaxImpl(_ node: Syntax) {
+    if visit(GenericParameterSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericParameterSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericRequirementListSyntaxImpl(_ node: Syntax) {
+    if visit(GenericRequirementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericRequirementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericRequirementSyntaxImpl(_ node: Syntax) {
+    if visit(GenericRequirementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericRequirementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericSpecializationExprSyntaxImpl(_ node: Syntax) {
+    if visit(GenericSpecializationExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericSpecializationExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGenericWhereClauseSyntaxImpl(_ node: Syntax) {
+    if visit(GenericWhereClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GenericWhereClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitGuardStmtSyntaxImpl(_ node: Syntax) {
+    if visit(GuardStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(GuardStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIdentifierPatternSyntaxImpl(_ node: Syntax) {
+    if visit(IdentifierPatternSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IdentifierPatternSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIdentifierTypeSyntaxImpl(_ node: Syntax) {
+    if visit(IdentifierTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IdentifierTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIfConfigClauseListSyntaxImpl(_ node: Syntax) {
+    if visit(IfConfigClauseListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IfConfigClauseListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIfConfigClauseSyntaxImpl(_ node: Syntax) {
+    if visit(IfConfigClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IfConfigClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIfConfigDeclSyntaxImpl(_ node: Syntax) {
+    if visit(IfConfigDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IfConfigDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIfExprSyntaxImpl(_ node: Syntax) {
+    if visit(IfExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IfExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitImplementsAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(ImplementsAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ImplementsAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitImplicitlyUnwrappedOptionalTypeSyntaxImpl(_ node: Syntax) {
+    if visit(ImplicitlyUnwrappedOptionalTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ImplicitlyUnwrappedOptionalTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitImportDeclSyntaxImpl(_ node: Syntax) {
+    if visit(ImportDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ImportDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitImportPathComponentListSyntaxImpl(_ node: Syntax) {
+    if visit(ImportPathComponentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ImportPathComponentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitImportPathComponentSyntaxImpl(_ node: Syntax) {
+    if visit(ImportPathComponentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ImportPathComponentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitInOutExprSyntaxImpl(_ node: Syntax) {
+    if visit(InOutExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(InOutExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitInfixOperatorExprSyntaxImpl(_ node: Syntax) {
+    if visit(InfixOperatorExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(InfixOperatorExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitInheritanceClauseSyntaxImpl(_ node: Syntax) {
+    if visit(InheritanceClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(InheritanceClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitInheritedTypeListSyntaxImpl(_ node: Syntax) {
+    if visit(InheritedTypeListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(InheritedTypeListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitInheritedTypeSyntaxImpl(_ node: Syntax) {
+    if visit(InheritedTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(InheritedTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitInitializerClauseSyntaxImpl(_ node: Syntax) {
+    if visit(InitializerClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(InitializerClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitInitializerDeclSyntaxImpl(_ node: Syntax) {
+    if visit(InitializerDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(InitializerDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIntegerLiteralExprSyntaxImpl(_ node: Syntax) {
+    if visit(IntegerLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IntegerLiteralExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIsExprSyntaxImpl(_ node: Syntax) {
+    if visit(IsExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IsExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitIsTypePatternSyntaxImpl(_ node: Syntax) {
+    if visit(IsTypePatternSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(IsTypePatternSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitKeyPathComponentListSyntaxImpl(_ node: Syntax) {
+    if visit(KeyPathComponentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(KeyPathComponentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitKeyPathComponentSyntaxImpl(_ node: Syntax) {
+    if visit(KeyPathComponentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(KeyPathComponentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitKeyPathExprSyntaxImpl(_ node: Syntax) {
+    if visit(KeyPathExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(KeyPathExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitKeyPathOptionalComponentSyntaxImpl(_ node: Syntax) {
+    if visit(KeyPathOptionalComponentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(KeyPathOptionalComponentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitKeyPathPropertyComponentSyntaxImpl(_ node: Syntax) {
+    if visit(KeyPathPropertyComponentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(KeyPathPropertyComponentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitKeyPathSubscriptComponentSyntaxImpl(_ node: Syntax) {
+    if visit(KeyPathSubscriptComponentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(KeyPathSubscriptComponentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLabeledExprListSyntaxImpl(_ node: Syntax) {
+    if visit(LabeledExprListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LabeledExprListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLabeledExprSyntaxImpl(_ node: Syntax) {
+    if visit(LabeledExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LabeledExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLabeledSpecializeArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(LabeledSpecializeArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LabeledSpecializeArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLabeledStmtSyntaxImpl(_ node: Syntax) {
+    if visit(LabeledStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LabeledStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLayoutRequirementSyntaxImpl(_ node: Syntax) {
+    if visit(LayoutRequirementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LayoutRequirementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLifetimeSpecifierArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(LifetimeSpecifierArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LifetimeSpecifierArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLifetimeSpecifierArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(LifetimeSpecifierArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LifetimeSpecifierArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitLifetimeTypeSpecifierSyntaxImpl(_ node: Syntax) {
+    if visit(LifetimeTypeSpecifierSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(LifetimeTypeSpecifierSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMacroDeclSyntaxImpl(_ node: Syntax) {
+    if visit(MacroDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MacroDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMacroExpansionDeclSyntaxImpl(_ node: Syntax) {
+    if visit(MacroExpansionDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MacroExpansionDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMacroExpansionExprSyntaxImpl(_ node: Syntax) {
+    if visit(MacroExpansionExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MacroExpansionExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMatchingPatternConditionSyntaxImpl(_ node: Syntax) {
+    if visit(MatchingPatternConditionSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MatchingPatternConditionSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMemberAccessExprSyntaxImpl(_ node: Syntax) {
+    if visit(MemberAccessExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MemberAccessExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMemberBlockItemListSyntaxImpl(_ node: Syntax) {
+    if visit(MemberBlockItemListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MemberBlockItemListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMemberBlockItemSyntaxImpl(_ node: Syntax) {
+    if visit(MemberBlockItemSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MemberBlockItemSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMemberBlockSyntaxImpl(_ node: Syntax) {
+    if visit(MemberBlockSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MemberBlockSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMemberTypeSyntaxImpl(_ node: Syntax) {
+    if visit(MemberTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MemberTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMetatypeTypeSyntaxImpl(_ node: Syntax) {
+    if visit(MetatypeTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MetatypeTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMissingDeclSyntaxImpl(_ node: Syntax) {
+    if visit(MissingDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MissingDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMissingExprSyntaxImpl(_ node: Syntax) {
+    if visit(MissingExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MissingExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMissingPatternSyntaxImpl(_ node: Syntax) {
+    if visit(MissingPatternSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MissingPatternSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMissingStmtSyntaxImpl(_ node: Syntax) {
+    if visit(MissingStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MissingStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMissingSyntaxImpl(_ node: Syntax) {
+    if visit(MissingSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MissingSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMissingTypeSyntaxImpl(_ node: Syntax) {
+    if visit(MissingTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MissingTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMultipleTrailingClosureElementListSyntaxImpl(_ node: Syntax) {
+    if visit(MultipleTrailingClosureElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MultipleTrailingClosureElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitMultipleTrailingClosureElementSyntaxImpl(_ node: Syntax) {
+    if visit(MultipleTrailingClosureElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(MultipleTrailingClosureElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitNamedOpaqueReturnTypeSyntaxImpl(_ node: Syntax) {
+    if visit(NamedOpaqueReturnTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(NamedOpaqueReturnTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitNilLiteralExprSyntaxImpl(_ node: Syntax) {
+    if visit(NilLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(NilLiteralExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitObjCSelectorPieceListSyntaxImpl(_ node: Syntax) {
+    if visit(ObjCSelectorPieceListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ObjCSelectorPieceListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitObjCSelectorPieceSyntaxImpl(_ node: Syntax) {
+    if visit(ObjCSelectorPieceSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ObjCSelectorPieceSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitOpaqueReturnTypeOfAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(OpaqueReturnTypeOfAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(OpaqueReturnTypeOfAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitOperatorDeclSyntaxImpl(_ node: Syntax) {
+    if visit(OperatorDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(OperatorDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitOperatorPrecedenceAndTypesSyntaxImpl(_ node: Syntax) {
+    if visit(OperatorPrecedenceAndTypesSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(OperatorPrecedenceAndTypesSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitOptionalBindingConditionSyntaxImpl(_ node: Syntax) {
+    if visit(OptionalBindingConditionSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(OptionalBindingConditionSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitOptionalChainingExprSyntaxImpl(_ node: Syntax) {
+    if visit(OptionalChainingExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(OptionalChainingExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitOptionalTypeSyntaxImpl(_ node: Syntax) {
+    if visit(OptionalTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(OptionalTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitOriginallyDefinedInAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(OriginallyDefinedInAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(OriginallyDefinedInAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPackElementExprSyntaxImpl(_ node: Syntax) {
+    if visit(PackElementExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PackElementExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPackElementTypeSyntaxImpl(_ node: Syntax) {
+    if visit(PackElementTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PackElementTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPackExpansionExprSyntaxImpl(_ node: Syntax) {
+    if visit(PackExpansionExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PackExpansionExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPackExpansionTypeSyntaxImpl(_ node: Syntax) {
+    if visit(PackExpansionTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PackExpansionTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPatternBindingListSyntaxImpl(_ node: Syntax) {
+    if visit(PatternBindingListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PatternBindingListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPatternBindingSyntaxImpl(_ node: Syntax) {
+    if visit(PatternBindingSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PatternBindingSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPatternExprSyntaxImpl(_ node: Syntax) {
+    if visit(PatternExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PatternExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPlatformVersionItemListSyntaxImpl(_ node: Syntax) {
+    if visit(PlatformVersionItemListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PlatformVersionItemListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPlatformVersionItemSyntaxImpl(_ node: Syntax) {
+    if visit(PlatformVersionItemSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PlatformVersionItemSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPlatformVersionSyntaxImpl(_ node: Syntax) {
+    if visit(PlatformVersionSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PlatformVersionSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPostfixIfConfigExprSyntaxImpl(_ node: Syntax) {
+    if visit(PostfixIfConfigExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PostfixIfConfigExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPostfixOperatorExprSyntaxImpl(_ node: Syntax) {
+    if visit(PostfixOperatorExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PostfixOperatorExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPoundSourceLocationArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(PoundSourceLocationArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PoundSourceLocationArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPoundSourceLocationSyntaxImpl(_ node: Syntax) {
+    if visit(PoundSourceLocationSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PoundSourceLocationSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupAssignmentSyntaxImpl(_ node: Syntax) {
+    if visit(PrecedenceGroupAssignmentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrecedenceGroupAssignmentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupAssociativitySyntaxImpl(_ node: Syntax) {
+    if visit(PrecedenceGroupAssociativitySyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrecedenceGroupAssociativitySyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupAttributeListSyntaxImpl(_ node: Syntax) {
+    if visit(PrecedenceGroupAttributeListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrecedenceGroupAttributeListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupDeclSyntaxImpl(_ node: Syntax) {
+    if visit(PrecedenceGroupDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrecedenceGroupDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupNameListSyntaxImpl(_ node: Syntax) {
+    if visit(PrecedenceGroupNameListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrecedenceGroupNameListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupNameSyntaxImpl(_ node: Syntax) {
+    if visit(PrecedenceGroupNameSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrecedenceGroupNameSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrecedenceGroupRelationSyntaxImpl(_ node: Syntax) {
+    if visit(PrecedenceGroupRelationSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrecedenceGroupRelationSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrefixOperatorExprSyntaxImpl(_ node: Syntax) {
+    if visit(PrefixOperatorExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrefixOperatorExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrimaryAssociatedTypeClauseSyntaxImpl(_ node: Syntax) {
+    if visit(PrimaryAssociatedTypeClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrimaryAssociatedTypeClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrimaryAssociatedTypeListSyntaxImpl(_ node: Syntax) {
+    if visit(PrimaryAssociatedTypeListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrimaryAssociatedTypeListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitPrimaryAssociatedTypeSyntaxImpl(_ node: Syntax) {
+    if visit(PrimaryAssociatedTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(PrimaryAssociatedTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitProtocolDeclSyntaxImpl(_ node: Syntax) {
+    if visit(ProtocolDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ProtocolDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitRegexLiteralExprSyntaxImpl(_ node: Syntax) {
+    if visit(RegexLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(RegexLiteralExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitRepeatStmtSyntaxImpl(_ node: Syntax) {
+    if visit(RepeatStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(RepeatStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitReturnClauseSyntaxImpl(_ node: Syntax) {
+    if visit(ReturnClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ReturnClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitReturnStmtSyntaxImpl(_ node: Syntax) {
+    if visit(ReturnStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ReturnStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSameTypeRequirementSyntaxImpl(_ node: Syntax) {
+    if visit(SameTypeRequirementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SameTypeRequirementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSequenceExprSyntaxImpl(_ node: Syntax) {
+    if visit(SequenceExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SequenceExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSimpleStringLiteralExprSyntaxImpl(_ node: Syntax) {
+    if visit(SimpleStringLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SimpleStringLiteralExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSimpleStringLiteralSegmentListSyntaxImpl(_ node: Syntax) {
+    if visit(SimpleStringLiteralSegmentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SimpleStringLiteralSegmentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSimpleTypeSpecifierSyntaxImpl(_ node: Syntax) {
+    if visit(SimpleTypeSpecifierSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SimpleTypeSpecifierSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSomeOrAnyTypeSyntaxImpl(_ node: Syntax) {
+    if visit(SomeOrAnyTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SomeOrAnyTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSourceFileSyntaxImpl(_ node: Syntax) {
+    if visit(SourceFileSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SourceFileSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSpecializeAttributeArgumentListSyntaxImpl(_ node: Syntax) {
+    if visit(SpecializeAttributeArgumentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SpecializeAttributeArgumentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSpecializeAvailabilityArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(SpecializeAvailabilityArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SpecializeAvailabilityArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSpecializeTargetFunctionArgumentSyntaxImpl(_ node: Syntax) {
+    if visit(SpecializeTargetFunctionArgumentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SpecializeTargetFunctionArgumentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitStringLiteralExprSyntaxImpl(_ node: Syntax) {
+    if visit(StringLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(StringLiteralExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitStringLiteralSegmentListSyntaxImpl(_ node: Syntax) {
+    if visit(StringLiteralSegmentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(StringLiteralSegmentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitStringSegmentSyntaxImpl(_ node: Syntax) {
+    if visit(StringSegmentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(StringSegmentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitStructDeclSyntaxImpl(_ node: Syntax) {
+    if visit(StructDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(StructDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSubscriptCallExprSyntaxImpl(_ node: Syntax) {
+    if visit(SubscriptCallExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SubscriptCallExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSubscriptDeclSyntaxImpl(_ node: Syntax) {
+    if visit(SubscriptDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SubscriptDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSuperExprSyntaxImpl(_ node: Syntax) {
+    if visit(SuperExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SuperExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSuppressedTypeSyntaxImpl(_ node: Syntax) {
+    if visit(SuppressedTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SuppressedTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseItemListSyntaxImpl(_ node: Syntax) {
+    if visit(SwitchCaseItemListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SwitchCaseItemListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseItemSyntaxImpl(_ node: Syntax) {
+    if visit(SwitchCaseItemSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SwitchCaseItemSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseLabelSyntaxImpl(_ node: Syntax) {
+    if visit(SwitchCaseLabelSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SwitchCaseLabelSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseListSyntaxImpl(_ node: Syntax) {
+    if visit(SwitchCaseListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SwitchCaseListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSwitchCaseSyntaxImpl(_ node: Syntax) {
+    if visit(SwitchCaseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SwitchCaseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSwitchDefaultLabelSyntaxImpl(_ node: Syntax) {
+    if visit(SwitchDefaultLabelSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SwitchDefaultLabelSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitSwitchExprSyntaxImpl(_ node: Syntax) {
+    if visit(SwitchExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(SwitchExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTernaryExprSyntaxImpl(_ node: Syntax) {
+    if visit(TernaryExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TernaryExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitThenStmtSyntaxImpl(_ node: Syntax) {
+    if visit(ThenStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ThenStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitThrowStmtSyntaxImpl(_ node: Syntax) {
+    if visit(ThrowStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ThrowStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitThrowsClauseSyntaxImpl(_ node: Syntax) {
+    if visit(ThrowsClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ThrowsClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTryExprSyntaxImpl(_ node: Syntax) {
+    if visit(TryExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TryExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTupleExprSyntaxImpl(_ node: Syntax) {
+    if visit(TupleExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TupleExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTuplePatternElementListSyntaxImpl(_ node: Syntax) {
+    if visit(TuplePatternElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TuplePatternElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTuplePatternElementSyntaxImpl(_ node: Syntax) {
+    if visit(TuplePatternElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TuplePatternElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTuplePatternSyntaxImpl(_ node: Syntax) {
+    if visit(TuplePatternSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TuplePatternSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTupleTypeElementListSyntaxImpl(_ node: Syntax) {
+    if visit(TupleTypeElementListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TupleTypeElementListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTupleTypeElementSyntaxImpl(_ node: Syntax) {
+    if visit(TupleTypeElementSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TupleTypeElementSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTupleTypeSyntaxImpl(_ node: Syntax) {
+    if visit(TupleTypeSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TupleTypeSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTypeAliasDeclSyntaxImpl(_ node: Syntax) {
+    if visit(TypeAliasDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TypeAliasDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTypeAnnotationSyntaxImpl(_ node: Syntax) {
+    if visit(TypeAnnotationSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TypeAnnotationSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTypeEffectSpecifiersSyntaxImpl(_ node: Syntax) {
+    if visit(TypeEffectSpecifiersSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TypeEffectSpecifiersSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTypeExprSyntaxImpl(_ node: Syntax) {
+    if visit(TypeExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TypeExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTypeInitializerClauseSyntaxImpl(_ node: Syntax) {
+    if visit(TypeInitializerClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TypeInitializerClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitTypeSpecifierListSyntaxImpl(_ node: Syntax) {
+    if visit(TypeSpecifierListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(TypeSpecifierListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitUnavailableFromAsyncAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(UnavailableFromAsyncAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(UnavailableFromAsyncAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitUnderscorePrivateAttributeArgumentsSyntaxImpl(_ node: Syntax) {
+    if visit(UnderscorePrivateAttributeArgumentsSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(UnderscorePrivateAttributeArgumentsSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitUnexpectedNodesSyntaxImpl(_ node: Syntax) {
+    if visit(UnexpectedNodesSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(UnexpectedNodesSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitUnresolvedAsExprSyntaxImpl(_ node: Syntax) {
+    if visit(UnresolvedAsExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(UnresolvedAsExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitUnresolvedIsExprSyntaxImpl(_ node: Syntax) {
+    if visit(UnresolvedIsExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(UnresolvedIsExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitUnresolvedTernaryExprSyntaxImpl(_ node: Syntax) {
+    if visit(UnresolvedTernaryExprSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(UnresolvedTernaryExprSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitValueBindingPatternSyntaxImpl(_ node: Syntax) {
+    if visit(ValueBindingPatternSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(ValueBindingPatternSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitVariableDeclSyntaxImpl(_ node: Syntax) {
+    if visit(VariableDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(VariableDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitVersionComponentListSyntaxImpl(_ node: Syntax) {
+    if visit(VersionComponentListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(VersionComponentListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitVersionComponentSyntaxImpl(_ node: Syntax) {
+    if visit(VersionComponentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(VersionComponentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitVersionTupleSyntaxImpl(_ node: Syntax) {
+    if visit(VersionTupleSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(VersionTupleSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitWhereClauseSyntaxImpl(_ node: Syntax) {
+    if visit(WhereClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(WhereClauseSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitWhileStmtSyntaxImpl(_ node: Syntax) {
+    if visit(WhileStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(WhileStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitWildcardPatternSyntaxImpl(_ node: Syntax) {
+    if visit(WildcardPatternSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(WildcardPatternSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitYieldStmtSyntaxImpl(_ node: Syntax) {
+    if visit(YieldStmtSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(YieldStmtSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitYieldedExpressionListSyntaxImpl(_ node: Syntax) {
+    if visit(YieldedExpressionListSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(YieldedExpressionListSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitYieldedExpressionSyntaxImpl(_ node: Syntax) {
+    if visit(YieldedExpressionSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(YieldedExpressionSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
+  private func visitYieldedExpressionsClauseSyntaxImpl(_ node: Syntax) {
+    if visit(YieldedExpressionsClauseSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(YieldedExpressionsClauseSyntax(unsafeCasting: node))
   }
 
   // SwiftSyntax requires a lot of stack space in debug builds for syntax tree
@@ -3544,1742 +5796,1164 @@ open class SyntaxVisitor {
   /// that determines the correct visitation function will be popped of the
   /// stack before the function is being called, making the switch's stack
   /// space transient instead of having it linger in the call stack.
-  private func visitationFunc(for node: Syntax) -> ((inout Syntax) -> Void) {
+  private func visitationFunc(for node: Syntax) -> (Syntax) -> Void {
     switch node.raw.kind {
     case .token:
-      return {
-        let node = $0.cast(TokenSyntax.self)
-        _ = self.visit(node)
-        // No children to visit.
-        self.visitPost(node)
-      }
+      return self.visitTokenSyntaxImpl(_:)
     case .abiAttributeArguments:
-      return {
-        self.visitImpl(&$0, ABIAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitABIAttributeArgumentsSyntaxImpl(_:)
     case .accessorBlock:
-      return {
-        self.visitImpl(&$0, AccessorBlockSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAccessorBlockSyntaxImpl(_:)
     case .accessorDeclList:
-      return {
-        self.visitImpl(&$0, AccessorDeclListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAccessorDeclListSyntaxImpl(_:)
     case .accessorDecl:
-      return {
-        self.visitImpl(&$0, AccessorDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAccessorDeclSyntaxImpl(_:)
     case .accessorEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, AccessorEffectSpecifiersSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAccessorEffectSpecifiersSyntaxImpl(_:)
     case .accessorParameters:
-      return {
-        self.visitImpl(&$0, AccessorParametersSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAccessorParametersSyntaxImpl(_:)
     case .actorDecl:
-      return {
-        self.visitImpl(&$0, ActorDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitActorDeclSyntaxImpl(_:)
     case .arrayElementList:
-      return {
-        self.visitImpl(&$0, ArrayElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitArrayElementListSyntaxImpl(_:)
     case .arrayElement:
-      return {
-        self.visitImpl(&$0, ArrayElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitArrayElementSyntaxImpl(_:)
     case .arrayExpr:
-      return {
-        self.visitImpl(&$0, ArrayExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitArrayExprSyntaxImpl(_:)
     case .arrayType:
-      return {
-        self.visitImpl(&$0, ArrayTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitArrayTypeSyntaxImpl(_:)
     case .arrowExpr:
-      return {
-        self.visitImpl(&$0, ArrowExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitArrowExprSyntaxImpl(_:)
     case .asExpr:
-      return {
-        self.visitImpl(&$0, AsExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAsExprSyntaxImpl(_:)
     case .assignmentExpr:
-      return {
-        self.visitImpl(&$0, AssignmentExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAssignmentExprSyntaxImpl(_:)
     case .associatedTypeDecl:
-      return {
-        self.visitImpl(&$0, AssociatedTypeDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAssociatedTypeDeclSyntaxImpl(_:)
     case .attributeList:
-      return {
-        self.visitImpl(&$0, AttributeListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAttributeListSyntaxImpl(_:)
     case .attribute:
-      return {
-        self.visitImpl(&$0, AttributeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAttributeSyntaxImpl(_:)
     case .attributedType:
-      return {
-        self.visitImpl(&$0, AttributedTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAttributedTypeSyntaxImpl(_:)
     case .availabilityArgumentList:
-      return {
-        self.visitImpl(&$0, AvailabilityArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAvailabilityArgumentListSyntaxImpl(_:)
     case .availabilityArgument:
-      return {
-        self.visitImpl(&$0, AvailabilityArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAvailabilityArgumentSyntaxImpl(_:)
     case .availabilityCondition:
-      return {
-        self.visitImpl(&$0, AvailabilityConditionSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAvailabilityConditionSyntaxImpl(_:)
     case .availabilityLabeledArgument:
-      return {
-        self.visitImpl(&$0, AvailabilityLabeledArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAvailabilityLabeledArgumentSyntaxImpl(_:)
     case .awaitExpr:
-      return {
-        self.visitImpl(&$0, AwaitExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitAwaitExprSyntaxImpl(_:)
     case .backDeployedAttributeArguments:
-      return {
-        self.visitImpl(&$0, BackDeployedAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitBackDeployedAttributeArgumentsSyntaxImpl(_:)
     case .binaryOperatorExpr:
-      return {
-        self.visitImpl(&$0, BinaryOperatorExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitBinaryOperatorExprSyntaxImpl(_:)
     case .booleanLiteralExpr:
-      return {
-        self.visitImpl(&$0, BooleanLiteralExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitBooleanLiteralExprSyntaxImpl(_:)
     case .borrowExpr:
-      return {
-        self.visitImpl(&$0, BorrowExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitBorrowExprSyntaxImpl(_:)
     case .breakStmt:
-      return {
-        self.visitImpl(&$0, BreakStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitBreakStmtSyntaxImpl(_:)
     case ._canImportExpr:
-      return {
-        self.visitImpl(&$0, _CanImportExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visit_CanImportExprSyntaxImpl(_:)
     case ._canImportVersionInfo:
-      return {
-        self.visitImpl(&$0, _CanImportVersionInfoSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visit_CanImportVersionInfoSyntaxImpl(_:)
     case .catchClauseList:
-      return {
-        self.visitImpl(&$0, CatchClauseListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCatchClauseListSyntaxImpl(_:)
     case .catchClause:
-      return {
-        self.visitImpl(&$0, CatchClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCatchClauseSyntaxImpl(_:)
     case .catchItemList:
-      return {
-        self.visitImpl(&$0, CatchItemListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCatchItemListSyntaxImpl(_:)
     case .catchItem:
-      return {
-        self.visitImpl(&$0, CatchItemSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCatchItemSyntaxImpl(_:)
     case .classDecl:
-      return {
-        self.visitImpl(&$0, ClassDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClassDeclSyntaxImpl(_:)
     case .classRestrictionType:
-      return {
-        self.visitImpl(&$0, ClassRestrictionTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClassRestrictionTypeSyntaxImpl(_:)
     case .closureCaptureClause:
-      return {
-        self.visitImpl(&$0, ClosureCaptureClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureCaptureClauseSyntaxImpl(_:)
     case .closureCaptureList:
-      return {
-        self.visitImpl(&$0, ClosureCaptureListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureCaptureListSyntaxImpl(_:)
     case .closureCaptureSpecifier:
-      return {
-        self.visitImpl(&$0, ClosureCaptureSpecifierSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureCaptureSpecifierSyntaxImpl(_:)
     case .closureCapture:
-      return {
-        self.visitImpl(&$0, ClosureCaptureSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureCaptureSyntaxImpl(_:)
     case .closureExpr:
-      return {
-        self.visitImpl(&$0, ClosureExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureExprSyntaxImpl(_:)
     case .closureParameterClause:
-      return {
-        self.visitImpl(&$0, ClosureParameterClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureParameterClauseSyntaxImpl(_:)
     case .closureParameterList:
-      return {
-        self.visitImpl(&$0, ClosureParameterListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureParameterListSyntaxImpl(_:)
     case .closureParameter:
-      return {
-        self.visitImpl(&$0, ClosureParameterSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureParameterSyntaxImpl(_:)
     case .closureShorthandParameterList:
-      return {
-        self.visitImpl(&$0, ClosureShorthandParameterListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureShorthandParameterListSyntaxImpl(_:)
     case .closureShorthandParameter:
-      return {
-        self.visitImpl(&$0, ClosureShorthandParameterSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureShorthandParameterSyntaxImpl(_:)
     case .closureSignature:
-      return {
-        self.visitImpl(&$0, ClosureSignatureSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitClosureSignatureSyntaxImpl(_:)
     case .codeBlockItemList:
-      return {
-        self.visitImpl(&$0, CodeBlockItemListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCodeBlockItemListSyntaxImpl(_:)
     case .codeBlockItem:
-      return {
-        self.visitImpl(&$0, CodeBlockItemSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCodeBlockItemSyntaxImpl(_:)
     case .codeBlock:
-      return {
-        self.visitImpl(&$0, CodeBlockSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCodeBlockSyntaxImpl(_:)
     case .compositionTypeElementList:
-      return {
-        self.visitImpl(&$0, CompositionTypeElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCompositionTypeElementListSyntaxImpl(_:)
     case .compositionTypeElement:
-      return {
-        self.visitImpl(&$0, CompositionTypeElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCompositionTypeElementSyntaxImpl(_:)
     case .compositionType:
-      return {
-        self.visitImpl(&$0, CompositionTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCompositionTypeSyntaxImpl(_:)
     case .conditionElementList:
-      return {
-        self.visitImpl(&$0, ConditionElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitConditionElementListSyntaxImpl(_:)
     case .conditionElement:
-      return {
-        self.visitImpl(&$0, ConditionElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitConditionElementSyntaxImpl(_:)
     case .conformanceRequirement:
-      return {
-        self.visitImpl(&$0, ConformanceRequirementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitConformanceRequirementSyntaxImpl(_:)
     case .consumeExpr:
-      return {
-        self.visitImpl(&$0, ConsumeExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitConsumeExprSyntaxImpl(_:)
     case .continueStmt:
-      return {
-        self.visitImpl(&$0, ContinueStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitContinueStmtSyntaxImpl(_:)
     case .conventionAttributeArguments:
-      return {
-        self.visitImpl(&$0, ConventionAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitConventionAttributeArgumentsSyntaxImpl(_:)
     case .conventionWitnessMethodAttributeArguments:
-      return {
-        self.visitImpl(&$0, ConventionWitnessMethodAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitConventionWitnessMethodAttributeArgumentsSyntaxImpl(_:)
     case .copyExpr:
-      return {
-        self.visitImpl(&$0, CopyExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitCopyExprSyntaxImpl(_:)
     case .declModifierDetail:
-      return {
-        self.visitImpl(&$0, DeclModifierDetailSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeclModifierDetailSyntaxImpl(_:)
     case .declModifierList:
-      return {
-        self.visitImpl(&$0, DeclModifierListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeclModifierListSyntaxImpl(_:)
     case .declModifier:
-      return {
-        self.visitImpl(&$0, DeclModifierSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeclModifierSyntaxImpl(_:)
     case .declNameArgumentList:
-      return {
-        self.visitImpl(&$0, DeclNameArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeclNameArgumentListSyntaxImpl(_:)
     case .declNameArgument:
-      return {
-        self.visitImpl(&$0, DeclNameArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeclNameArgumentSyntaxImpl(_:)
     case .declNameArguments:
-      return {
-        self.visitImpl(&$0, DeclNameArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeclNameArgumentsSyntaxImpl(_:)
     case .declReferenceExpr:
-      return {
-        self.visitImpl(&$0, DeclReferenceExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeclReferenceExprSyntaxImpl(_:)
     case .deferStmt:
-      return {
-        self.visitImpl(&$0, DeferStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeferStmtSyntaxImpl(_:)
     case .deinitializerDecl:
-      return {
-        self.visitImpl(&$0, DeinitializerDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeinitializerDeclSyntaxImpl(_:)
     case .deinitializerEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, DeinitializerEffectSpecifiersSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDeinitializerEffectSpecifiersSyntaxImpl(_:)
     case .derivativeAttributeArguments:
-      return {
-        self.visitImpl(&$0, DerivativeAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDerivativeAttributeArgumentsSyntaxImpl(_:)
     case .designatedTypeList:
-      return {
-        self.visitImpl(&$0, DesignatedTypeListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDesignatedTypeListSyntaxImpl(_:)
     case .designatedType:
-      return {
-        self.visitImpl(&$0, DesignatedTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDesignatedTypeSyntaxImpl(_:)
     case .dictionaryElementList:
-      return {
-        self.visitImpl(&$0, DictionaryElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDictionaryElementListSyntaxImpl(_:)
     case .dictionaryElement:
-      return {
-        self.visitImpl(&$0, DictionaryElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDictionaryElementSyntaxImpl(_:)
     case .dictionaryExpr:
-      return {
-        self.visitImpl(&$0, DictionaryExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDictionaryExprSyntaxImpl(_:)
     case .dictionaryType:
-      return {
-        self.visitImpl(&$0, DictionaryTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDictionaryTypeSyntaxImpl(_:)
     case .differentiabilityArgumentList:
-      return {
-        self.visitImpl(&$0, DifferentiabilityArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDifferentiabilityArgumentListSyntaxImpl(_:)
     case .differentiabilityArgument:
-      return {
-        self.visitImpl(&$0, DifferentiabilityArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDifferentiabilityArgumentSyntaxImpl(_:)
     case .differentiabilityArguments:
-      return {
-        self.visitImpl(&$0, DifferentiabilityArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDifferentiabilityArgumentsSyntaxImpl(_:)
     case .differentiabilityWithRespectToArgument:
-      return {
-        self.visitImpl(&$0, DifferentiabilityWithRespectToArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDifferentiabilityWithRespectToArgumentSyntaxImpl(_:)
     case .differentiableAttributeArguments:
-      return {
-        self.visitImpl(&$0, DifferentiableAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDifferentiableAttributeArgumentsSyntaxImpl(_:)
     case .discardAssignmentExpr:
-      return {
-        self.visitImpl(&$0, DiscardAssignmentExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDiscardAssignmentExprSyntaxImpl(_:)
     case .discardStmt:
-      return {
-        self.visitImpl(&$0, DiscardStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDiscardStmtSyntaxImpl(_:)
     case .doExpr:
-      return {
-        self.visitImpl(&$0, DoExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDoExprSyntaxImpl(_:)
     case .doStmt:
-      return {
-        self.visitImpl(&$0, DoStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDoStmtSyntaxImpl(_:)
     case .documentationAttributeArgumentList:
-      return {
-        self.visitImpl(&$0, DocumentationAttributeArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDocumentationAttributeArgumentListSyntaxImpl(_:)
     case .documentationAttributeArgument:
-      return {
-        self.visitImpl(&$0, DocumentationAttributeArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDocumentationAttributeArgumentSyntaxImpl(_:)
     case .dynamicReplacementAttributeArguments:
-      return {
-        self.visitImpl(&$0, DynamicReplacementAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitDynamicReplacementAttributeArgumentsSyntaxImpl(_:)
     case .editorPlaceholderDecl:
-      return {
-        self.visitImpl(&$0, EditorPlaceholderDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEditorPlaceholderDeclSyntaxImpl(_:)
     case .editorPlaceholderExpr:
-      return {
-        self.visitImpl(&$0, EditorPlaceholderExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEditorPlaceholderExprSyntaxImpl(_:)
     case .effectsAttributeArgumentList:
-      return {
-        self.visitImpl(&$0, EffectsAttributeArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEffectsAttributeArgumentListSyntaxImpl(_:)
     case .enumCaseDecl:
-      return {
-        self.visitImpl(&$0, EnumCaseDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEnumCaseDeclSyntaxImpl(_:)
     case .enumCaseElementList:
-      return {
-        self.visitImpl(&$0, EnumCaseElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEnumCaseElementListSyntaxImpl(_:)
     case .enumCaseElement:
-      return {
-        self.visitImpl(&$0, EnumCaseElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEnumCaseElementSyntaxImpl(_:)
     case .enumCaseParameterClause:
-      return {
-        self.visitImpl(&$0, EnumCaseParameterClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEnumCaseParameterClauseSyntaxImpl(_:)
     case .enumCaseParameterList:
-      return {
-        self.visitImpl(&$0, EnumCaseParameterListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEnumCaseParameterListSyntaxImpl(_:)
     case .enumCaseParameter:
-      return {
-        self.visitImpl(&$0, EnumCaseParameterSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEnumCaseParameterSyntaxImpl(_:)
     case .enumDecl:
-      return {
-        self.visitImpl(&$0, EnumDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitEnumDeclSyntaxImpl(_:)
     case .exposeAttributeArguments:
-      return {
-        self.visitImpl(&$0, ExposeAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitExposeAttributeArgumentsSyntaxImpl(_:)
     case .exprList:
-      return {
-        self.visitImpl(&$0, ExprListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitExprListSyntaxImpl(_:)
     case .expressionPattern:
-      return {
-        self.visitImpl(&$0, ExpressionPatternSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitExpressionPatternSyntaxImpl(_:)
     case .expressionSegment:
-      return {
-        self.visitImpl(&$0, ExpressionSegmentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitExpressionSegmentSyntaxImpl(_:)
     case .expressionStmt:
-      return {
-        self.visitImpl(&$0, ExpressionStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitExpressionStmtSyntaxImpl(_:)
     case .extensionDecl:
-      return {
-        self.visitImpl(&$0, ExtensionDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitExtensionDeclSyntaxImpl(_:)
     case .fallThroughStmt:
-      return {
-        self.visitImpl(&$0, FallThroughStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFallThroughStmtSyntaxImpl(_:)
     case .floatLiteralExpr:
-      return {
-        self.visitImpl(&$0, FloatLiteralExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFloatLiteralExprSyntaxImpl(_:)
     case .forStmt:
-      return {
-        self.visitImpl(&$0, ForStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitForStmtSyntaxImpl(_:)
     case .forceUnwrapExpr:
-      return {
-        self.visitImpl(&$0, ForceUnwrapExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitForceUnwrapExprSyntaxImpl(_:)
     case .functionCallExpr:
-      return {
-        self.visitImpl(&$0, FunctionCallExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionCallExprSyntaxImpl(_:)
     case .functionDecl:
-      return {
-        self.visitImpl(&$0, FunctionDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionDeclSyntaxImpl(_:)
     case .functionEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, FunctionEffectSpecifiersSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionEffectSpecifiersSyntaxImpl(_:)
     case .functionParameterClause:
-      return {
-        self.visitImpl(&$0, FunctionParameterClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionParameterClauseSyntaxImpl(_:)
     case .functionParameterList:
-      return {
-        self.visitImpl(&$0, FunctionParameterListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionParameterListSyntaxImpl(_:)
     case .functionParameter:
-      return {
-        self.visitImpl(&$0, FunctionParameterSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionParameterSyntaxImpl(_:)
     case .functionSignature:
-      return {
-        self.visitImpl(&$0, FunctionSignatureSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionSignatureSyntaxImpl(_:)
     case .functionType:
-      return {
-        self.visitImpl(&$0, FunctionTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitFunctionTypeSyntaxImpl(_:)
     case .genericArgumentClause:
-      return {
-        self.visitImpl(&$0, GenericArgumentClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericArgumentClauseSyntaxImpl(_:)
     case .genericArgumentList:
-      return {
-        self.visitImpl(&$0, GenericArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericArgumentListSyntaxImpl(_:)
     case .genericArgument:
-      return {
-        self.visitImpl(&$0, GenericArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericArgumentSyntaxImpl(_:)
     case .genericParameterClause:
-      return {
-        self.visitImpl(&$0, GenericParameterClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericParameterClauseSyntaxImpl(_:)
     case .genericParameterList:
-      return {
-        self.visitImpl(&$0, GenericParameterListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericParameterListSyntaxImpl(_:)
     case .genericParameter:
-      return {
-        self.visitImpl(&$0, GenericParameterSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericParameterSyntaxImpl(_:)
     case .genericRequirementList:
-      return {
-        self.visitImpl(&$0, GenericRequirementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericRequirementListSyntaxImpl(_:)
     case .genericRequirement:
-      return {
-        self.visitImpl(&$0, GenericRequirementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericRequirementSyntaxImpl(_:)
     case .genericSpecializationExpr:
-      return {
-        self.visitImpl(&$0, GenericSpecializationExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericSpecializationExprSyntaxImpl(_:)
     case .genericWhereClause:
-      return {
-        self.visitImpl(&$0, GenericWhereClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGenericWhereClauseSyntaxImpl(_:)
     case .guardStmt:
-      return {
-        self.visitImpl(&$0, GuardStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitGuardStmtSyntaxImpl(_:)
     case .identifierPattern:
-      return {
-        self.visitImpl(&$0, IdentifierPatternSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIdentifierPatternSyntaxImpl(_:)
     case .identifierType:
-      return {
-        self.visitImpl(&$0, IdentifierTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIdentifierTypeSyntaxImpl(_:)
     case .ifConfigClauseList:
-      return {
-        self.visitImpl(&$0, IfConfigClauseListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIfConfigClauseListSyntaxImpl(_:)
     case .ifConfigClause:
-      return {
-        self.visitImpl(&$0, IfConfigClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIfConfigClauseSyntaxImpl(_:)
     case .ifConfigDecl:
-      return {
-        self.visitImpl(&$0, IfConfigDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIfConfigDeclSyntaxImpl(_:)
     case .ifExpr:
-      return {
-        self.visitImpl(&$0, IfExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIfExprSyntaxImpl(_:)
     case .implementsAttributeArguments:
-      return {
-        self.visitImpl(&$0, ImplementsAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitImplementsAttributeArgumentsSyntaxImpl(_:)
     case .implicitlyUnwrappedOptionalType:
-      return {
-        self.visitImpl(&$0, ImplicitlyUnwrappedOptionalTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitImplicitlyUnwrappedOptionalTypeSyntaxImpl(_:)
     case .importDecl:
-      return {
-        self.visitImpl(&$0, ImportDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitImportDeclSyntaxImpl(_:)
     case .importPathComponentList:
-      return {
-        self.visitImpl(&$0, ImportPathComponentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitImportPathComponentListSyntaxImpl(_:)
     case .importPathComponent:
-      return {
-        self.visitImpl(&$0, ImportPathComponentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitImportPathComponentSyntaxImpl(_:)
     case .inOutExpr:
-      return {
-        self.visitImpl(&$0, InOutExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitInOutExprSyntaxImpl(_:)
     case .infixOperatorExpr:
-      return {
-        self.visitImpl(&$0, InfixOperatorExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitInfixOperatorExprSyntaxImpl(_:)
     case .inheritanceClause:
-      return {
-        self.visitImpl(&$0, InheritanceClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitInheritanceClauseSyntaxImpl(_:)
     case .inheritedTypeList:
-      return {
-        self.visitImpl(&$0, InheritedTypeListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitInheritedTypeListSyntaxImpl(_:)
     case .inheritedType:
-      return {
-        self.visitImpl(&$0, InheritedTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitInheritedTypeSyntaxImpl(_:)
     case .initializerClause:
-      return {
-        self.visitImpl(&$0, InitializerClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitInitializerClauseSyntaxImpl(_:)
     case .initializerDecl:
-      return {
-        self.visitImpl(&$0, InitializerDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitInitializerDeclSyntaxImpl(_:)
     case .integerLiteralExpr:
-      return {
-        self.visitImpl(&$0, IntegerLiteralExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIntegerLiteralExprSyntaxImpl(_:)
     case .isExpr:
-      return {
-        self.visitImpl(&$0, IsExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIsExprSyntaxImpl(_:)
     case .isTypePattern:
-      return {
-        self.visitImpl(&$0, IsTypePatternSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitIsTypePatternSyntaxImpl(_:)
     case .keyPathComponentList:
-      return {
-        self.visitImpl(&$0, KeyPathComponentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitKeyPathComponentListSyntaxImpl(_:)
     case .keyPathComponent:
-      return {
-        self.visitImpl(&$0, KeyPathComponentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitKeyPathComponentSyntaxImpl(_:)
     case .keyPathExpr:
-      return {
-        self.visitImpl(&$0, KeyPathExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitKeyPathExprSyntaxImpl(_:)
     case .keyPathOptionalComponent:
-      return {
-        self.visitImpl(&$0, KeyPathOptionalComponentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitKeyPathOptionalComponentSyntaxImpl(_:)
     case .keyPathPropertyComponent:
-      return {
-        self.visitImpl(&$0, KeyPathPropertyComponentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitKeyPathPropertyComponentSyntaxImpl(_:)
     case .keyPathSubscriptComponent:
-      return {
-        self.visitImpl(&$0, KeyPathSubscriptComponentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitKeyPathSubscriptComponentSyntaxImpl(_:)
     case .labeledExprList:
-      return {
-        self.visitImpl(&$0, LabeledExprListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLabeledExprListSyntaxImpl(_:)
     case .labeledExpr:
-      return {
-        self.visitImpl(&$0, LabeledExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLabeledExprSyntaxImpl(_:)
     case .labeledSpecializeArgument:
-      return {
-        self.visitImpl(&$0, LabeledSpecializeArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLabeledSpecializeArgumentSyntaxImpl(_:)
     case .labeledStmt:
-      return {
-        self.visitImpl(&$0, LabeledStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLabeledStmtSyntaxImpl(_:)
     case .layoutRequirement:
-      return {
-        self.visitImpl(&$0, LayoutRequirementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLayoutRequirementSyntaxImpl(_:)
     case .lifetimeSpecifierArgumentList:
-      return {
-        self.visitImpl(&$0, LifetimeSpecifierArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLifetimeSpecifierArgumentListSyntaxImpl(_:)
     case .lifetimeSpecifierArgument:
-      return {
-        self.visitImpl(&$0, LifetimeSpecifierArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLifetimeSpecifierArgumentSyntaxImpl(_:)
     case .lifetimeTypeSpecifier:
-      return {
-        self.visitImpl(&$0, LifetimeTypeSpecifierSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitLifetimeTypeSpecifierSyntaxImpl(_:)
     case .macroDecl:
-      return {
-        self.visitImpl(&$0, MacroDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMacroDeclSyntaxImpl(_:)
     case .macroExpansionDecl:
-      return {
-        self.visitImpl(&$0, MacroExpansionDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMacroExpansionDeclSyntaxImpl(_:)
     case .macroExpansionExpr:
-      return {
-        self.visitImpl(&$0, MacroExpansionExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMacroExpansionExprSyntaxImpl(_:)
     case .matchingPatternCondition:
-      return {
-        self.visitImpl(&$0, MatchingPatternConditionSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMatchingPatternConditionSyntaxImpl(_:)
     case .memberAccessExpr:
-      return {
-        self.visitImpl(&$0, MemberAccessExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMemberAccessExprSyntaxImpl(_:)
     case .memberBlockItemList:
-      return {
-        self.visitImpl(&$0, MemberBlockItemListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMemberBlockItemListSyntaxImpl(_:)
     case .memberBlockItem:
-      return {
-        self.visitImpl(&$0, MemberBlockItemSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMemberBlockItemSyntaxImpl(_:)
     case .memberBlock:
-      return {
-        self.visitImpl(&$0, MemberBlockSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMemberBlockSyntaxImpl(_:)
     case .memberType:
-      return {
-        self.visitImpl(&$0, MemberTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMemberTypeSyntaxImpl(_:)
     case .metatypeType:
-      return {
-        self.visitImpl(&$0, MetatypeTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMetatypeTypeSyntaxImpl(_:)
     case .missingDecl:
-      return {
-        self.visitImpl(&$0, MissingDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMissingDeclSyntaxImpl(_:)
     case .missingExpr:
-      return {
-        self.visitImpl(&$0, MissingExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMissingExprSyntaxImpl(_:)
     case .missingPattern:
-      return {
-        self.visitImpl(&$0, MissingPatternSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMissingPatternSyntaxImpl(_:)
     case .missingStmt:
-      return {
-        self.visitImpl(&$0, MissingStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMissingStmtSyntaxImpl(_:)
     case .missing:
-      return {
-        self.visitImpl(&$0, MissingSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMissingSyntaxImpl(_:)
     case .missingType:
-      return {
-        self.visitImpl(&$0, MissingTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMissingTypeSyntaxImpl(_:)
     case .multipleTrailingClosureElementList:
-      return {
-        self.visitImpl(&$0, MultipleTrailingClosureElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMultipleTrailingClosureElementListSyntaxImpl(_:)
     case .multipleTrailingClosureElement:
-      return {
-        self.visitImpl(&$0, MultipleTrailingClosureElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitMultipleTrailingClosureElementSyntaxImpl(_:)
     case .namedOpaqueReturnType:
-      return {
-        self.visitImpl(&$0, NamedOpaqueReturnTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitNamedOpaqueReturnTypeSyntaxImpl(_:)
     case .nilLiteralExpr:
-      return {
-        self.visitImpl(&$0, NilLiteralExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitNilLiteralExprSyntaxImpl(_:)
     case .objCSelectorPieceList:
-      return {
-        self.visitImpl(&$0, ObjCSelectorPieceListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitObjCSelectorPieceListSyntaxImpl(_:)
     case .objCSelectorPiece:
-      return {
-        self.visitImpl(&$0, ObjCSelectorPieceSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitObjCSelectorPieceSyntaxImpl(_:)
     case .opaqueReturnTypeOfAttributeArguments:
-      return {
-        self.visitImpl(&$0, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitOpaqueReturnTypeOfAttributeArgumentsSyntaxImpl(_:)
     case .operatorDecl:
-      return {
-        self.visitImpl(&$0, OperatorDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitOperatorDeclSyntaxImpl(_:)
     case .operatorPrecedenceAndTypes:
-      return {
-        self.visitImpl(&$0, OperatorPrecedenceAndTypesSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitOperatorPrecedenceAndTypesSyntaxImpl(_:)
     case .optionalBindingCondition:
-      return {
-        self.visitImpl(&$0, OptionalBindingConditionSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitOptionalBindingConditionSyntaxImpl(_:)
     case .optionalChainingExpr:
-      return {
-        self.visitImpl(&$0, OptionalChainingExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitOptionalChainingExprSyntaxImpl(_:)
     case .optionalType:
-      return {
-        self.visitImpl(&$0, OptionalTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitOptionalTypeSyntaxImpl(_:)
     case .originallyDefinedInAttributeArguments:
-      return {
-        self.visitImpl(&$0, OriginallyDefinedInAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitOriginallyDefinedInAttributeArgumentsSyntaxImpl(_:)
     case .packElementExpr:
-      return {
-        self.visitImpl(&$0, PackElementExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPackElementExprSyntaxImpl(_:)
     case .packElementType:
-      return {
-        self.visitImpl(&$0, PackElementTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPackElementTypeSyntaxImpl(_:)
     case .packExpansionExpr:
-      return {
-        self.visitImpl(&$0, PackExpansionExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPackExpansionExprSyntaxImpl(_:)
     case .packExpansionType:
-      return {
-        self.visitImpl(&$0, PackExpansionTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPackExpansionTypeSyntaxImpl(_:)
     case .patternBindingList:
-      return {
-        self.visitImpl(&$0, PatternBindingListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPatternBindingListSyntaxImpl(_:)
     case .patternBinding:
-      return {
-        self.visitImpl(&$0, PatternBindingSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPatternBindingSyntaxImpl(_:)
     case .patternExpr:
-      return {
-        self.visitImpl(&$0, PatternExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPatternExprSyntaxImpl(_:)
     case .platformVersionItemList:
-      return {
-        self.visitImpl(&$0, PlatformVersionItemListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPlatformVersionItemListSyntaxImpl(_:)
     case .platformVersionItem:
-      return {
-        self.visitImpl(&$0, PlatformVersionItemSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPlatformVersionItemSyntaxImpl(_:)
     case .platformVersion:
-      return {
-        self.visitImpl(&$0, PlatformVersionSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPlatformVersionSyntaxImpl(_:)
     case .postfixIfConfigExpr:
-      return {
-        self.visitImpl(&$0, PostfixIfConfigExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPostfixIfConfigExprSyntaxImpl(_:)
     case .postfixOperatorExpr:
-      return {
-        self.visitImpl(&$0, PostfixOperatorExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPostfixOperatorExprSyntaxImpl(_:)
     case .poundSourceLocationArguments:
-      return {
-        self.visitImpl(&$0, PoundSourceLocationArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPoundSourceLocationArgumentsSyntaxImpl(_:)
     case .poundSourceLocation:
-      return {
-        self.visitImpl(&$0, PoundSourceLocationSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPoundSourceLocationSyntaxImpl(_:)
     case .precedenceGroupAssignment:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupAssignmentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrecedenceGroupAssignmentSyntaxImpl(_:)
     case .precedenceGroupAssociativity:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupAssociativitySyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrecedenceGroupAssociativitySyntaxImpl(_:)
     case .precedenceGroupAttributeList:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupAttributeListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrecedenceGroupAttributeListSyntaxImpl(_:)
     case .precedenceGroupDecl:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrecedenceGroupDeclSyntaxImpl(_:)
     case .precedenceGroupNameList:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupNameListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrecedenceGroupNameListSyntaxImpl(_:)
     case .precedenceGroupName:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupNameSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrecedenceGroupNameSyntaxImpl(_:)
     case .precedenceGroupRelation:
-      return {
-        self.visitImpl(&$0, PrecedenceGroupRelationSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrecedenceGroupRelationSyntaxImpl(_:)
     case .prefixOperatorExpr:
-      return {
-        self.visitImpl(&$0, PrefixOperatorExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrefixOperatorExprSyntaxImpl(_:)
     case .primaryAssociatedTypeClause:
-      return {
-        self.visitImpl(&$0, PrimaryAssociatedTypeClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrimaryAssociatedTypeClauseSyntaxImpl(_:)
     case .primaryAssociatedTypeList:
-      return {
-        self.visitImpl(&$0, PrimaryAssociatedTypeListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrimaryAssociatedTypeListSyntaxImpl(_:)
     case .primaryAssociatedType:
-      return {
-        self.visitImpl(&$0, PrimaryAssociatedTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitPrimaryAssociatedTypeSyntaxImpl(_:)
     case .protocolDecl:
-      return {
-        self.visitImpl(&$0, ProtocolDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitProtocolDeclSyntaxImpl(_:)
     case .regexLiteralExpr:
-      return {
-        self.visitImpl(&$0, RegexLiteralExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitRegexLiteralExprSyntaxImpl(_:)
     case .repeatStmt:
-      return {
-        self.visitImpl(&$0, RepeatStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitRepeatStmtSyntaxImpl(_:)
     case .returnClause:
-      return {
-        self.visitImpl(&$0, ReturnClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitReturnClauseSyntaxImpl(_:)
     case .returnStmt:
-      return {
-        self.visitImpl(&$0, ReturnStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitReturnStmtSyntaxImpl(_:)
     case .sameTypeRequirement:
-      return {
-        self.visitImpl(&$0, SameTypeRequirementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSameTypeRequirementSyntaxImpl(_:)
     case .sequenceExpr:
-      return {
-        self.visitImpl(&$0, SequenceExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSequenceExprSyntaxImpl(_:)
     case .simpleStringLiteralExpr:
-      return {
-        self.visitImpl(&$0, SimpleStringLiteralExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSimpleStringLiteralExprSyntaxImpl(_:)
     case .simpleStringLiteralSegmentList:
-      return {
-        self.visitImpl(&$0, SimpleStringLiteralSegmentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSimpleStringLiteralSegmentListSyntaxImpl(_:)
     case .simpleTypeSpecifier:
-      return {
-        self.visitImpl(&$0, SimpleTypeSpecifierSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSimpleTypeSpecifierSyntaxImpl(_:)
     case .someOrAnyType:
-      return {
-        self.visitImpl(&$0, SomeOrAnyTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSomeOrAnyTypeSyntaxImpl(_:)
     case .sourceFile:
-      return {
-        self.visitImpl(&$0, SourceFileSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSourceFileSyntaxImpl(_:)
     case .specializeAttributeArgumentList:
-      return {
-        self.visitImpl(&$0, SpecializeAttributeArgumentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSpecializeAttributeArgumentListSyntaxImpl(_:)
     case .specializeAvailabilityArgument:
-      return {
-        self.visitImpl(&$0, SpecializeAvailabilityArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSpecializeAvailabilityArgumentSyntaxImpl(_:)
     case .specializeTargetFunctionArgument:
-      return {
-        self.visitImpl(&$0, SpecializeTargetFunctionArgumentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSpecializeTargetFunctionArgumentSyntaxImpl(_:)
     case .stringLiteralExpr:
-      return {
-        self.visitImpl(&$0, StringLiteralExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitStringLiteralExprSyntaxImpl(_:)
     case .stringLiteralSegmentList:
-      return {
-        self.visitImpl(&$0, StringLiteralSegmentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitStringLiteralSegmentListSyntaxImpl(_:)
     case .stringSegment:
-      return {
-        self.visitImpl(&$0, StringSegmentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitStringSegmentSyntaxImpl(_:)
     case .structDecl:
-      return {
-        self.visitImpl(&$0, StructDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitStructDeclSyntaxImpl(_:)
     case .subscriptCallExpr:
-      return {
-        self.visitImpl(&$0, SubscriptCallExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSubscriptCallExprSyntaxImpl(_:)
     case .subscriptDecl:
-      return {
-        self.visitImpl(&$0, SubscriptDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSubscriptDeclSyntaxImpl(_:)
     case .superExpr:
-      return {
-        self.visitImpl(&$0, SuperExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSuperExprSyntaxImpl(_:)
     case .suppressedType:
-      return {
-        self.visitImpl(&$0, SuppressedTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSuppressedTypeSyntaxImpl(_:)
     case .switchCaseItemList:
-      return {
-        self.visitImpl(&$0, SwitchCaseItemListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSwitchCaseItemListSyntaxImpl(_:)
     case .switchCaseItem:
-      return {
-        self.visitImpl(&$0, SwitchCaseItemSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSwitchCaseItemSyntaxImpl(_:)
     case .switchCaseLabel:
-      return {
-        self.visitImpl(&$0, SwitchCaseLabelSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSwitchCaseLabelSyntaxImpl(_:)
     case .switchCaseList:
-      return {
-        self.visitImpl(&$0, SwitchCaseListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSwitchCaseListSyntaxImpl(_:)
     case .switchCase:
-      return {
-        self.visitImpl(&$0, SwitchCaseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSwitchCaseSyntaxImpl(_:)
     case .switchDefaultLabel:
-      return {
-        self.visitImpl(&$0, SwitchDefaultLabelSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSwitchDefaultLabelSyntaxImpl(_:)
     case .switchExpr:
-      return {
-        self.visitImpl(&$0, SwitchExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitSwitchExprSyntaxImpl(_:)
     case .ternaryExpr:
-      return {
-        self.visitImpl(&$0, TernaryExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTernaryExprSyntaxImpl(_:)
     case .thenStmt:
-      return {
-        self.visitImpl(&$0, ThenStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitThenStmtSyntaxImpl(_:)
     case .throwStmt:
-      return {
-        self.visitImpl(&$0, ThrowStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitThrowStmtSyntaxImpl(_:)
     case .throwsClause:
-      return {
-        self.visitImpl(&$0, ThrowsClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitThrowsClauseSyntaxImpl(_:)
     case .tryExpr:
-      return {
-        self.visitImpl(&$0, TryExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTryExprSyntaxImpl(_:)
     case .tupleExpr:
-      return {
-        self.visitImpl(&$0, TupleExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTupleExprSyntaxImpl(_:)
     case .tuplePatternElementList:
-      return {
-        self.visitImpl(&$0, TuplePatternElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTuplePatternElementListSyntaxImpl(_:)
     case .tuplePatternElement:
-      return {
-        self.visitImpl(&$0, TuplePatternElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTuplePatternElementSyntaxImpl(_:)
     case .tuplePattern:
-      return {
-        self.visitImpl(&$0, TuplePatternSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTuplePatternSyntaxImpl(_:)
     case .tupleTypeElementList:
-      return {
-        self.visitImpl(&$0, TupleTypeElementListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTupleTypeElementListSyntaxImpl(_:)
     case .tupleTypeElement:
-      return {
-        self.visitImpl(&$0, TupleTypeElementSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTupleTypeElementSyntaxImpl(_:)
     case .tupleType:
-      return {
-        self.visitImpl(&$0, TupleTypeSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTupleTypeSyntaxImpl(_:)
     case .typeAliasDecl:
-      return {
-        self.visitImpl(&$0, TypeAliasDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTypeAliasDeclSyntaxImpl(_:)
     case .typeAnnotation:
-      return {
-        self.visitImpl(&$0, TypeAnnotationSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTypeAnnotationSyntaxImpl(_:)
     case .typeEffectSpecifiers:
-      return {
-        self.visitImpl(&$0, TypeEffectSpecifiersSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTypeEffectSpecifiersSyntaxImpl(_:)
     case .typeExpr:
-      return {
-        self.visitImpl(&$0, TypeExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTypeExprSyntaxImpl(_:)
     case .typeInitializerClause:
-      return {
-        self.visitImpl(&$0, TypeInitializerClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTypeInitializerClauseSyntaxImpl(_:)
     case .typeSpecifierList:
-      return {
-        self.visitImpl(&$0, TypeSpecifierListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitTypeSpecifierListSyntaxImpl(_:)
     case .unavailableFromAsyncAttributeArguments:
-      return {
-        self.visitImpl(&$0, UnavailableFromAsyncAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitUnavailableFromAsyncAttributeArgumentsSyntaxImpl(_:)
     case .underscorePrivateAttributeArguments:
-      return {
-        self.visitImpl(&$0, UnderscorePrivateAttributeArgumentsSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitUnderscorePrivateAttributeArgumentsSyntaxImpl(_:)
     case .unexpectedNodes:
-      return {
-        self.visitImpl(&$0, UnexpectedNodesSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitUnexpectedNodesSyntaxImpl(_:)
     case .unresolvedAsExpr:
-      return {
-        self.visitImpl(&$0, UnresolvedAsExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitUnresolvedAsExprSyntaxImpl(_:)
     case .unresolvedIsExpr:
-      return {
-        self.visitImpl(&$0, UnresolvedIsExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitUnresolvedIsExprSyntaxImpl(_:)
     case .unresolvedTernaryExpr:
-      return {
-        self.visitImpl(&$0, UnresolvedTernaryExprSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitUnresolvedTernaryExprSyntaxImpl(_:)
     case .valueBindingPattern:
-      return {
-        self.visitImpl(&$0, ValueBindingPatternSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitValueBindingPatternSyntaxImpl(_:)
     case .variableDecl:
-      return {
-        self.visitImpl(&$0, VariableDeclSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitVariableDeclSyntaxImpl(_:)
     case .versionComponentList:
-      return {
-        self.visitImpl(&$0, VersionComponentListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitVersionComponentListSyntaxImpl(_:)
     case .versionComponent:
-      return {
-        self.visitImpl(&$0, VersionComponentSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitVersionComponentSyntaxImpl(_:)
     case .versionTuple:
-      return {
-        self.visitImpl(&$0, VersionTupleSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitVersionTupleSyntaxImpl(_:)
     case .whereClause:
-      return {
-        self.visitImpl(&$0, WhereClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitWhereClauseSyntaxImpl(_:)
     case .whileStmt:
-      return {
-        self.visitImpl(&$0, WhileStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitWhileStmtSyntaxImpl(_:)
     case .wildcardPattern:
-      return {
-        self.visitImpl(&$0, WildcardPatternSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitWildcardPatternSyntaxImpl(_:)
     case .yieldStmt:
-      return {
-        self.visitImpl(&$0, YieldStmtSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitYieldStmtSyntaxImpl(_:)
     case .yieldedExpressionList:
-      return {
-        self.visitImpl(&$0, YieldedExpressionListSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitYieldedExpressionListSyntaxImpl(_:)
     case .yieldedExpression:
-      return {
-        self.visitImpl(&$0, YieldedExpressionSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitYieldedExpressionSyntaxImpl(_:)
     case .yieldedExpressionsClause:
-      return {
-        self.visitImpl(&$0, YieldedExpressionsClauseSyntax.self, self.visit, self.visitPost)
-      }
+      return self.visitYieldedExpressionsClauseSyntaxImpl(_:)
     }
   }
-  private func visit(_ node: inout Syntax) {
-    return visitationFunc(for: node)(&node)
+  private func dispatchVisit(_ node: Syntax) {
+    return visitationFunc(for: node)(node)
   }
   #else
-  /// - Note: `node` is `inout` to avoid ref-counting. See comment in `visitImpl`
-  private func visit(_ node: inout Syntax) {
+  private func dispatchVisit(_ node: Syntax) {
     switch node.raw.kind {
     case .token:
-      let node = node.cast(TokenSyntax.self)
-      _ = visit(node)
-      // No children to visit.
-      visitPost(node)
+      self.visitTokenSyntaxImpl(node)
     case .abiAttributeArguments:
-      visitImpl(&node, ABIAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitABIAttributeArgumentsSyntaxImpl(node)
     case .accessorBlock:
-      visitImpl(&node, AccessorBlockSyntax.self, visit, visitPost)
+      self.visitAccessorBlockSyntaxImpl(node)
     case .accessorDeclList:
-      visitImpl(&node, AccessorDeclListSyntax.self, visit, visitPost)
+      self.visitAccessorDeclListSyntaxImpl(node)
     case .accessorDecl:
-      visitImpl(&node, AccessorDeclSyntax.self, visit, visitPost)
+      self.visitAccessorDeclSyntaxImpl(node)
     case .accessorEffectSpecifiers:
-      visitImpl(&node, AccessorEffectSpecifiersSyntax.self, visit, visitPost)
+      self.visitAccessorEffectSpecifiersSyntaxImpl(node)
     case .accessorParameters:
-      visitImpl(&node, AccessorParametersSyntax.self, visit, visitPost)
+      self.visitAccessorParametersSyntaxImpl(node)
     case .actorDecl:
-      visitImpl(&node, ActorDeclSyntax.self, visit, visitPost)
+      self.visitActorDeclSyntaxImpl(node)
     case .arrayElementList:
-      visitImpl(&node, ArrayElementListSyntax.self, visit, visitPost)
+      self.visitArrayElementListSyntaxImpl(node)
     case .arrayElement:
-      visitImpl(&node, ArrayElementSyntax.self, visit, visitPost)
+      self.visitArrayElementSyntaxImpl(node)
     case .arrayExpr:
-      visitImpl(&node, ArrayExprSyntax.self, visit, visitPost)
+      self.visitArrayExprSyntaxImpl(node)
     case .arrayType:
-      visitImpl(&node, ArrayTypeSyntax.self, visit, visitPost)
+      self.visitArrayTypeSyntaxImpl(node)
     case .arrowExpr:
-      visitImpl(&node, ArrowExprSyntax.self, visit, visitPost)
+      self.visitArrowExprSyntaxImpl(node)
     case .asExpr:
-      visitImpl(&node, AsExprSyntax.self, visit, visitPost)
+      self.visitAsExprSyntaxImpl(node)
     case .assignmentExpr:
-      visitImpl(&node, AssignmentExprSyntax.self, visit, visitPost)
+      self.visitAssignmentExprSyntaxImpl(node)
     case .associatedTypeDecl:
-      visitImpl(&node, AssociatedTypeDeclSyntax.self, visit, visitPost)
+      self.visitAssociatedTypeDeclSyntaxImpl(node)
     case .attributeList:
-      visitImpl(&node, AttributeListSyntax.self, visit, visitPost)
+      self.visitAttributeListSyntaxImpl(node)
     case .attribute:
-      visitImpl(&node, AttributeSyntax.self, visit, visitPost)
+      self.visitAttributeSyntaxImpl(node)
     case .attributedType:
-      visitImpl(&node, AttributedTypeSyntax.self, visit, visitPost)
+      self.visitAttributedTypeSyntaxImpl(node)
     case .availabilityArgumentList:
-      visitImpl(&node, AvailabilityArgumentListSyntax.self, visit, visitPost)
+      self.visitAvailabilityArgumentListSyntaxImpl(node)
     case .availabilityArgument:
-      visitImpl(&node, AvailabilityArgumentSyntax.self, visit, visitPost)
+      self.visitAvailabilityArgumentSyntaxImpl(node)
     case .availabilityCondition:
-      visitImpl(&node, AvailabilityConditionSyntax.self, visit, visitPost)
+      self.visitAvailabilityConditionSyntaxImpl(node)
     case .availabilityLabeledArgument:
-      visitImpl(&node, AvailabilityLabeledArgumentSyntax.self, visit, visitPost)
+      self.visitAvailabilityLabeledArgumentSyntaxImpl(node)
     case .awaitExpr:
-      visitImpl(&node, AwaitExprSyntax.self, visit, visitPost)
+      self.visitAwaitExprSyntaxImpl(node)
     case .backDeployedAttributeArguments:
-      visitImpl(&node, BackDeployedAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitBackDeployedAttributeArgumentsSyntaxImpl(node)
     case .binaryOperatorExpr:
-      visitImpl(&node, BinaryOperatorExprSyntax.self, visit, visitPost)
+      self.visitBinaryOperatorExprSyntaxImpl(node)
     case .booleanLiteralExpr:
-      visitImpl(&node, BooleanLiteralExprSyntax.self, visit, visitPost)
+      self.visitBooleanLiteralExprSyntaxImpl(node)
     case .borrowExpr:
-      visitImpl(&node, BorrowExprSyntax.self, visit, visitPost)
+      self.visitBorrowExprSyntaxImpl(node)
     case .breakStmt:
-      visitImpl(&node, BreakStmtSyntax.self, visit, visitPost)
+      self.visitBreakStmtSyntaxImpl(node)
     case ._canImportExpr:
-      visitImpl(&node, _CanImportExprSyntax.self, visit, visitPost)
+      self.visit_CanImportExprSyntaxImpl(node)
     case ._canImportVersionInfo:
-      visitImpl(&node, _CanImportVersionInfoSyntax.self, visit, visitPost)
+      self.visit_CanImportVersionInfoSyntaxImpl(node)
     case .catchClauseList:
-      visitImpl(&node, CatchClauseListSyntax.self, visit, visitPost)
+      self.visitCatchClauseListSyntaxImpl(node)
     case .catchClause:
-      visitImpl(&node, CatchClauseSyntax.self, visit, visitPost)
+      self.visitCatchClauseSyntaxImpl(node)
     case .catchItemList:
-      visitImpl(&node, CatchItemListSyntax.self, visit, visitPost)
+      self.visitCatchItemListSyntaxImpl(node)
     case .catchItem:
-      visitImpl(&node, CatchItemSyntax.self, visit, visitPost)
+      self.visitCatchItemSyntaxImpl(node)
     case .classDecl:
-      visitImpl(&node, ClassDeclSyntax.self, visit, visitPost)
+      self.visitClassDeclSyntaxImpl(node)
     case .classRestrictionType:
-      visitImpl(&node, ClassRestrictionTypeSyntax.self, visit, visitPost)
+      self.visitClassRestrictionTypeSyntaxImpl(node)
     case .closureCaptureClause:
-      visitImpl(&node, ClosureCaptureClauseSyntax.self, visit, visitPost)
+      self.visitClosureCaptureClauseSyntaxImpl(node)
     case .closureCaptureList:
-      visitImpl(&node, ClosureCaptureListSyntax.self, visit, visitPost)
+      self.visitClosureCaptureListSyntaxImpl(node)
     case .closureCaptureSpecifier:
-      visitImpl(&node, ClosureCaptureSpecifierSyntax.self, visit, visitPost)
+      self.visitClosureCaptureSpecifierSyntaxImpl(node)
     case .closureCapture:
-      visitImpl(&node, ClosureCaptureSyntax.self, visit, visitPost)
+      self.visitClosureCaptureSyntaxImpl(node)
     case .closureExpr:
-      visitImpl(&node, ClosureExprSyntax.self, visit, visitPost)
+      self.visitClosureExprSyntaxImpl(node)
     case .closureParameterClause:
-      visitImpl(&node, ClosureParameterClauseSyntax.self, visit, visitPost)
+      self.visitClosureParameterClauseSyntaxImpl(node)
     case .closureParameterList:
-      visitImpl(&node, ClosureParameterListSyntax.self, visit, visitPost)
+      self.visitClosureParameterListSyntaxImpl(node)
     case .closureParameter:
-      visitImpl(&node, ClosureParameterSyntax.self, visit, visitPost)
+      self.visitClosureParameterSyntaxImpl(node)
     case .closureShorthandParameterList:
-      visitImpl(&node, ClosureShorthandParameterListSyntax.self, visit, visitPost)
+      self.visitClosureShorthandParameterListSyntaxImpl(node)
     case .closureShorthandParameter:
-      visitImpl(&node, ClosureShorthandParameterSyntax.self, visit, visitPost)
+      self.visitClosureShorthandParameterSyntaxImpl(node)
     case .closureSignature:
-      visitImpl(&node, ClosureSignatureSyntax.self, visit, visitPost)
+      self.visitClosureSignatureSyntaxImpl(node)
     case .codeBlockItemList:
-      visitImpl(&node, CodeBlockItemListSyntax.self, visit, visitPost)
+      self.visitCodeBlockItemListSyntaxImpl(node)
     case .codeBlockItem:
-      visitImpl(&node, CodeBlockItemSyntax.self, visit, visitPost)
+      self.visitCodeBlockItemSyntaxImpl(node)
     case .codeBlock:
-      visitImpl(&node, CodeBlockSyntax.self, visit, visitPost)
+      self.visitCodeBlockSyntaxImpl(node)
     case .compositionTypeElementList:
-      visitImpl(&node, CompositionTypeElementListSyntax.self, visit, visitPost)
+      self.visitCompositionTypeElementListSyntaxImpl(node)
     case .compositionTypeElement:
-      visitImpl(&node, CompositionTypeElementSyntax.self, visit, visitPost)
+      self.visitCompositionTypeElementSyntaxImpl(node)
     case .compositionType:
-      visitImpl(&node, CompositionTypeSyntax.self, visit, visitPost)
+      self.visitCompositionTypeSyntaxImpl(node)
     case .conditionElementList:
-      visitImpl(&node, ConditionElementListSyntax.self, visit, visitPost)
+      self.visitConditionElementListSyntaxImpl(node)
     case .conditionElement:
-      visitImpl(&node, ConditionElementSyntax.self, visit, visitPost)
+      self.visitConditionElementSyntaxImpl(node)
     case .conformanceRequirement:
-      visitImpl(&node, ConformanceRequirementSyntax.self, visit, visitPost)
+      self.visitConformanceRequirementSyntaxImpl(node)
     case .consumeExpr:
-      visitImpl(&node, ConsumeExprSyntax.self, visit, visitPost)
+      self.visitConsumeExprSyntaxImpl(node)
     case .continueStmt:
-      visitImpl(&node, ContinueStmtSyntax.self, visit, visitPost)
+      self.visitContinueStmtSyntaxImpl(node)
     case .conventionAttributeArguments:
-      visitImpl(&node, ConventionAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitConventionAttributeArgumentsSyntaxImpl(node)
     case .conventionWitnessMethodAttributeArguments:
-      visitImpl(&node, ConventionWitnessMethodAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitConventionWitnessMethodAttributeArgumentsSyntaxImpl(node)
     case .copyExpr:
-      visitImpl(&node, CopyExprSyntax.self, visit, visitPost)
+      self.visitCopyExprSyntaxImpl(node)
     case .declModifierDetail:
-      visitImpl(&node, DeclModifierDetailSyntax.self, visit, visitPost)
+      self.visitDeclModifierDetailSyntaxImpl(node)
     case .declModifierList:
-      visitImpl(&node, DeclModifierListSyntax.self, visit, visitPost)
+      self.visitDeclModifierListSyntaxImpl(node)
     case .declModifier:
-      visitImpl(&node, DeclModifierSyntax.self, visit, visitPost)
+      self.visitDeclModifierSyntaxImpl(node)
     case .declNameArgumentList:
-      visitImpl(&node, DeclNameArgumentListSyntax.self, visit, visitPost)
+      self.visitDeclNameArgumentListSyntaxImpl(node)
     case .declNameArgument:
-      visitImpl(&node, DeclNameArgumentSyntax.self, visit, visitPost)
+      self.visitDeclNameArgumentSyntaxImpl(node)
     case .declNameArguments:
-      visitImpl(&node, DeclNameArgumentsSyntax.self, visit, visitPost)
+      self.visitDeclNameArgumentsSyntaxImpl(node)
     case .declReferenceExpr:
-      visitImpl(&node, DeclReferenceExprSyntax.self, visit, visitPost)
+      self.visitDeclReferenceExprSyntaxImpl(node)
     case .deferStmt:
-      visitImpl(&node, DeferStmtSyntax.self, visit, visitPost)
+      self.visitDeferStmtSyntaxImpl(node)
     case .deinitializerDecl:
-      visitImpl(&node, DeinitializerDeclSyntax.self, visit, visitPost)
+      self.visitDeinitializerDeclSyntaxImpl(node)
     case .deinitializerEffectSpecifiers:
-      visitImpl(&node, DeinitializerEffectSpecifiersSyntax.self, visit, visitPost)
+      self.visitDeinitializerEffectSpecifiersSyntaxImpl(node)
     case .derivativeAttributeArguments:
-      visitImpl(&node, DerivativeAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitDerivativeAttributeArgumentsSyntaxImpl(node)
     case .designatedTypeList:
-      visitImpl(&node, DesignatedTypeListSyntax.self, visit, visitPost)
+      self.visitDesignatedTypeListSyntaxImpl(node)
     case .designatedType:
-      visitImpl(&node, DesignatedTypeSyntax.self, visit, visitPost)
+      self.visitDesignatedTypeSyntaxImpl(node)
     case .dictionaryElementList:
-      visitImpl(&node, DictionaryElementListSyntax.self, visit, visitPost)
+      self.visitDictionaryElementListSyntaxImpl(node)
     case .dictionaryElement:
-      visitImpl(&node, DictionaryElementSyntax.self, visit, visitPost)
+      self.visitDictionaryElementSyntaxImpl(node)
     case .dictionaryExpr:
-      visitImpl(&node, DictionaryExprSyntax.self, visit, visitPost)
+      self.visitDictionaryExprSyntaxImpl(node)
     case .dictionaryType:
-      visitImpl(&node, DictionaryTypeSyntax.self, visit, visitPost)
+      self.visitDictionaryTypeSyntaxImpl(node)
     case .differentiabilityArgumentList:
-      visitImpl(&node, DifferentiabilityArgumentListSyntax.self, visit, visitPost)
+      self.visitDifferentiabilityArgumentListSyntaxImpl(node)
     case .differentiabilityArgument:
-      visitImpl(&node, DifferentiabilityArgumentSyntax.self, visit, visitPost)
+      self.visitDifferentiabilityArgumentSyntaxImpl(node)
     case .differentiabilityArguments:
-      visitImpl(&node, DifferentiabilityArgumentsSyntax.self, visit, visitPost)
+      self.visitDifferentiabilityArgumentsSyntaxImpl(node)
     case .differentiabilityWithRespectToArgument:
-      visitImpl(&node, DifferentiabilityWithRespectToArgumentSyntax.self, visit, visitPost)
+      self.visitDifferentiabilityWithRespectToArgumentSyntaxImpl(node)
     case .differentiableAttributeArguments:
-      visitImpl(&node, DifferentiableAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitDifferentiableAttributeArgumentsSyntaxImpl(node)
     case .discardAssignmentExpr:
-      visitImpl(&node, DiscardAssignmentExprSyntax.self, visit, visitPost)
+      self.visitDiscardAssignmentExprSyntaxImpl(node)
     case .discardStmt:
-      visitImpl(&node, DiscardStmtSyntax.self, visit, visitPost)
+      self.visitDiscardStmtSyntaxImpl(node)
     case .doExpr:
-      visitImpl(&node, DoExprSyntax.self, visit, visitPost)
+      self.visitDoExprSyntaxImpl(node)
     case .doStmt:
-      visitImpl(&node, DoStmtSyntax.self, visit, visitPost)
+      self.visitDoStmtSyntaxImpl(node)
     case .documentationAttributeArgumentList:
-      visitImpl(&node, DocumentationAttributeArgumentListSyntax.self, visit, visitPost)
+      self.visitDocumentationAttributeArgumentListSyntaxImpl(node)
     case .documentationAttributeArgument:
-      visitImpl(&node, DocumentationAttributeArgumentSyntax.self, visit, visitPost)
+      self.visitDocumentationAttributeArgumentSyntaxImpl(node)
     case .dynamicReplacementAttributeArguments:
-      visitImpl(&node, DynamicReplacementAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitDynamicReplacementAttributeArgumentsSyntaxImpl(node)
     case .editorPlaceholderDecl:
-      visitImpl(&node, EditorPlaceholderDeclSyntax.self, visit, visitPost)
+      self.visitEditorPlaceholderDeclSyntaxImpl(node)
     case .editorPlaceholderExpr:
-      visitImpl(&node, EditorPlaceholderExprSyntax.self, visit, visitPost)
+      self.visitEditorPlaceholderExprSyntaxImpl(node)
     case .effectsAttributeArgumentList:
-      visitImpl(&node, EffectsAttributeArgumentListSyntax.self, visit, visitPost)
+      self.visitEffectsAttributeArgumentListSyntaxImpl(node)
     case .enumCaseDecl:
-      visitImpl(&node, EnumCaseDeclSyntax.self, visit, visitPost)
+      self.visitEnumCaseDeclSyntaxImpl(node)
     case .enumCaseElementList:
-      visitImpl(&node, EnumCaseElementListSyntax.self, visit, visitPost)
+      self.visitEnumCaseElementListSyntaxImpl(node)
     case .enumCaseElement:
-      visitImpl(&node, EnumCaseElementSyntax.self, visit, visitPost)
+      self.visitEnumCaseElementSyntaxImpl(node)
     case .enumCaseParameterClause:
-      visitImpl(&node, EnumCaseParameterClauseSyntax.self, visit, visitPost)
+      self.visitEnumCaseParameterClauseSyntaxImpl(node)
     case .enumCaseParameterList:
-      visitImpl(&node, EnumCaseParameterListSyntax.self, visit, visitPost)
+      self.visitEnumCaseParameterListSyntaxImpl(node)
     case .enumCaseParameter:
-      visitImpl(&node, EnumCaseParameterSyntax.self, visit, visitPost)
+      self.visitEnumCaseParameterSyntaxImpl(node)
     case .enumDecl:
-      visitImpl(&node, EnumDeclSyntax.self, visit, visitPost)
+      self.visitEnumDeclSyntaxImpl(node)
     case .exposeAttributeArguments:
-      visitImpl(&node, ExposeAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitExposeAttributeArgumentsSyntaxImpl(node)
     case .exprList:
-      visitImpl(&node, ExprListSyntax.self, visit, visitPost)
+      self.visitExprListSyntaxImpl(node)
     case .expressionPattern:
-      visitImpl(&node, ExpressionPatternSyntax.self, visit, visitPost)
+      self.visitExpressionPatternSyntaxImpl(node)
     case .expressionSegment:
-      visitImpl(&node, ExpressionSegmentSyntax.self, visit, visitPost)
+      self.visitExpressionSegmentSyntaxImpl(node)
     case .expressionStmt:
-      visitImpl(&node, ExpressionStmtSyntax.self, visit, visitPost)
+      self.visitExpressionStmtSyntaxImpl(node)
     case .extensionDecl:
-      visitImpl(&node, ExtensionDeclSyntax.self, visit, visitPost)
+      self.visitExtensionDeclSyntaxImpl(node)
     case .fallThroughStmt:
-      visitImpl(&node, FallThroughStmtSyntax.self, visit, visitPost)
+      self.visitFallThroughStmtSyntaxImpl(node)
     case .floatLiteralExpr:
-      visitImpl(&node, FloatLiteralExprSyntax.self, visit, visitPost)
+      self.visitFloatLiteralExprSyntaxImpl(node)
     case .forStmt:
-      visitImpl(&node, ForStmtSyntax.self, visit, visitPost)
+      self.visitForStmtSyntaxImpl(node)
     case .forceUnwrapExpr:
-      visitImpl(&node, ForceUnwrapExprSyntax.self, visit, visitPost)
+      self.visitForceUnwrapExprSyntaxImpl(node)
     case .functionCallExpr:
-      visitImpl(&node, FunctionCallExprSyntax.self, visit, visitPost)
+      self.visitFunctionCallExprSyntaxImpl(node)
     case .functionDecl:
-      visitImpl(&node, FunctionDeclSyntax.self, visit, visitPost)
+      self.visitFunctionDeclSyntaxImpl(node)
     case .functionEffectSpecifiers:
-      visitImpl(&node, FunctionEffectSpecifiersSyntax.self, visit, visitPost)
+      self.visitFunctionEffectSpecifiersSyntaxImpl(node)
     case .functionParameterClause:
-      visitImpl(&node, FunctionParameterClauseSyntax.self, visit, visitPost)
+      self.visitFunctionParameterClauseSyntaxImpl(node)
     case .functionParameterList:
-      visitImpl(&node, FunctionParameterListSyntax.self, visit, visitPost)
+      self.visitFunctionParameterListSyntaxImpl(node)
     case .functionParameter:
-      visitImpl(&node, FunctionParameterSyntax.self, visit, visitPost)
+      self.visitFunctionParameterSyntaxImpl(node)
     case .functionSignature:
-      visitImpl(&node, FunctionSignatureSyntax.self, visit, visitPost)
+      self.visitFunctionSignatureSyntaxImpl(node)
     case .functionType:
-      visitImpl(&node, FunctionTypeSyntax.self, visit, visitPost)
+      self.visitFunctionTypeSyntaxImpl(node)
     case .genericArgumentClause:
-      visitImpl(&node, GenericArgumentClauseSyntax.self, visit, visitPost)
+      self.visitGenericArgumentClauseSyntaxImpl(node)
     case .genericArgumentList:
-      visitImpl(&node, GenericArgumentListSyntax.self, visit, visitPost)
+      self.visitGenericArgumentListSyntaxImpl(node)
     case .genericArgument:
-      visitImpl(&node, GenericArgumentSyntax.self, visit, visitPost)
+      self.visitGenericArgumentSyntaxImpl(node)
     case .genericParameterClause:
-      visitImpl(&node, GenericParameterClauseSyntax.self, visit, visitPost)
+      self.visitGenericParameterClauseSyntaxImpl(node)
     case .genericParameterList:
-      visitImpl(&node, GenericParameterListSyntax.self, visit, visitPost)
+      self.visitGenericParameterListSyntaxImpl(node)
     case .genericParameter:
-      visitImpl(&node, GenericParameterSyntax.self, visit, visitPost)
+      self.visitGenericParameterSyntaxImpl(node)
     case .genericRequirementList:
-      visitImpl(&node, GenericRequirementListSyntax.self, visit, visitPost)
+      self.visitGenericRequirementListSyntaxImpl(node)
     case .genericRequirement:
-      visitImpl(&node, GenericRequirementSyntax.self, visit, visitPost)
+      self.visitGenericRequirementSyntaxImpl(node)
     case .genericSpecializationExpr:
-      visitImpl(&node, GenericSpecializationExprSyntax.self, visit, visitPost)
+      self.visitGenericSpecializationExprSyntaxImpl(node)
     case .genericWhereClause:
-      visitImpl(&node, GenericWhereClauseSyntax.self, visit, visitPost)
+      self.visitGenericWhereClauseSyntaxImpl(node)
     case .guardStmt:
-      visitImpl(&node, GuardStmtSyntax.self, visit, visitPost)
+      self.visitGuardStmtSyntaxImpl(node)
     case .identifierPattern:
-      visitImpl(&node, IdentifierPatternSyntax.self, visit, visitPost)
+      self.visitIdentifierPatternSyntaxImpl(node)
     case .identifierType:
-      visitImpl(&node, IdentifierTypeSyntax.self, visit, visitPost)
+      self.visitIdentifierTypeSyntaxImpl(node)
     case .ifConfigClauseList:
-      visitImpl(&node, IfConfigClauseListSyntax.self, visit, visitPost)
+      self.visitIfConfigClauseListSyntaxImpl(node)
     case .ifConfigClause:
-      visitImpl(&node, IfConfigClauseSyntax.self, visit, visitPost)
+      self.visitIfConfigClauseSyntaxImpl(node)
     case .ifConfigDecl:
-      visitImpl(&node, IfConfigDeclSyntax.self, visit, visitPost)
+      self.visitIfConfigDeclSyntaxImpl(node)
     case .ifExpr:
-      visitImpl(&node, IfExprSyntax.self, visit, visitPost)
+      self.visitIfExprSyntaxImpl(node)
     case .implementsAttributeArguments:
-      visitImpl(&node, ImplementsAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitImplementsAttributeArgumentsSyntaxImpl(node)
     case .implicitlyUnwrappedOptionalType:
-      visitImpl(&node, ImplicitlyUnwrappedOptionalTypeSyntax.self, visit, visitPost)
+      self.visitImplicitlyUnwrappedOptionalTypeSyntaxImpl(node)
     case .importDecl:
-      visitImpl(&node, ImportDeclSyntax.self, visit, visitPost)
+      self.visitImportDeclSyntaxImpl(node)
     case .importPathComponentList:
-      visitImpl(&node, ImportPathComponentListSyntax.self, visit, visitPost)
+      self.visitImportPathComponentListSyntaxImpl(node)
     case .importPathComponent:
-      visitImpl(&node, ImportPathComponentSyntax.self, visit, visitPost)
+      self.visitImportPathComponentSyntaxImpl(node)
     case .inOutExpr:
-      visitImpl(&node, InOutExprSyntax.self, visit, visitPost)
+      self.visitInOutExprSyntaxImpl(node)
     case .infixOperatorExpr:
-      visitImpl(&node, InfixOperatorExprSyntax.self, visit, visitPost)
+      self.visitInfixOperatorExprSyntaxImpl(node)
     case .inheritanceClause:
-      visitImpl(&node, InheritanceClauseSyntax.self, visit, visitPost)
+      self.visitInheritanceClauseSyntaxImpl(node)
     case .inheritedTypeList:
-      visitImpl(&node, InheritedTypeListSyntax.self, visit, visitPost)
+      self.visitInheritedTypeListSyntaxImpl(node)
     case .inheritedType:
-      visitImpl(&node, InheritedTypeSyntax.self, visit, visitPost)
+      self.visitInheritedTypeSyntaxImpl(node)
     case .initializerClause:
-      visitImpl(&node, InitializerClauseSyntax.self, visit, visitPost)
+      self.visitInitializerClauseSyntaxImpl(node)
     case .initializerDecl:
-      visitImpl(&node, InitializerDeclSyntax.self, visit, visitPost)
+      self.visitInitializerDeclSyntaxImpl(node)
     case .integerLiteralExpr:
-      visitImpl(&node, IntegerLiteralExprSyntax.self, visit, visitPost)
+      self.visitIntegerLiteralExprSyntaxImpl(node)
     case .isExpr:
-      visitImpl(&node, IsExprSyntax.self, visit, visitPost)
+      self.visitIsExprSyntaxImpl(node)
     case .isTypePattern:
-      visitImpl(&node, IsTypePatternSyntax.self, visit, visitPost)
+      self.visitIsTypePatternSyntaxImpl(node)
     case .keyPathComponentList:
-      visitImpl(&node, KeyPathComponentListSyntax.self, visit, visitPost)
+      self.visitKeyPathComponentListSyntaxImpl(node)
     case .keyPathComponent:
-      visitImpl(&node, KeyPathComponentSyntax.self, visit, visitPost)
+      self.visitKeyPathComponentSyntaxImpl(node)
     case .keyPathExpr:
-      visitImpl(&node, KeyPathExprSyntax.self, visit, visitPost)
+      self.visitKeyPathExprSyntaxImpl(node)
     case .keyPathOptionalComponent:
-      visitImpl(&node, KeyPathOptionalComponentSyntax.self, visit, visitPost)
+      self.visitKeyPathOptionalComponentSyntaxImpl(node)
     case .keyPathPropertyComponent:
-      visitImpl(&node, KeyPathPropertyComponentSyntax.self, visit, visitPost)
+      self.visitKeyPathPropertyComponentSyntaxImpl(node)
     case .keyPathSubscriptComponent:
-      visitImpl(&node, KeyPathSubscriptComponentSyntax.self, visit, visitPost)
+      self.visitKeyPathSubscriptComponentSyntaxImpl(node)
     case .labeledExprList:
-      visitImpl(&node, LabeledExprListSyntax.self, visit, visitPost)
+      self.visitLabeledExprListSyntaxImpl(node)
     case .labeledExpr:
-      visitImpl(&node, LabeledExprSyntax.self, visit, visitPost)
+      self.visitLabeledExprSyntaxImpl(node)
     case .labeledSpecializeArgument:
-      visitImpl(&node, LabeledSpecializeArgumentSyntax.self, visit, visitPost)
+      self.visitLabeledSpecializeArgumentSyntaxImpl(node)
     case .labeledStmt:
-      visitImpl(&node, LabeledStmtSyntax.self, visit, visitPost)
+      self.visitLabeledStmtSyntaxImpl(node)
     case .layoutRequirement:
-      visitImpl(&node, LayoutRequirementSyntax.self, visit, visitPost)
+      self.visitLayoutRequirementSyntaxImpl(node)
     case .lifetimeSpecifierArgumentList:
-      visitImpl(&node, LifetimeSpecifierArgumentListSyntax.self, visit, visitPost)
+      self.visitLifetimeSpecifierArgumentListSyntaxImpl(node)
     case .lifetimeSpecifierArgument:
-      visitImpl(&node, LifetimeSpecifierArgumentSyntax.self, visit, visitPost)
+      self.visitLifetimeSpecifierArgumentSyntaxImpl(node)
     case .lifetimeTypeSpecifier:
-      visitImpl(&node, LifetimeTypeSpecifierSyntax.self, visit, visitPost)
+      self.visitLifetimeTypeSpecifierSyntaxImpl(node)
     case .macroDecl:
-      visitImpl(&node, MacroDeclSyntax.self, visit, visitPost)
+      self.visitMacroDeclSyntaxImpl(node)
     case .macroExpansionDecl:
-      visitImpl(&node, MacroExpansionDeclSyntax.self, visit, visitPost)
+      self.visitMacroExpansionDeclSyntaxImpl(node)
     case .macroExpansionExpr:
-      visitImpl(&node, MacroExpansionExprSyntax.self, visit, visitPost)
+      self.visitMacroExpansionExprSyntaxImpl(node)
     case .matchingPatternCondition:
-      visitImpl(&node, MatchingPatternConditionSyntax.self, visit, visitPost)
+      self.visitMatchingPatternConditionSyntaxImpl(node)
     case .memberAccessExpr:
-      visitImpl(&node, MemberAccessExprSyntax.self, visit, visitPost)
+      self.visitMemberAccessExprSyntaxImpl(node)
     case .memberBlockItemList:
-      visitImpl(&node, MemberBlockItemListSyntax.self, visit, visitPost)
+      self.visitMemberBlockItemListSyntaxImpl(node)
     case .memberBlockItem:
-      visitImpl(&node, MemberBlockItemSyntax.self, visit, visitPost)
+      self.visitMemberBlockItemSyntaxImpl(node)
     case .memberBlock:
-      visitImpl(&node, MemberBlockSyntax.self, visit, visitPost)
+      self.visitMemberBlockSyntaxImpl(node)
     case .memberType:
-      visitImpl(&node, MemberTypeSyntax.self, visit, visitPost)
+      self.visitMemberTypeSyntaxImpl(node)
     case .metatypeType:
-      visitImpl(&node, MetatypeTypeSyntax.self, visit, visitPost)
+      self.visitMetatypeTypeSyntaxImpl(node)
     case .missingDecl:
-      visitImpl(&node, MissingDeclSyntax.self, visit, visitPost)
+      self.visitMissingDeclSyntaxImpl(node)
     case .missingExpr:
-      visitImpl(&node, MissingExprSyntax.self, visit, visitPost)
+      self.visitMissingExprSyntaxImpl(node)
     case .missingPattern:
-      visitImpl(&node, MissingPatternSyntax.self, visit, visitPost)
+      self.visitMissingPatternSyntaxImpl(node)
     case .missingStmt:
-      visitImpl(&node, MissingStmtSyntax.self, visit, visitPost)
+      self.visitMissingStmtSyntaxImpl(node)
     case .missing:
-      visitImpl(&node, MissingSyntax.self, visit, visitPost)
+      self.visitMissingSyntaxImpl(node)
     case .missingType:
-      visitImpl(&node, MissingTypeSyntax.self, visit, visitPost)
+      self.visitMissingTypeSyntaxImpl(node)
     case .multipleTrailingClosureElementList:
-      visitImpl(&node, MultipleTrailingClosureElementListSyntax.self, visit, visitPost)
+      self.visitMultipleTrailingClosureElementListSyntaxImpl(node)
     case .multipleTrailingClosureElement:
-      visitImpl(&node, MultipleTrailingClosureElementSyntax.self, visit, visitPost)
+      self.visitMultipleTrailingClosureElementSyntaxImpl(node)
     case .namedOpaqueReturnType:
-      visitImpl(&node, NamedOpaqueReturnTypeSyntax.self, visit, visitPost)
+      self.visitNamedOpaqueReturnTypeSyntaxImpl(node)
     case .nilLiteralExpr:
-      visitImpl(&node, NilLiteralExprSyntax.self, visit, visitPost)
+      self.visitNilLiteralExprSyntaxImpl(node)
     case .objCSelectorPieceList:
-      visitImpl(&node, ObjCSelectorPieceListSyntax.self, visit, visitPost)
+      self.visitObjCSelectorPieceListSyntaxImpl(node)
     case .objCSelectorPiece:
-      visitImpl(&node, ObjCSelectorPieceSyntax.self, visit, visitPost)
+      self.visitObjCSelectorPieceSyntaxImpl(node)
     case .opaqueReturnTypeOfAttributeArguments:
-      visitImpl(&node, OpaqueReturnTypeOfAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitOpaqueReturnTypeOfAttributeArgumentsSyntaxImpl(node)
     case .operatorDecl:
-      visitImpl(&node, OperatorDeclSyntax.self, visit, visitPost)
+      self.visitOperatorDeclSyntaxImpl(node)
     case .operatorPrecedenceAndTypes:
-      visitImpl(&node, OperatorPrecedenceAndTypesSyntax.self, visit, visitPost)
+      self.visitOperatorPrecedenceAndTypesSyntaxImpl(node)
     case .optionalBindingCondition:
-      visitImpl(&node, OptionalBindingConditionSyntax.self, visit, visitPost)
+      self.visitOptionalBindingConditionSyntaxImpl(node)
     case .optionalChainingExpr:
-      visitImpl(&node, OptionalChainingExprSyntax.self, visit, visitPost)
+      self.visitOptionalChainingExprSyntaxImpl(node)
     case .optionalType:
-      visitImpl(&node, OptionalTypeSyntax.self, visit, visitPost)
+      self.visitOptionalTypeSyntaxImpl(node)
     case .originallyDefinedInAttributeArguments:
-      visitImpl(&node, OriginallyDefinedInAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitOriginallyDefinedInAttributeArgumentsSyntaxImpl(node)
     case .packElementExpr:
-      visitImpl(&node, PackElementExprSyntax.self, visit, visitPost)
+      self.visitPackElementExprSyntaxImpl(node)
     case .packElementType:
-      visitImpl(&node, PackElementTypeSyntax.self, visit, visitPost)
+      self.visitPackElementTypeSyntaxImpl(node)
     case .packExpansionExpr:
-      visitImpl(&node, PackExpansionExprSyntax.self, visit, visitPost)
+      self.visitPackExpansionExprSyntaxImpl(node)
     case .packExpansionType:
-      visitImpl(&node, PackExpansionTypeSyntax.self, visit, visitPost)
+      self.visitPackExpansionTypeSyntaxImpl(node)
     case .patternBindingList:
-      visitImpl(&node, PatternBindingListSyntax.self, visit, visitPost)
+      self.visitPatternBindingListSyntaxImpl(node)
     case .patternBinding:
-      visitImpl(&node, PatternBindingSyntax.self, visit, visitPost)
+      self.visitPatternBindingSyntaxImpl(node)
     case .patternExpr:
-      visitImpl(&node, PatternExprSyntax.self, visit, visitPost)
+      self.visitPatternExprSyntaxImpl(node)
     case .platformVersionItemList:
-      visitImpl(&node, PlatformVersionItemListSyntax.self, visit, visitPost)
+      self.visitPlatformVersionItemListSyntaxImpl(node)
     case .platformVersionItem:
-      visitImpl(&node, PlatformVersionItemSyntax.self, visit, visitPost)
+      self.visitPlatformVersionItemSyntaxImpl(node)
     case .platformVersion:
-      visitImpl(&node, PlatformVersionSyntax.self, visit, visitPost)
+      self.visitPlatformVersionSyntaxImpl(node)
     case .postfixIfConfigExpr:
-      visitImpl(&node, PostfixIfConfigExprSyntax.self, visit, visitPost)
+      self.visitPostfixIfConfigExprSyntaxImpl(node)
     case .postfixOperatorExpr:
-      visitImpl(&node, PostfixOperatorExprSyntax.self, visit, visitPost)
+      self.visitPostfixOperatorExprSyntaxImpl(node)
     case .poundSourceLocationArguments:
-      visitImpl(&node, PoundSourceLocationArgumentsSyntax.self, visit, visitPost)
+      self.visitPoundSourceLocationArgumentsSyntaxImpl(node)
     case .poundSourceLocation:
-      visitImpl(&node, PoundSourceLocationSyntax.self, visit, visitPost)
+      self.visitPoundSourceLocationSyntaxImpl(node)
     case .precedenceGroupAssignment:
-      visitImpl(&node, PrecedenceGroupAssignmentSyntax.self, visit, visitPost)
+      self.visitPrecedenceGroupAssignmentSyntaxImpl(node)
     case .precedenceGroupAssociativity:
-      visitImpl(&node, PrecedenceGroupAssociativitySyntax.self, visit, visitPost)
+      self.visitPrecedenceGroupAssociativitySyntaxImpl(node)
     case .precedenceGroupAttributeList:
-      visitImpl(&node, PrecedenceGroupAttributeListSyntax.self, visit, visitPost)
+      self.visitPrecedenceGroupAttributeListSyntaxImpl(node)
     case .precedenceGroupDecl:
-      visitImpl(&node, PrecedenceGroupDeclSyntax.self, visit, visitPost)
+      self.visitPrecedenceGroupDeclSyntaxImpl(node)
     case .precedenceGroupNameList:
-      visitImpl(&node, PrecedenceGroupNameListSyntax.self, visit, visitPost)
+      self.visitPrecedenceGroupNameListSyntaxImpl(node)
     case .precedenceGroupName:
-      visitImpl(&node, PrecedenceGroupNameSyntax.self, visit, visitPost)
+      self.visitPrecedenceGroupNameSyntaxImpl(node)
     case .precedenceGroupRelation:
-      visitImpl(&node, PrecedenceGroupRelationSyntax.self, visit, visitPost)
+      self.visitPrecedenceGroupRelationSyntaxImpl(node)
     case .prefixOperatorExpr:
-      visitImpl(&node, PrefixOperatorExprSyntax.self, visit, visitPost)
+      self.visitPrefixOperatorExprSyntaxImpl(node)
     case .primaryAssociatedTypeClause:
-      visitImpl(&node, PrimaryAssociatedTypeClauseSyntax.self, visit, visitPost)
+      self.visitPrimaryAssociatedTypeClauseSyntaxImpl(node)
     case .primaryAssociatedTypeList:
-      visitImpl(&node, PrimaryAssociatedTypeListSyntax.self, visit, visitPost)
+      self.visitPrimaryAssociatedTypeListSyntaxImpl(node)
     case .primaryAssociatedType:
-      visitImpl(&node, PrimaryAssociatedTypeSyntax.self, visit, visitPost)
+      self.visitPrimaryAssociatedTypeSyntaxImpl(node)
     case .protocolDecl:
-      visitImpl(&node, ProtocolDeclSyntax.self, visit, visitPost)
+      self.visitProtocolDeclSyntaxImpl(node)
     case .regexLiteralExpr:
-      visitImpl(&node, RegexLiteralExprSyntax.self, visit, visitPost)
+      self.visitRegexLiteralExprSyntaxImpl(node)
     case .repeatStmt:
-      visitImpl(&node, RepeatStmtSyntax.self, visit, visitPost)
+      self.visitRepeatStmtSyntaxImpl(node)
     case .returnClause:
-      visitImpl(&node, ReturnClauseSyntax.self, visit, visitPost)
+      self.visitReturnClauseSyntaxImpl(node)
     case .returnStmt:
-      visitImpl(&node, ReturnStmtSyntax.self, visit, visitPost)
+      self.visitReturnStmtSyntaxImpl(node)
     case .sameTypeRequirement:
-      visitImpl(&node, SameTypeRequirementSyntax.self, visit, visitPost)
+      self.visitSameTypeRequirementSyntaxImpl(node)
     case .sequenceExpr:
-      visitImpl(&node, SequenceExprSyntax.self, visit, visitPost)
+      self.visitSequenceExprSyntaxImpl(node)
     case .simpleStringLiteralExpr:
-      visitImpl(&node, SimpleStringLiteralExprSyntax.self, visit, visitPost)
+      self.visitSimpleStringLiteralExprSyntaxImpl(node)
     case .simpleStringLiteralSegmentList:
-      visitImpl(&node, SimpleStringLiteralSegmentListSyntax.self, visit, visitPost)
+      self.visitSimpleStringLiteralSegmentListSyntaxImpl(node)
     case .simpleTypeSpecifier:
-      visitImpl(&node, SimpleTypeSpecifierSyntax.self, visit, visitPost)
+      self.visitSimpleTypeSpecifierSyntaxImpl(node)
     case .someOrAnyType:
-      visitImpl(&node, SomeOrAnyTypeSyntax.self, visit, visitPost)
+      self.visitSomeOrAnyTypeSyntaxImpl(node)
     case .sourceFile:
-      visitImpl(&node, SourceFileSyntax.self, visit, visitPost)
+      self.visitSourceFileSyntaxImpl(node)
     case .specializeAttributeArgumentList:
-      visitImpl(&node, SpecializeAttributeArgumentListSyntax.self, visit, visitPost)
+      self.visitSpecializeAttributeArgumentListSyntaxImpl(node)
     case .specializeAvailabilityArgument:
-      visitImpl(&node, SpecializeAvailabilityArgumentSyntax.self, visit, visitPost)
+      self.visitSpecializeAvailabilityArgumentSyntaxImpl(node)
     case .specializeTargetFunctionArgument:
-      visitImpl(&node, SpecializeTargetFunctionArgumentSyntax.self, visit, visitPost)
+      self.visitSpecializeTargetFunctionArgumentSyntaxImpl(node)
     case .stringLiteralExpr:
-      visitImpl(&node, StringLiteralExprSyntax.self, visit, visitPost)
+      self.visitStringLiteralExprSyntaxImpl(node)
     case .stringLiteralSegmentList:
-      visitImpl(&node, StringLiteralSegmentListSyntax.self, visit, visitPost)
+      self.visitStringLiteralSegmentListSyntaxImpl(node)
     case .stringSegment:
-      visitImpl(&node, StringSegmentSyntax.self, visit, visitPost)
+      self.visitStringSegmentSyntaxImpl(node)
     case .structDecl:
-      visitImpl(&node, StructDeclSyntax.self, visit, visitPost)
+      self.visitStructDeclSyntaxImpl(node)
     case .subscriptCallExpr:
-      visitImpl(&node, SubscriptCallExprSyntax.self, visit, visitPost)
+      self.visitSubscriptCallExprSyntaxImpl(node)
     case .subscriptDecl:
-      visitImpl(&node, SubscriptDeclSyntax.self, visit, visitPost)
+      self.visitSubscriptDeclSyntaxImpl(node)
     case .superExpr:
-      visitImpl(&node, SuperExprSyntax.self, visit, visitPost)
+      self.visitSuperExprSyntaxImpl(node)
     case .suppressedType:
-      visitImpl(&node, SuppressedTypeSyntax.self, visit, visitPost)
+      self.visitSuppressedTypeSyntaxImpl(node)
     case .switchCaseItemList:
-      visitImpl(&node, SwitchCaseItemListSyntax.self, visit, visitPost)
+      self.visitSwitchCaseItemListSyntaxImpl(node)
     case .switchCaseItem:
-      visitImpl(&node, SwitchCaseItemSyntax.self, visit, visitPost)
+      self.visitSwitchCaseItemSyntaxImpl(node)
     case .switchCaseLabel:
-      visitImpl(&node, SwitchCaseLabelSyntax.self, visit, visitPost)
+      self.visitSwitchCaseLabelSyntaxImpl(node)
     case .switchCaseList:
-      visitImpl(&node, SwitchCaseListSyntax.self, visit, visitPost)
+      self.visitSwitchCaseListSyntaxImpl(node)
     case .switchCase:
-      visitImpl(&node, SwitchCaseSyntax.self, visit, visitPost)
+      self.visitSwitchCaseSyntaxImpl(node)
     case .switchDefaultLabel:
-      visitImpl(&node, SwitchDefaultLabelSyntax.self, visit, visitPost)
+      self.visitSwitchDefaultLabelSyntaxImpl(node)
     case .switchExpr:
-      visitImpl(&node, SwitchExprSyntax.self, visit, visitPost)
+      self.visitSwitchExprSyntaxImpl(node)
     case .ternaryExpr:
-      visitImpl(&node, TernaryExprSyntax.self, visit, visitPost)
+      self.visitTernaryExprSyntaxImpl(node)
     case .thenStmt:
-      visitImpl(&node, ThenStmtSyntax.self, visit, visitPost)
+      self.visitThenStmtSyntaxImpl(node)
     case .throwStmt:
-      visitImpl(&node, ThrowStmtSyntax.self, visit, visitPost)
+      self.visitThrowStmtSyntaxImpl(node)
     case .throwsClause:
-      visitImpl(&node, ThrowsClauseSyntax.self, visit, visitPost)
+      self.visitThrowsClauseSyntaxImpl(node)
     case .tryExpr:
-      visitImpl(&node, TryExprSyntax.self, visit, visitPost)
+      self.visitTryExprSyntaxImpl(node)
     case .tupleExpr:
-      visitImpl(&node, TupleExprSyntax.self, visit, visitPost)
+      self.visitTupleExprSyntaxImpl(node)
     case .tuplePatternElementList:
-      visitImpl(&node, TuplePatternElementListSyntax.self, visit, visitPost)
+      self.visitTuplePatternElementListSyntaxImpl(node)
     case .tuplePatternElement:
-      visitImpl(&node, TuplePatternElementSyntax.self, visit, visitPost)
+      self.visitTuplePatternElementSyntaxImpl(node)
     case .tuplePattern:
-      visitImpl(&node, TuplePatternSyntax.self, visit, visitPost)
+      self.visitTuplePatternSyntaxImpl(node)
     case .tupleTypeElementList:
-      visitImpl(&node, TupleTypeElementListSyntax.self, visit, visitPost)
+      self.visitTupleTypeElementListSyntaxImpl(node)
     case .tupleTypeElement:
-      visitImpl(&node, TupleTypeElementSyntax.self, visit, visitPost)
+      self.visitTupleTypeElementSyntaxImpl(node)
     case .tupleType:
-      visitImpl(&node, TupleTypeSyntax.self, visit, visitPost)
+      self.visitTupleTypeSyntaxImpl(node)
     case .typeAliasDecl:
-      visitImpl(&node, TypeAliasDeclSyntax.self, visit, visitPost)
+      self.visitTypeAliasDeclSyntaxImpl(node)
     case .typeAnnotation:
-      visitImpl(&node, TypeAnnotationSyntax.self, visit, visitPost)
+      self.visitTypeAnnotationSyntaxImpl(node)
     case .typeEffectSpecifiers:
-      visitImpl(&node, TypeEffectSpecifiersSyntax.self, visit, visitPost)
+      self.visitTypeEffectSpecifiersSyntaxImpl(node)
     case .typeExpr:
-      visitImpl(&node, TypeExprSyntax.self, visit, visitPost)
+      self.visitTypeExprSyntaxImpl(node)
     case .typeInitializerClause:
-      visitImpl(&node, TypeInitializerClauseSyntax.self, visit, visitPost)
+      self.visitTypeInitializerClauseSyntaxImpl(node)
     case .typeSpecifierList:
-      visitImpl(&node, TypeSpecifierListSyntax.self, visit, visitPost)
+      self.visitTypeSpecifierListSyntaxImpl(node)
     case .unavailableFromAsyncAttributeArguments:
-      visitImpl(&node, UnavailableFromAsyncAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitUnavailableFromAsyncAttributeArgumentsSyntaxImpl(node)
     case .underscorePrivateAttributeArguments:
-      visitImpl(&node, UnderscorePrivateAttributeArgumentsSyntax.self, visit, visitPost)
+      self.visitUnderscorePrivateAttributeArgumentsSyntaxImpl(node)
     case .unexpectedNodes:
-      visitImpl(&node, UnexpectedNodesSyntax.self, visit, visitPost)
+      self.visitUnexpectedNodesSyntaxImpl(node)
     case .unresolvedAsExpr:
-      visitImpl(&node, UnresolvedAsExprSyntax.self, visit, visitPost)
+      self.visitUnresolvedAsExprSyntaxImpl(node)
     case .unresolvedIsExpr:
-      visitImpl(&node, UnresolvedIsExprSyntax.self, visit, visitPost)
+      self.visitUnresolvedIsExprSyntaxImpl(node)
     case .unresolvedTernaryExpr:
-      visitImpl(&node, UnresolvedTernaryExprSyntax.self, visit, visitPost)
+      self.visitUnresolvedTernaryExprSyntaxImpl(node)
     case .valueBindingPattern:
-      visitImpl(&node, ValueBindingPatternSyntax.self, visit, visitPost)
+      self.visitValueBindingPatternSyntaxImpl(node)
     case .variableDecl:
-      visitImpl(&node, VariableDeclSyntax.self, visit, visitPost)
+      self.visitVariableDeclSyntaxImpl(node)
     case .versionComponentList:
-      visitImpl(&node, VersionComponentListSyntax.self, visit, visitPost)
+      self.visitVersionComponentListSyntaxImpl(node)
     case .versionComponent:
-      visitImpl(&node, VersionComponentSyntax.self, visit, visitPost)
+      self.visitVersionComponentSyntaxImpl(node)
     case .versionTuple:
-      visitImpl(&node, VersionTupleSyntax.self, visit, visitPost)
+      self.visitVersionTupleSyntaxImpl(node)
     case .whereClause:
-      visitImpl(&node, WhereClauseSyntax.self, visit, visitPost)
+      self.visitWhereClauseSyntaxImpl(node)
     case .whileStmt:
-      visitImpl(&node, WhileStmtSyntax.self, visit, visitPost)
+      self.visitWhileStmtSyntaxImpl(node)
     case .wildcardPattern:
-      visitImpl(&node, WildcardPatternSyntax.self, visit, visitPost)
+      self.visitWildcardPatternSyntaxImpl(node)
     case .yieldStmt:
-      visitImpl(&node, YieldStmtSyntax.self, visit, visitPost)
+      self.visitYieldStmtSyntaxImpl(node)
     case .yieldedExpressionList:
-      visitImpl(&node, YieldedExpressionListSyntax.self, visit, visitPost)
+      self.visitYieldedExpressionListSyntaxImpl(node)
     case .yieldedExpression:
-      visitImpl(&node, YieldedExpressionSyntax.self, visit, visitPost)
+      self.visitYieldedExpressionSyntaxImpl(node)
     case .yieldedExpressionsClause:
-      visitImpl(&node, YieldedExpressionsClauseSyntax.self, visit, visitPost)
+      self.visitYieldedExpressionsClauseSyntaxImpl(node)
     }
   }
   #endif
 
-  /// - Note: `node` is `inout` to avoid reference counting. See comment in `visitImpl`.
-  private func visitChildren(_ node: inout Syntax) {
+  private func visitChildren(_ node: Syntax) {
     for case let (child?, info) in RawSyntaxChildren(node) where viewMode.shouldTraverse(node: child) {
       var childNode = nodeFactory.create(parent: node, raw: child, absoluteInfo: info)
-      visit(&childNode)
+      dispatchVisit(childNode)
       nodeFactory.dispose(&childNode)
     }
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -345,6 +345,11 @@ public struct ABIAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -502,6 +507,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - leftBrace: The brace introducing the accessor block.
@@ -655,6 +665,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -919,6 +934,11 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - asyncSpecifier: The `async` keyword.
@@ -1039,6 +1059,11 @@ public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1189,6 +1214,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1534,6 +1564,11 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1647,6 +1682,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1818,6 +1858,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1969,6 +2014,11 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2096,6 +2146,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2266,6 +2321,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2369,6 +2429,11 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3397,6 +3462,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - atSign: The `@` sign.
@@ -3608,6 +3678,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3927,6 +4002,11 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - argument: The actual argument.
@@ -4048,6 +4128,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4336,6 +4421,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable,
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - label: The label of the argument.
@@ -4490,6 +4580,11 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4607,6 +4702,11 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4790,6 +4890,11 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4861,6 +4966,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4937,6 +5047,11 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyn
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -5051,6 +5166,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
@@ -31,6 +31,11 @@ public struct _CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -236,6 +241,11 @@ public struct _CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -413,6 +423,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -583,6 +598,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -749,6 +769,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1093,6 +1118,11 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1170,6 +1200,11 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1344,6 +1379,11 @@ public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Le
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1529,6 +1569,11 @@ public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1706,6 +1751,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1907,6 +1957,11 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - leftParen: The '(' to open the parameter clause.
@@ -2091,6 +2146,11 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2452,6 +2512,11 @@ public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2655,6 +2720,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3017,6 +3087,11 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - item: The underlying node inside the code block.
@@ -3149,6 +3224,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3329,6 +3409,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3435,6 +3520,11 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3686,6 +3776,11 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3801,6 +3896,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable, _Lea
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3941,6 +4041,11 @@ public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4053,6 +4158,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4177,6 +4287,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4388,6 +4503,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - witnessMethodLabel: The `witnessMethod` label.
@@ -4539,6 +4659,11 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynta
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -33,6 +33,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -180,6 +185,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -334,6 +344,11 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -449,6 +464,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -627,6 +647,11 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -746,6 +771,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -870,6 +900,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1128,6 +1163,11 @@ public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashabl
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - asyncSpecifier: The `async` keyword.
@@ -1214,6 +1254,11 @@ public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1490,6 +1535,11 @@ public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1608,6 +1658,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1863,6 +1918,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2005,6 +2065,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2210,6 +2275,11 @@ public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2333,6 +2403,11 @@ public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable, 
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2593,6 +2668,11 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - wrtLabel: The "wrt" label.
@@ -2747,6 +2827,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2973,6 +3058,11 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3045,6 +3135,11 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3185,6 +3280,11 @@ public struct DoExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3352,6 +3452,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxN
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3642,6 +3747,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingComma: A trailing comma if this argument is followed by another one
@@ -3822,6 +3932,11 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -33,6 +33,11 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - attributes: If there were attributes before the editor placeholder, the ``EditorPlaceholderDeclSyntax`` will contain these.
@@ -233,6 +238,11 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -309,6 +319,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -573,6 +588,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - name: The name of this case.
@@ -753,6 +773,11 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -938,6 +963,11 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1238,6 +1268,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynta
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1590,6 +1625,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1741,6 +1781,11 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1821,6 +1866,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2048,6 +2098,11 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStm
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2134,6 +2189,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2454,6 +2514,11 @@ public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafSt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2525,6 +2590,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2607,6 +2677,11 @@ public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntax
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2941,6 +3016,11 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3055,6 +3135,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3354,6 +3439,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3707,6 +3797,11 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - asyncSpecifier: The `async` or `reasync` keyword.
@@ -3830,6 +3925,11 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Le
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4011,6 +4111,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4409,6 +4514,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - parameterClause: The parameters of the function.
@@ -4551,6 +4661,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -38,6 +38,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -300,6 +305,11 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - argument: The argument type for a generic argument. This can either be a regular type argument or an expression for value generics.
@@ -429,6 +439,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _Lea
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -641,6 +656,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1012,6 +1032,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1122,6 +1147,11 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1251,6 +1281,11 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1397,6 +1432,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1603,6 +1643,11 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1680,6 +1725,11 @@ public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1982,6 +2032,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2127,6 +2182,11 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2353,6 +2413,11 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2582,6 +2647,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - type: The type for which the method with this attribute implements a requirement.
@@ -2727,6 +2797,11 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2848,6 +2923,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3151,6 +3231,11 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3272,6 +3357,11 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3389,6 +3479,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3536,6 +3631,11 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3679,6 +3779,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3800,6 +3905,11 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3929,6 +4039,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDe
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4275,6 +4390,11 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4359,6 +4479,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxN
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4504,6 +4629,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafP
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -145,6 +145,11 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -264,6 +269,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -436,6 +446,11 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -516,6 +531,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable, _L
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -632,6 +652,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable, _
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -814,6 +839,11 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -992,6 +1022,11 @@ public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1182,6 +1217,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1331,6 +1371,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1638,6 +1683,11 @@ public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - parameter: The parameter on which the lifetime of this type depends. 
@@ -1774,6 +1824,11 @@ public struct LifetimeTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2012,6 +2067,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2351,6 +2411,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Lea
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2801,6 +2866,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - pound: The `#` sign.
@@ -3141,6 +3211,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3308,6 +3383,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - base: The base of the member access, optionally specified.
@@ -3456,6 +3536,11 @@ public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - decl: The declaration of the type member.
@@ -3581,6 +3666,11 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3753,6 +3843,11 @@ public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyn
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3923,6 +4018,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4067,6 +4167,11 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4271,6 +4376,11 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - placeholder: A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression.
@@ -4349,6 +4459,11 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4431,6 +4546,11 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - placeholder: A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern.
@@ -4511,6 +4631,11 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - placeholder: A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern.
@@ -4589,6 +4714,11 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4673,6 +4803,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4818,6 +4953,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - genericParameterClause: The parameter clause that defines the generic parameters.
@@ -4926,6 +5066,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
@@ -34,6 +34,11 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - name: The identifier name for a nullary selection, if it exists.
@@ -156,6 +161,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -306,6 +316,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -496,6 +511,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable, 
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - precedenceGroup: The precedence group for this operator
@@ -675,6 +695,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -845,6 +870,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _L
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -955,6 +985,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1076,6 +1111,11 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1303,6 +1343,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafEx
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1413,6 +1458,11 @@ public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1529,6 +1579,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1639,6 +1694,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1760,6 +1820,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1971,6 +2036,11 @@ public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2046,6 +2116,11 @@ public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2172,6 +2247,11 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - platform: The name of the OS on which the availability should be restricted or 'swift' if the availability should be restricted based on a Swift version.
@@ -2293,6 +2373,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2400,6 +2485,11 @@ public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Le
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2521,6 +2611,11 @@ public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2782,6 +2877,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2959,6 +3059,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable, _
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - value: When true, an operator in the corresponding precedence group uses the same grouping rules during optional chaining as the assignment operators from the standard library. Otherwise, operators in the precedence group follows the same optional chaining rules as operators that don't perform assignment.
@@ -3113,6 +3218,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3270,6 +3380,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _Le
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3617,6 +3732,11 @@ public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3737,6 +3857,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable, _Le
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3926,6 +4051,11 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Lea
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4041,6 +4171,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable,
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4215,6 +4350,11 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4344,6 +4484,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -31,6 +31,11 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -235,6 +240,11 @@ public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -409,6 +419,11 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - arrow: If return type is presented, the arrow introducing the return type.
@@ -524,6 +539,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -823,6 +843,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - leftType: The left hand side type for a same type requirement. This can either be a regular type argument or an expression for value generics.
@@ -975,6 +1000,11 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprS
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1079,6 +1109,11 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable,
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1266,6 +1301,11 @@ public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - specifier: The specifier token that's attached to the type.
@@ -1349,6 +1389,11 @@ public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafType
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1464,6 +1509,11 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1643,6 +1693,11 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1856,6 +1911,11 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - targetLabel: The label of the argument
@@ -2057,6 +2117,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2299,6 +2364,11 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNo
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2435,6 +2505,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyn
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2784,6 +2859,11 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3061,6 +3141,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3388,6 +3473,11 @@ public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3460,6 +3550,11 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3577,6 +3672,11 @@ public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3720,6 +3820,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3975,6 +4080,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeP
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - attribute: The `@unknown` attribute of a default label, if present.
@@ -4143,6 +4253,11 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4272,6 +4387,11 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyn
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -42,6 +42,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -248,6 +253,11 @@ public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynta
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -358,6 +368,11 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -479,6 +494,11 @@ public struct ThrowsClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -681,6 +701,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntax
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -823,6 +848,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -999,6 +1029,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1194,6 +1229,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPa
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - leftParen: The parent introducing the tuple.
@@ -1375,6 +1415,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -1639,6 +1684,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -1810,6 +1860,11 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2122,6 +2177,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxN
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - colon: The colon separating previous pattern and the type.
@@ -2243,6 +2303,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafS
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - throwsClause: The clause specifying thrown errors
@@ -2356,6 +2421,11 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSynta
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2430,6 +2500,11 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2549,6 +2624,11 @@ public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, Synt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -2699,6 +2779,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2845,6 +2930,11 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -2966,6 +3056,11 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3045,6 +3140,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3188,6 +3288,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, 
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3312,6 +3417,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclS
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3588,6 +3698,11 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynta
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - period: The period of this version component.
@@ -3715,6 +3830,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -3867,6 +3987,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -3978,6 +4103,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4157,6 +4287,11 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Lea
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4311,6 +4446,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
     self._syntaxNode = node._syntaxNode
   }
 
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
@@ -4425,6 +4565,11 @@ public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:
@@ -4542,6 +4687,11 @@ public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable, _L
       return nil
     }
     self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
   }
 
   /// - Parameters:


### PR DESCRIPTION
`init(unsafeCasting:)` should only be used when we are absolutely sure the syntax kind matches the type, and only in perf critial places. Use it in `SyntaxEnum`, `SyntaxVisitor`, and `SyntaxRewriter`.

Also, rework `SyntaxVisitor`/`SyntaxRewriter` visitation, eliminating unnecessary ARC traffic.

Baseline:
```
'-[PerformanceTest.PerfTests testEmptyRewriter]' measured [Time, seconds] average: 1.626, relative standard deviation: 0.492%, values: [1.645482, 1.618930, 1.620801, 1.619107, 1.621778, 1.620863, 1.621619, 1.629248, 1.633502, 1.628365],
'-[PerformanceTest.PerfTests testEmptyVisitor]' measured [Time, seconds] average: 1.169, relative standard deviation: 0.825%, values: [1.195887, 1.166237, 1.164091, 1.167106, 1.167065, 1.175714, 1.164696, 1.160530, 1.163220, 1.167872]
```
With this patch:
```
'-[PerformanceTest.PerfTests testEmptyRewriter]' measured [Time, seconds] average: 1.281, relative standard deviation: 0.991%, values: [1.317752, 1.279236, 1.281419, 1.273362, 1.273581, 1.277479, 1.283182, 1.277359, 1.273263, 1.273686]
'-[PerformanceTest.PerfTests testEmptyVisitor]' measured [Time, seconds] average: 0.933, relative standard deviation: 0.710%, values: [0.952931, 0.931542, 0.933043, 0.932171, 0.931005, 0.929917, 0.931035, 0.930155, 0.931712, 0.929429]
```
This patch eliminates ARC during visitation funcs, but we still need to retain the parent `Syntax.Info` when constructing `Syntax`.