### PR TITLE
[Syntax] Fix TriviaPiece.isNewline

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Trivia.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Trivia.swift
@@ -44,11 +44,6 @@ public class Trivia {
   /// Useful for multi-character trivias like `\r\n`.
   public let characters: [Character]
 
-  /// The list of characters as they would appear in Swift code.
-  ///
-  /// This might differ from `characters` due to Swift's character escape requirements.
-  public let swiftCharacters: [Character]
-
   /// The traits.
   public let traits: TriviaTraits
 
@@ -84,27 +79,17 @@ public class Trivia {
   ///   - name: A name of the trivia.
   ///   - comment: A doc comment describing the trivia.
   ///   - characters: A list of characters that make up the trivia.
-  ///   - swiftCharacters: A list of characters as they would appear in Swift code.
   ///   - isComment: Indicates if the trivia represents a comment.
   init(
     name: TokenSyntax,
     comment: SwiftSyntax.Trivia,
     characters: [Character] = [],
-    swiftCharacters: [Character] = [],
     traits: TriviaTraits = []
   ) {
     self.name = name
     self.comment = comment
     self.characters = characters
     self.traits = traits
-
-    // Swift sometimes doesn't support escaped characters like \f or \v;
-    // we should allow specifying alternatives explicitly.
-    if !swiftCharacters.isEmpty {
-      self.swiftCharacters = swiftCharacters
-    } else {
-      self.swiftCharacters = characters
-    }
   }
 }
 
@@ -112,12 +97,7 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "Backslash",
     comment: #"A backslash that is at the end of a line in a multi-line string literal to escape the newline."#,
-    characters: [
-      Character("\\")
-    ],
-    swiftCharacters: [
-      Character("\\")
-    ]
+    characters: ["\\"]
   ),
 
   Trivia(
@@ -129,26 +109,14 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "CarriageReturn",
     comment: #"A newline '\r' character."#,
-    characters: [
-      Character("\r")
-    ],
-    swiftCharacters: [
-      Character("\r")
-    ],
+    characters: ["\r"],
     traits: [.whitespace, .newline]
   ),
 
   Trivia(
     name: "CarriageReturnLineFeed",
     comment: #"A newline consists of contiguous '\r' and '\n' characters."#,
-    characters: [
-      Character("\r"),
-      Character("\n"),
-    ],
-    swiftCharacters: [
-      Character("\r"),
-      Character("\n"),
-    ],
+    characters: ["\r", "\n"],
     traits: [.whitespace, .newline]
   ),
 
@@ -168,12 +136,7 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "Formfeed",
     comment: #"A form-feed 'f' character."#,
-    characters: [
-      Character("\u{c}")
-    ],
-    swiftCharacters: [
-      Character("\u{240C}")
-    ],
+    characters: ["\u{000C}"],
     traits: [.whitespace]
   ),
 
@@ -186,47 +149,27 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "Newline",
     comment: #"A newline '\n' character."#,
-    characters: [
-      Character("\n")
-    ],
-    swiftCharacters: [
-      Character("\n")
-    ],
+    characters: ["\n"],
     traits: [.whitespace, .newline]
   ),
 
   Trivia(
     name: "Pound",
     comment: #"A '#' that is at the end of a line in a multi-line string literal to escape the newline."#,
-    characters: [
-      Character("#")
-    ],
-    swiftCharacters: [
-      Character("#")
-    ]
+    characters: ["#"]
   ),
 
   Trivia(
     name: "Space",
     comment: #"A space ' ' character."#,
-    characters: [
-      Character(" ")
-    ],
-    swiftCharacters: [
-      Character(" ")
-    ],
+    characters: [" "],
     traits: [.whitespace, .spaceOrTab]
   ),
 
   Trivia(
     name: "Tab",
     comment: #"A tab '\t' character."#,
-    characters: [
-      Character("\t")
-    ],
-    swiftCharacters: [
-      Character("\t")
-    ],
+    characters: ["\t"],
     traits: [.whitespace, .spaceOrTab]
   ),
 
@@ -239,12 +182,7 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "VerticalTab",
     comment: #"A vertical tab '\v' character."#,
-    characters: [
-      Character("\u{b}")
-    ],
-    swiftCharacters: [
-      Character("\u{2B7F}")
-    ],
+    characters: ["\u{000B}"],
     traits: [.whitespace]
   ),
 ]

--- a/CodeGeneration/Sources/SyntaxSupport/Trivia.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Trivia.swift
@@ -39,10 +39,8 @@ public class Trivia {
   /// The doc comment describing the trivia.
   public let comment: SwiftSyntax.Trivia
 
-  /// The list of characters that make up the trivia.
-  ///
-  /// Useful for multi-character trivias like `\r\n`.
-  public let characters: [Character]
+  /// The characters that make up the trivia.
+  public let characters: String?
 
   /// The traits.
   public let traits: TriviaTraits
@@ -65,13 +63,10 @@ public class Trivia {
     }
   }
 
-  /// The length of the `characters` array.
-  public var charactersLen: Int { characters.count }
-
   /// Indicates if the trivia is a collection of characters.
   ///
   /// If `true`, the trivia is made up of multiple characters.
-  public var isCollection: Bool { charactersLen > 0 }
+  public var isCollection: Bool { characters != nil }
 
   /// Initializes a new `Trivia` instance.
   ///
@@ -83,7 +78,7 @@ public class Trivia {
   init(
     name: TokenSyntax,
     comment: SwiftSyntax.Trivia,
-    characters: [Character] = [],
+    characters: String? = nil,
     traits: TriviaTraits = []
   ) {
     self.name = name
@@ -97,7 +92,7 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "Backslash",
     comment: #"A backslash that is at the end of a line in a multi-line string literal to escape the newline."#,
-    characters: ["\\"]
+    characters: "\\"
   ),
 
   Trivia(
@@ -109,14 +104,14 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "CarriageReturn",
     comment: #"A newline '\r' character."#,
-    characters: ["\r"],
+    characters: "\r",
     traits: [.whitespace, .newline]
   ),
 
   Trivia(
     name: "CarriageReturnLineFeed",
     comment: #"A newline consists of contiguous '\r' and '\n' characters."#,
-    characters: ["\r", "\n"],
+    characters: "\r\n",
     traits: [.whitespace, .newline]
   ),
 
@@ -136,7 +131,7 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "Formfeed",
     comment: #"A form-feed 'f' character."#,
-    characters: ["\u{000C}"],
+    characters: "\u{000C}",
     traits: [.whitespace]
   ),
 
@@ -149,27 +144,27 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "Newline",
     comment: #"A newline '\n' character."#,
-    characters: ["\n"],
+    characters: "\n",
     traits: [.whitespace, .newline]
   ),
 
   Trivia(
     name: "Pound",
     comment: #"A '#' that is at the end of a line in a multi-line string literal to escape the newline."#,
-    characters: ["#"]
+    characters: "#"
   ),
 
   Trivia(
     name: "Space",
     comment: #"A space ' ' character."#,
-    characters: [" "],
+    characters: " ",
     traits: [.whitespace, .spaceOrTab]
   ),
 
   Trivia(
     name: "Tab",
     comment: #"A tab '\t' character."#,
-    characters: ["\t"],
+    characters: "\t",
     traits: [.whitespace, .spaceOrTab]
   ),
 
@@ -182,7 +177,7 @@ public let TRIVIAS: [Trivia] = [
   Trivia(
     name: "VerticalTab",
     comment: #"A vertical tab '\v' character."#,
-    characters: ["\u{000B}"],
+    characters: "\u{000B}",
     traits: [.whitespace]
   ),
 ]

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/TriviaPiecesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/TriviaPiecesFile.swift
@@ -68,10 +68,9 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       try SwitchExprSyntax("switch self") {
         for trivia in TRIVIAS {
-          if trivia.isCollection {
-            let joined = trivia.characters.map { "\($0)" }.joined()
+          if let characters = trivia.characters {
             SwitchCaseSyntax("case let .\(trivia.enumCaseName)(count):") {
-              ExprSyntax("printRepeated(\(literal: joined), count: count)")
+              ExprSyntax("printRepeated(\(literal: characters), count: count)")
             }
           } else {
             SwitchCaseSyntax("case let .\(trivia.enumCaseName)(text):") {
@@ -112,11 +111,10 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     """
   ) {
     for trivia in TRIVIAS {
-      if trivia.isCollection {
-        let joined = trivia.characters.map { "\($0)" }.joined()
+      if let characters = trivia.characters {
         DeclSyntax(
           """
-          /// Returns a piece of trivia for some number of \(literal: joined) characters.
+          /// Returns a piece of trivia for some number of \(literal: characters) characters.
           public static func \(trivia.enumCaseName)(_ count: Int) -> Trivia {
             return [.\(trivia.enumCaseName)(count)]
           }
@@ -125,7 +123,7 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
         DeclSyntax(
           """
-          /// Gets a piece of trivia for \(literal: joined) characters.
+          /// Gets a piece of trivia for \(literal: characters) characters.
           public static var \(trivia.lowerName): Trivia {
             return .\(trivia.enumCaseName)(1)
           }
@@ -151,10 +149,10 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     try VariableDeclSyntax("public var sourceLength: SourceLength") {
       try SwitchExprSyntax("switch self") {
         for trivia in TRIVIAS {
-          if trivia.isCollection {
+          if let characters = trivia.characters {
             SwitchCaseSyntax("case let .\(trivia.enumCaseName)(count):") {
-              if trivia.charactersLen != 1 {
-                StmtSyntax("return SourceLength(utf8Length: count * \(raw: trivia.charactersLen))")
+              if characters.utf8.count != 1 {
+                StmtSyntax("return SourceLength(utf8Length: count * \(raw: characters.utf8.count))")
               } else {
                 StmtSyntax("return SourceLength(utf8Length: count)")
               }
@@ -231,10 +229,10 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     try VariableDeclSyntax("public var byteLength: Int") {
       try SwitchExprSyntax("switch self") {
         for trivia in TRIVIAS {
-          if trivia.isCollection {
+          if let characters = trivia.characters {
             SwitchCaseSyntax("case let .\(trivia.enumCaseName)(count):") {
-              if trivia.charactersLen != 1 {
-                StmtSyntax("return count * \(raw: trivia.charactersLen)")
+              if characters.utf8.count != 1 {
+                StmtSyntax("return count * \(raw: characters.utf8.count)")
               } else {
                 StmtSyntax("return count")
               }

--- a/Sources/SwiftSyntax/generated/TriviaPieces.swift
+++ b/Sources/SwiftSyntax/generated/TriviaPieces.swift
@@ -443,12 +443,8 @@ extension RawTriviaPiece {
 }
 
 extension TriviaPiece {
-  /// Returns `true` if this piece is a newline, space or tab.
+  /// Returns `true` if this piece is a whitespace.
   public var isWhitespace: Bool {
-    return isSpaceOrTab || isNewline
-  }
-
-  public var isNewline: Bool {
     switch self {
     case .carriageReturns:
       return true
@@ -458,6 +454,10 @@ extension TriviaPiece {
       return true
     case .newlines:
       return true
+    case .spaces:
+      return true
+    case .tabs:
+      return true
     case .verticalTabs:
       return true
     default:
@@ -465,6 +465,21 @@ extension TriviaPiece {
     }
   }
 
+  /// Returns `true` if this piece is a newline.
+  public var isNewline: Bool {
+    switch self {
+    case .carriageReturns:
+      return true
+    case .carriageReturnLineFeeds:
+      return true
+    case .newlines:
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` if this piece is a space or tab.
   public var isSpaceOrTab: Bool {
     switch self {
     case .spaces:
@@ -479,7 +494,13 @@ extension TriviaPiece {
   /// Returns `true` if this piece is a comment.
   public var isComment: Bool {
     switch self {
-    case .lineComment, .blockComment, .docLineComment, .docBlockComment:
+    case .blockComment:
+      return true
+    case .docBlockComment:
+      return true
+    case .docLineComment:
+      return true
+    case .lineComment:
       return true
     default:
       return false
@@ -488,12 +509,8 @@ extension TriviaPiece {
 }
 
 extension RawTriviaPiece {
-  /// Returns `true` if this piece is a newline, space or tab.
+  /// Returns `true` if this piece is a whitespace.
   public var isWhitespace: Bool {
-    return isSpaceOrTab || isNewline
-  }
-
-  public var isNewline: Bool {
     switch self {
     case .carriageReturns:
       return true
@@ -503,6 +520,10 @@ extension RawTriviaPiece {
       return true
     case .newlines:
       return true
+    case .spaces:
+      return true
+    case .tabs:
+      return true
     case .verticalTabs:
       return true
     default:
@@ -510,6 +531,21 @@ extension RawTriviaPiece {
     }
   }
 
+  /// Returns `true` if this piece is a newline.
+  public var isNewline: Bool {
+    switch self {
+    case .carriageReturns:
+      return true
+    case .carriageReturnLineFeeds:
+      return true
+    case .newlines:
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` if this piece is a space or tab.
   public var isSpaceOrTab: Bool {
     switch self {
     case .spaces:
@@ -524,7 +560,13 @@ extension RawTriviaPiece {
   /// Returns `true` if this piece is a comment.
   public var isComment: Bool {
     switch self {
-    case .lineComment, .blockComment, .docLineComment, .docBlockComment:
+    case .blockComment:
+      return true
+    case .docBlockComment:
+      return true
+    case .docLineComment:
+      return true
+    case .lineComment:
       return true
     default:
       return false


### PR DESCRIPTION
In Swift, only `CR`, `LF`, and `CR`+`LF` are considered newline characters. `TriviaPiece.isNewline` should not return true for `VT` and `FF`.

Instead of using `Swift.Character.isNewline`, introduce `TriviaTraits` in CodeGeneration, and manually set them for each trivia piece kind.

Also some drive-by cleanups:
* Eliminate `Trivia.swiftCharacters` because it was unused.
* Use `String?` for `Token.characters` because string is naturally a collection of characters.
* Eliminate `Trivia.CharactersLen` because `Trivia.characters.utf8.count` is straightforward enough, and it was technically wrong because it returned character count, but not UTF8 byte count.