### PR TITLE
[Syntax] Use no-op PlatformMutex implemtation for wasm32-unknown-wasi

### DIFF
--- a/Sources/_SwiftSyntaxCShims/PlatformMutex.c
+++ b/Sources/_SwiftSyntaxCShims/PlatformMutex.c
@@ -13,6 +13,13 @@
 #include "PlatformMutex.h"
 #include <stdlib.h>
 
+#if defined(__wasi__) && !defined(_REENTRANT)
+#define SWIFTSYNTAX_HAS_THREAD 0
+#else
+#define SWIFTSYNTAX_HAS_THREAD 1
+#endif
+
+#if SWIFTSYNTAX_HAS_THREAD
 #if defined(__APPLE__)
 #include <os/lock.h>
 
@@ -81,5 +88,20 @@ void swiftsyntax_platform_mutex_destroy(PlatformMutex m) {
 }
 
 #else
-#error "platfrom mutex implementation is not available"
+#error "platform mutex implementation is not available"
+// Add platform specific implementation above, or set SWIFTSYNTAX_HAS_THREAD to 0.
 #endif
+
+#else // SWIFTSYNTAX_HAS_THREAD
+
+PlatformMutex swiftsyntax_platform_mutex_create() {
+  PlatformMutex m;
+  m.opaque = 0;
+  return m;
+}
+
+void swiftsyntax_platform_mutex_lock(PlatformMutex m) {}
+void swiftsyntax_platform_mutex_unlock(PlatformMutex m) {}
+void swiftsyntax_platform_mutex_destroy(PlatformMutex m) {}
+
+#endif // SWIFTSYNTAX_HAS_THREAD


### PR DESCRIPTION
Can be detected with `defined(__wasi__) && !defined(_REENTRANT)`

Fixes https://github.com/kkebo/swift-syntax/issues/145