### PR TITLE
[Syntax] Let SyntaxIdentifier use RawSyntax.ID directly

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -965,13 +965,6 @@ extension RawSyntax: Identifiable {
   }
 }
 
-extension UInt {
-  /// Convert `RawSymtax.ID` to `UInt`. Lossless.
-  init(rawID: RawSyntax.ID) {
-    self.init(bitPattern: rawID.pointer)
-  }
-}
-
 /// See `SyntaxMemoryLayout`.
 let RawSyntaxDataMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
   "RawSyntaxData": .init(RawSyntaxData.self),

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -76,7 +76,7 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
     // This var is a workaround for a potential compiler bug (rdar://141977987)
     let rootDataRef = arena.root
     return SyntaxIdentifier(
-      rootId: UInt(rawID: rootDataRef.pointee.raw.id),
+      rootId: rootDataRef.pointee.raw.id,
       indexInTree: SyntaxIdentifier.SyntaxIndexInTree(indexInTree: absoluteInfo.indexInTree)
     )
   }

--- a/Sources/SwiftSyntax/SyntaxIdentifier.swift
+++ b/Sources/SwiftSyntax/SyntaxIdentifier.swift
@@ -55,7 +55,7 @@ public struct SyntaxIdentifier: Comparable, Hashable, Sendable {
   /// same instance. This guarantees that the trees with the same 'rootId' have
   /// exact the same structure. But, two trees with exactly the same structure
   /// might still have different 'rootId's.
-  let rootId: UInt
+  let rootId: RawSyntax.ID
 
   /// Unique value for a node within its own tree.
   public let indexInTree: SyntaxIndexInTree
@@ -81,7 +81,7 @@ public struct SyntaxIdentifier: Comparable, Hashable, Sendable {
       return nil
     }
 
-    return SyntaxIdentifier(rootId: UInt(rawID: root.raw.id), indexInTree: indexInTree)
+    return SyntaxIdentifier(rootId: root.raw.id, indexInTree: indexInTree)
   }
 
   /// A ``SyntaxIdentifier`` compares less than another ``SyntaxIdentifier`` if the node at that identifier occurs first

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -364,7 +364,7 @@ extension SyntaxProtocol {
   /// ``SyntaxIdentifier``) or if no node with the given identifier is a child of this syntax node, returns `nil`.
   public func node(at syntaxIdentifier: SyntaxIdentifier) -> Syntax? {
     let syntax = Syntax(self)
-    guard UInt(rawID: syntax.raw.id) == syntaxIdentifier.rootId else {
+    guard syntax.raw.id == syntaxIdentifier.rootId else {
       return nil
     }
 


### PR DESCRIPTION
There was no reason to convert it to UInt.