### PR TITLE
Make `SyntaxArena` SPI

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SwiftSyntaxDoccIndexTemplate.md
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SwiftSyntaxDoccIndexTemplate.md
@@ -66,7 +66,6 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 ### Internals
 
 - <doc:SwiftSyntax/SyntaxProtocol>
-- <doc:SwiftSyntax/SyntaxArena>
 - <doc:SwiftSyntax/SyntaxEnum>
 - <doc:SwiftSyntax/SyntaxHashable>
 - <doc:SwiftSyntax/SyntaxIdentifier>

--- a/Release Notes/602.md
+++ b/Release Notes/602.md
@@ -14,6 +14,12 @@
   - Migration steps: Replace uses of `ExpandEditorPlaceholdersToTrailingClosures` with `ExpandEditorPlaceholdersToLiteralClosures`. The initializer does not need to change: `.init(indentationWidth:)` on the new type provides the same behavior as the old type.
   - Notes: This improves code completion in a SourceKitLSP session where the trailing closure form may be undesirable. The nested placeholders offer more flexibility to end users, in editors that support it.
 
+- `SyntaxArena` and `ParsingSyntaxArena` has changed to SPI
+  - Description: `SyntaxArena` and the subclasses were only meant to be used when dealing with `RawSyntax` which is also SPI.
+  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2930
+  - Migration steps: Do not use `SyntaxArena` or `ParsingSyntaxArena` directly.
+  - Notes: Although the type itself was `public`, most initializers were already SPI and there was no way to retrive them from existing types via public API.
+
 ## Template
 
 - *Affected API or two word description*

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -303,15 +303,10 @@ public struct Parser {
   ///                          if this is `nil`.
   ///   - parseTransition: The previously recorded state for an incremental
   ///                      parse, or `nil`.
-  ///   - arena: Arena the parsing syntax are made into. If it's `nil`, a new
-  ///            arena is created automatically, and `input` copied into the
-  ///            arena. If non-`nil`, `input` must be within its registered
-  ///            source buffer or allocator.
   public init(
     _ input: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
-    arena: ParsingSyntaxArena? = nil,
     swiftVersion: SwiftVersion? = nil
   ) {
     // Chain to the private buffer initializer.
@@ -319,7 +314,7 @@ public struct Parser {
       buffer: input,
       maximumNestingLevel: maximumNestingLevel,
       parseTransition: parseTransition,
-      arena: arena,
+      arena: nil,
       swiftVersion: swiftVersion,
       experimentalFeatures: []
     )

--- a/Sources/SwiftSyntax/Documentation.docc/Glossary.md
+++ b/Sources/SwiftSyntax/Documentation.docc/Glossary.md
@@ -7,8 +7,6 @@ Glossary of terms and abbreviations used in SwiftSyntax
 To avoid ongoing repetition of common long terms, SwiftSyntax uses a couple of abbreviations that are common in compiler projects.
 
 
-**Arena** See ``SyntaxArena``
-
 **Decl** Abbreviation for *Declaration*
 
 **Expr** Abbreviation for *Expression*

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -411,7 +411,6 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 ### Internals
 
 - <doc:SwiftSyntax/SyntaxProtocol>
-- <doc:SwiftSyntax/SyntaxArena>
 - <doc:SwiftSyntax/SyntaxEnum>
 - <doc:SwiftSyntax/SyntaxHashable>
 - <doc:SwiftSyntax/SyntaxIdentifier>

--- a/Sources/SwiftSyntax/MissingNodeInitializers.swift
+++ b/Sources/SwiftSyntax/MissingNodeInitializers.swift
@@ -13,8 +13,7 @@
 extension MissingDeclSyntax {
   public init(
     attributes: AttributeListSyntax,
-    modifiers: DeclModifierListSyntax,
-    arena: __shared SyntaxArena
+    modifiers: DeclModifierListSyntax
   ) {
     self.init(
       attributes: attributes,

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -43,6 +43,7 @@
 /// As an added benefit of the ``SyntaxArena``, `RawSyntax` nodes don’t need to
 /// be reference-counted, further improving the performance of ``SwiftSyntax``
 /// when worked with at that level.
+@_spi(RawSyntax)
 public class SyntaxArena {
   /// Bump-pointer allocator for all "intern" methods.
   fileprivate let allocator: BumpPtrAllocator
@@ -105,7 +106,6 @@ public class SyntaxArena {
 
   /// Copies the contents of a ``SyntaxText`` to the memory this arena manages,
   /// and return the ``SyntaxText`` in the destination.
-  @_spi(RawSyntax)
   public func intern(_ value: SyntaxText) -> SyntaxText {
     // Return the passed-in value if it's already managed by this arena.
     if self.contains(text: value) {
@@ -119,7 +119,6 @@ public class SyntaxArena {
 
   /// Copies a UTF8 sequence of `String` to the memory this arena manages, and
   /// returns the copied string as a ``SyntaxText``
-  @_spi(RawSyntax)
   public func intern(_ value: String) -> SyntaxText {
     if value.isEmpty { return SyntaxText() }
     var value = value
@@ -173,8 +172,8 @@ public class SyntaxArena {
 }
 
 /// SyntaxArena for parsing.
+@_spi(RawSyntax)
 public class ParsingSyntaxArena: SyntaxArena {
-  @_spi(RawSyntax)
   public typealias ParseTriviaFunction = (_ source: SyntaxText, _ position: TriviaPosition) -> [RawTriviaPiece]
 
   /// Source file buffer the Syntax tree represents.
@@ -185,7 +184,6 @@ public class ParsingSyntaxArena: SyntaxArena {
   /// - Important: Must never be changed to a mutable value. See `SyntaxArenaRef.parseTrivia`.
   private let parseTriviaFunction: ParseTriviaFunction
 
-  @_spi(RawSyntax)
   public init(parseTriviaFunction: @escaping ParseTriviaFunction) {
     self.sourceBuffer = .init(start: nil, count: 0)
     self.parseTriviaFunction = parseTriviaFunction
@@ -198,7 +196,6 @@ public class ParsingSyntaxArena: SyntaxArena {
   /// The interned buffer is guaranteed to be null-terminated.
   /// `contains(address _:)` is faster if the address is inside the memory
   /// range this function returned.
-  @_spi(RawSyntax)
   public func internSourceBuffer(_ buffer: UnsafeBufferPointer<UInt8>) -> UnsafeBufferPointer<UInt8> {
     let allocated = allocator.allocate(
       UInt8.self,
@@ -214,7 +211,6 @@ public class ParsingSyntaxArena: SyntaxArena {
     return sourceBuffer
   }
 
-  @_spi(RawSyntax)
   public override func contains(text: SyntaxText) -> Bool {
     if let addr = text.baseAddress, self.sourceBufferContains(addr) {
       return true
@@ -230,7 +226,6 @@ public class ParsingSyntaxArena: SyntaxArena {
   }
 
   /// Parse `source` into a list of ``RawTriviaPiece`` using `parseTriviaFunction`.
-  @_spi(RawSyntax)
   public func parseTrivia(source: SyntaxText, position: TriviaPosition) -> [RawTriviaPiece] {
     // Must never access mutable state. See `SyntaxArenaRef.parseTrivia`.
     return self.parseTriviaFunction(source, position)


### PR DESCRIPTION
(Preparation for #2926)

Mark `SyntaxArena` and `ParsingSyntaxArena` with `@_spi(RawSyntax)`.

`SyntaxArena` and its subclass `ParsingSyntaxArena` were only meant be used when dealing with `RawSyntax` which is already a SPI. Although the type itself was `public`, most initializers were SPI, also there was no way to retrieve it from existing types via public API. So we assume no one was actually using it directly.