### PR TITLE
[Diagnostics] Fix and adjust FixIt application

### DIFF
--- a/Sources/SwiftIDEUtils/FixItApplier.swift
+++ b/Sources/SwiftIDEUtils/FixItApplier.swift
@@ -36,6 +36,7 @@ public enum FixItApplier {
   ) -> String {
     let messages = messages ?? diagnostics.compactMap { $0.fixIts.first?.message.message }
 
+    // FIXME: This assumes every fix-it is applied to a node in the 'tree', which is not guaranteed.
     let edits =
       diagnostics
       .flatMap(\.fixIts)

--- a/Tests/SwiftDiagnosticsTest/FixItTests.swift
+++ b/Tests/SwiftDiagnosticsTest/FixItTests.swift
@@ -18,14 +18,14 @@ import _SwiftSyntaxTestSupport
 
 final class FixItTests: XCTestCase {
   func testEditsForFixIt() throws {
-    let markedSource = "protocol 1️⃣Multi 2️⃣ident 3️⃣{}"
+    let markedSource = "protocol 1️⃣Multi2️⃣ 3️⃣ident 4️⃣{}"
     let (markers, source) = extractMarkers(markedSource)
     let positions = markers.mapValues { AbsolutePosition(utf8Offset: $0) }
-    XCTAssertEqual(positions.count, 3)
+    XCTAssertEqual(positions.count, 4)
 
     let expectedEdits = [
-      SourceEdit(range: positions["1️⃣"]!..<positions["2️⃣"]!, replacement: "Multiident "),
-      SourceEdit(range: positions["2️⃣"]!..<positions["3️⃣"]!, replacement: ""),
+      SourceEdit(range: positions["1️⃣"]!..<positions["2️⃣"]!, replacement: "Multiident"),
+      SourceEdit(range: positions["3️⃣"]!..<positions["4️⃣"]!, replacement: ""),
     ]
     let tree = Parser.parse(source: source)
     let diags = ParseDiagnosticsGenerator.diagnostics(for: tree)


### PR DESCRIPTION
* Fix mismatch on `FixIt.Change.replace` between several application implementations. Specifically `.replace` should includes the trivia.
* Ignore no-op `FixIt.Change.replace{Leading|Trailing}Triviia`.
