### PR TITLE
[6.1] Don’t remove `#if` attributes with `AttributeRemover`

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -530,7 +530,11 @@ public class AttributeRemover: SyntaxRewriter {
 
   public override func visit(_ node: AttributeListSyntax) -> AttributeListSyntax {
     var filteredAttributes: [AttributeListSyntax.Element] = []
-    for case .attribute(let attribute) in node {
+    for attribute in node {
+      guard case .attribute(let attribute) = attribute else {
+        filteredAttributes.append(attribute)
+        continue
+      }
       if self.predicate(attribute) {
         var leadingTrivia = attribute.leadingTrivia
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
@@ -470,4 +470,21 @@ final class AttributeRemoverTests: XCTestCase {
         """
     )
   }
+
+  func testKeepPoundIfInAttributes() {
+    assertSyntaxRemovingTestAttributes(
+      """
+      #if true
+      @inlinable
+      #endif
+      func f() {}
+      """,
+      reduction: """
+        #if true
+        @inlinable
+        #endif
+        func f() {}
+        """
+    )
+  }
 }


### PR DESCRIPTION
- **Explanation**: When expanding macros using MacroSystem, we would always remove attributes inside `#if`. Change the behavior to never remove them since we can’t evaluate `#if`.
- **Scope**: Expansion of macros in `assertMacroExpansion`
- **Issue**: #2923 / rdar://141840779
- **Original PR**:https://github.com/swiftlang/swift-syntax/pull/2945
- **Risk**: Does not affect compile-time expansion of macros
- **Testing**: Added test case 
- **Reviewer**:  @bnbarham 
