### PR TITLE
[Perf] Optimize TokenSequence

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -36,7 +36,7 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
     self.dataRef = dataRef
   }
 
-  private var data: SyntaxData {
+  var data: SyntaxData {
     @_transparent unsafeAddress { dataRef.pointer }
   }
 

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -253,20 +253,7 @@ extension SyntaxProtocol {
   /// Recursively walks through the tree to find the token semantically before
   /// this node.
   public func previousToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
-    guard let parent = self.parent else {
-      return nil
-    }
-    let siblings = parent.children(viewMode: viewMode)
-    // `self` could be a missing node at index 0 and `viewMode` be `.sourceAccurate`.
-    // In that case `siblings` skips over the missing `self` node and has a `startIndex > 0`.
-    if siblings.startIndex < self.indexInParent {
-      for child in siblings[..<self.indexInParent].reversed() {
-        if let token = child.lastToken(viewMode: viewMode) {
-          return token
-        }
-      }
-    }
-    return parent.previousToken(viewMode: viewMode)
+    return self._syntaxNode.previousToken(viewMode: viewMode)
   }
 
   @available(*, deprecated, message: "Use nextToken(viewMode:) instead")
@@ -277,16 +264,7 @@ extension SyntaxProtocol {
   /// Recursively walks through the tree to find the next token semantically
   /// after this node.
   public func nextToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
-    guard let parent = self.parent else {
-      return nil
-    }
-    let siblings = parent.children(viewMode: viewMode)
-    for child in siblings[siblings.index(after: self.indexInParent)...] {
-      if let token = child.firstToken(viewMode: viewMode) {
-        return token
-      }
-    }
-    return parent.nextToken(viewMode: viewMode)
+    return self._syntaxNode.nextToken(viewMode: viewMode)
   }
 
   @available(*, deprecated, message: "Use firstToken(viewMode: .sourceAccurate) instead")
@@ -296,17 +274,7 @@ extension SyntaxProtocol {
 
   /// Returns the first token node that is part of this syntax node.
   public func firstToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
-    guard viewMode.shouldTraverse(node: raw) else { return nil }
-    if let token = _syntaxNode.as(TokenSyntax.self) {
-      return token
-    }
-
-    for child in children(viewMode: viewMode) {
-      if let token = child.firstToken(viewMode: viewMode) {
-        return token
-      }
-    }
-    return nil
+    return self._syntaxNode.firstToken(viewMode: viewMode)
   }
 
   @available(*, deprecated, message: "Use lastToken(viewMode: .sourceAccurate) instead")
@@ -316,17 +284,7 @@ extension SyntaxProtocol {
 
   /// Returns the last token node that is part of this syntax node.
   public func lastToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
-    guard viewMode.shouldTraverse(node: raw) else { return nil }
-    if let token = _syntaxNode.as(TokenSyntax.self) {
-      return token
-    }
-
-    for child in children(viewMode: viewMode).reversed() {
-      if let tok = child.lastToken(viewMode: viewMode) {
-        return tok
-      }
-    }
-    return nil
+    return self._syntaxNode.lastToken(viewMode: viewMode)
   }
 
   /// Sequence of tokens that are part of this Syntax node.


### PR DESCRIPTION
i.e. `previousToken`, `nextToken`, `firstToken`, and `lastToken`

Iterate over `layoutBuffer` directly to avoid `SyntaxChildren` which implies ARC for each element. This way, it only retains the found `TokenSyntax`, no ARC for layout nodes when traversing.

```swift
measure {
  for _ in 0 ..< iterations {
    for _ in syntax.tokens(viewMode: .sourceAccurate) {}
    for _ in syntax.tokens(viewMode: .sourceAccurate).reversed() {}
  }
}
```
Baseline (main):
```
measured [Time, seconds] average: 2.465, relative standard deviation: 0.494%, values: [2.495664, 2.473491, 2.457856, 2.470168, 2.454836, 2.465194, 2.455580, 2.456892, 2.453483, 2.464719]
```
After:
```
measured [Time, seconds] average: 0.780, relative standard deviation: 1.101%, values: [0.803369, 0.773848, 0.772971, 0.782759, 0.775489, 0.773815, 0.777069, 0.782878, 0.776262, 0.782629]
```

For reference: [affected projects](https://github.com/search?q=language%3ASwift++NOT+is%3Afork+%28%22firstToken%28viewMode%22+OR+%22lastToken%28viewMode%22+OR+%22nextToken%28viewMode%22+OR+%22previousToken%28viewMode%22%29&type=code)