### PR TITLE
Add keypath method and initializer syntax under an experimental feature flag `keypathWithMethodMembers`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -21,6 +21,7 @@ public enum ExperimentalFeature: String, CaseIterable {
   case coroutineAccessors
   case valueGenerics
   case abiAttribute
+  case keypathWithMethodMembers
 
   /// The name of the feature as it is written in the compiler's `Features.def` file.
   public var featureName: String {
@@ -41,6 +42,8 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "ValueGenerics"
     case .abiAttribute:
       return "ABIAttribute"
+    case .keypathWithMethodMembers:
+      return "KeypathWithMethodMembers"
     }
   }
 
@@ -63,6 +66,8 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "value generics"
     case .abiAttribute:
       return "@abi attribute"
+    case .keypathWithMethodMembers:
+      return "keypaths with method members"
     }
   }
 

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -1209,6 +1209,11 @@ public let EXPR_NODES: [Node] = [
             kind: .node(kind: .keyPathPropertyComponent)
           ),
           Child(
+            name: "method",
+            kind: .node(kind: .keyPathMethodComponent),
+            experimentalFeature: .keypathWithMethodMembers
+          ),
+          Child(
             name: "subscript",
             kind: .node(kind: .keyPathSubscriptComponent)
           ),
@@ -1309,6 +1314,33 @@ public let EXPR_NODES: [Node] = [
         "arguments": .renamed(from: "argumentList"),
         "rightSquare": .renamed(from: "rightBracket"),
       ]
+    ]
+  ),
+
+  Node(
+    kind: .keyPathMethodComponent,
+    base: .syntax,
+    experimentalFeature: .keypathWithMethodMembers,
+    nameForDiagnostics: "key path method component",
+    documentation: "A key path component like `.method()`, `.method(10)`, or `.method(val: 10)`.",
+    children: [
+      Child(
+        name: "declName",
+        kind: .node(kind: .declReferenceExpr)
+      ),
+      Child(
+        name: "leftParen",
+        kind: .token(choices: [.token(.leftParen)])
+      ),
+      Child(
+        name: "arguments",
+        kind: .collection(kind: .labeledExprList, collectionElementName: "Argument"),
+        nameForDiagnostics: "arguments"
+      ),
+      Child(
+        name: "rightParen",
+        kind: .token(choices: [.token(.rightParen)])
+      ),
     ]
   ),
 

--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -182,6 +182,7 @@ public enum SyntaxNodeKind: String, CaseIterable, IdentifierConvertible, TypeCon
   case keyPathOptionalComponent
   case keyPathPropertyComponent
   case keyPathSubscriptComponent
+  case keyPathMethodComponent
   case labeledExpr
   case labeledExprList
   case labeledSpecializeArgument

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -570,6 +570,10 @@ class ValidateSyntaxNodes: XCTestCase {
         ),
         ValidationFailure(node: .lifetimeTypeSpecifier, message: "could conform to trait 'Parenthesized' but does not"),
         ValidationFailure(node: .codeBlockFile, message: "could conform to trait 'WithCodeBlock' but does not"),
+        ValidationFailure(
+          node: .keyPathMethodComponent,
+          message: "could conform to trait 'Parenthesized' but does not"
+        ),
       ]
     )
   }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
-@_spi(RawSyntax) internal import SwiftSyntax
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
 #else
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 #endif
 
 extension TokenConsumer {
@@ -1115,11 +1115,54 @@ extension Parser {
         continue
       }
 
-      // Check for a .name or .1 suffix.
+      // Check for a .name, .1, .name(), .name("Kiwi"), .name(fruit:),
+      // .name(_:), .name(fruit: "Kiwi) suffix.
       if self.at(.period) {
         let (unexpectedPeriod, period, declName, generics) = parseDottedExpressionSuffix(
           previousNode: components.last?.raw ?? rootType?.raw ?? backslash.raw
         )
+
+        // If fully applied method component, parse as a keypath method.
+        if self.experimentalFeatures.contains(.keypathWithMethodMembers)
+          && self.at(.leftParen)
+        {
+          var (unexpectedBeforeLParen, leftParen) = self.expect(.leftParen)
+          if let generics = generics {
+            unexpectedBeforeLParen = RawUnexpectedNodesSyntax(
+              (unexpectedBeforeLParen?.elements ?? []) + [RawSyntax(generics)],
+              arena: self.arena
+            )
+          }
+          let args = self.parseArgumentListElements(
+            pattern: pattern,
+            allowTrailingComma: true
+          )
+          let (unexpectedBeforeRParen, rightParen) = self.expect(.rightParen)
+
+          components.append(
+            RawKeyPathComponentSyntax(
+              unexpectedPeriod,
+              period: period,
+              component: .method(
+                RawKeyPathMethodComponentSyntax(
+                  declName: declName,
+                  unexpectedBeforeLParen,
+                  leftParen: leftParen,
+                  arguments: RawLabeledExprListSyntax(
+                    elements: args,
+                    arena: self.arena
+                  ),
+                  unexpectedBeforeRParen,
+                  rightParen: rightParen,
+                  arena: self.arena
+                )
+              ),
+              arena: self.arena
+            )
+          )
+          continue
+        }
+        // Else, parse as a property.
         components.append(
           RawKeyPathComponentSyntax(
             unexpectedPeriod,
@@ -1140,7 +1183,6 @@ extension Parser {
       // No more postfix expressions.
       break
     }
-
     return RawKeyPathExprSyntax(
       unexpectedBeforeBackslash,
       backslash: backslash,

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -48,6 +48,9 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of @abi attribute.
   public static let abiAttribute = Self (rawValue: 1 << 7)
 
+  /// Whether to enable the parsing of keypaths with method members.
+  public static let keypathWithMethodMembers = Self (rawValue: 1 << 8)
+
   /// Creates a new value representing the experimental feature with the
   /// given name, or returns nil if the name is not recognized.
   public init?(name: String) {
@@ -68,6 +71,8 @@ extension Parser.ExperimentalFeatures {
       self = .valueGenerics
     case "ABIAttribute":
       self = .abiAttribute
+    case "KeypathWithMethodMembers":
+      self = .keypathWithMethodMembers
     default:
       return nil
     }

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -206,6 +206,8 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "generic where clause"
   case \KeyPathExprSyntax.root:
     return "root"
+  case \KeyPathMethodComponentSyntax.arguments:
+    return "arguments"
   case \KeyPathSubscriptComponentSyntax.arguments:
     return "arguments"
   case \LabeledExprSyntax.label:

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -249,6 +249,8 @@ extension SyntaxKind {
       return "key path component"
     case .keyPathExpr:
       return "key path"
+    case .keyPathMethodComponent:
+      return "key path method component"
     case .keyPathOptionalComponent:
       return "key path optional component"
     case .keyPathPropertyComponent:

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1951,6 +1951,24 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "components"
   case \KeyPathExprSyntax.unexpectedAfterComponents:
     return "unexpectedAfterComponents"
+  case \KeyPathMethodComponentSyntax.unexpectedBeforeDeclName:
+    return "unexpectedBeforeDeclName"
+  case \KeyPathMethodComponentSyntax.declName:
+    return "declName"
+  case \KeyPathMethodComponentSyntax.unexpectedBetweenDeclNameAndLeftParen:
+    return "unexpectedBetweenDeclNameAndLeftParen"
+  case \KeyPathMethodComponentSyntax.leftParen:
+    return "leftParen"
+  case \KeyPathMethodComponentSyntax.unexpectedBetweenLeftParenAndArguments:
+    return "unexpectedBetweenLeftParenAndArguments"
+  case \KeyPathMethodComponentSyntax.arguments:
+    return "arguments"
+  case \KeyPathMethodComponentSyntax.unexpectedBetweenArgumentsAndRightParen:
+    return "unexpectedBetweenArgumentsAndRightParen"
+  case \KeyPathMethodComponentSyntax.rightParen:
+    return "rightParen"
+  case \KeyPathMethodComponentSyntax.unexpectedAfterRightParen:
+    return "unexpectedAfterRightParen"
   case \KeyPathOptionalComponentSyntax.unexpectedBeforeQuestionOrExclamationMark:
     return "unexpectedBeforeQuestionOrExclamationMark"
   case \KeyPathOptionalComponentSyntax.questionOrExclamationMark:

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -1324,6 +1324,16 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
+  @_spi(ExperimentalLanguageFeatures)
+  override open func visit(_ node: KeyPathMethodComponentSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  @_spi(ExperimentalLanguageFeatures)
+  override open func visitPost(_ node: KeyPathMethodComponentSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+
   override open func visit(_ node: KeyPathOptionalComponentSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -1676,6 +1676,7 @@ extension Syntax {
       .node(KeyPathComponentListSyntax.self),
       .node(KeyPathComponentSyntax.self),
       .node(KeyPathExprSyntax.self),
+      .node(KeyPathMethodComponentSyntax.self),
       .node(KeyPathOptionalComponentSyntax.self),
       .node(KeyPathPropertyComponentSyntax.self),
       .node(KeyPathSubscriptComponentSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -178,6 +178,8 @@ public enum SyntaxEnum: Sendable {
   case keyPathComponentList(KeyPathComponentListSyntax)
   case keyPathComponent(KeyPathComponentSyntax)
   case keyPathExpr(KeyPathExprSyntax)
+  @_spi(ExperimentalLanguageFeatures)
+  case keyPathMethodComponent(KeyPathMethodComponentSyntax)
   case keyPathOptionalComponent(KeyPathOptionalComponentSyntax)
   case keyPathPropertyComponent(KeyPathPropertyComponentSyntax)
   case keyPathSubscriptComponent(KeyPathSubscriptComponentSyntax)
@@ -638,6 +640,8 @@ extension Syntax {
       return .keyPathComponent(KeyPathComponentSyntax(self)!)
     case .keyPathExpr:
       return .keyPathExpr(KeyPathExprSyntax(self)!)
+    case .keyPathMethodComponent:
+      return .keyPathMethodComponent(KeyPathMethodComponentSyntax(self)!)
     case .keyPathOptionalComponent:
       return .keyPathOptionalComponent(KeyPathOptionalComponentSyntax(self)!)
     case .keyPathPropertyComponent:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -178,6 +178,8 @@ public enum SyntaxKind: Sendable {
   case keyPathComponentList
   case keyPathComponent
   case keyPathExpr
+  @_spi(ExperimentalLanguageFeatures)
+  case keyPathMethodComponent
   case keyPathOptionalComponent
   case keyPathPropertyComponent
   case keyPathSubscriptComponent
@@ -763,6 +765,8 @@ public enum SyntaxKind: Sendable {
       return KeyPathComponentSyntax.self
     case .keyPathExpr:
       return KeyPathExprSyntax.self
+    case .keyPathMethodComponent:
+      return KeyPathMethodComponentSyntax.self
     case .keyPathOptionalComponent:
       return KeyPathOptionalComponentSyntax.self
     case .keyPathPropertyComponent:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -1203,6 +1203,14 @@ open class SyntaxRewriter {
     return ExprSyntax(KeyPathExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
+  /// Visit a `KeyPathMethodComponentSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  @_spi(ExperimentalLanguageFeatures)
+  open func visit(_ node: KeyPathMethodComponentSyntax) -> KeyPathMethodComponentSyntax {
+    return KeyPathMethodComponentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
+  }
+
   /// Visit a ``KeyPathOptionalComponentSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -2965,6 +2973,11 @@ open class SyntaxRewriter {
   }
 
   @inline(never)
+  private func visitKeyPathMethodComponentSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(KeyPathMethodComponentSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
   private func visitKeyPathOptionalComponentSyntaxImpl(_ node: Syntax) -> Syntax {
     Syntax(visit(KeyPathOptionalComponentSyntax(unsafeCasting: node)))
   }
@@ -3971,6 +3984,8 @@ open class SyntaxRewriter {
       return self.visitKeyPathComponentSyntaxImpl(_:)
     case .keyPathExpr:
       return self.visitKeyPathExprSyntaxImpl(_:)
+    case .keyPathMethodComponent:
+      return self.visitKeyPathMethodComponentSyntaxImpl(_:)
     case .keyPathOptionalComponent:
       return self.visitKeyPathOptionalComponentSyntaxImpl(_:)
     case .keyPathPropertyComponent:
@@ -4561,6 +4576,8 @@ open class SyntaxRewriter {
       return visitKeyPathComponentSyntaxImpl(node)
     case .keyPathExpr:
       return visitKeyPathExprSyntaxImpl(node)
+    case .keyPathMethodComponent:
+      return visitKeyPathMethodComponentSyntaxImpl(node)
     case .keyPathOptionalComponent:
       return visitKeyPathOptionalComponentSyntaxImpl(node)
     case .keyPathPropertyComponent:

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -1930,6 +1930,20 @@ open class SyntaxVisitor {
   open func visitPost(_ node: KeyPathExprSyntax) {
   }
 
+  /// Visiting `KeyPathMethodComponentSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  @_spi(ExperimentalLanguageFeatures)
+  open func visit(_ node: KeyPathMethodComponentSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `KeyPathMethodComponentSyntax` and its descendants.
+  ///   - node: the node we just finished visiting.
+  @_spi(ExperimentalLanguageFeatures)
+  open func visitPost(_ node: KeyPathMethodComponentSyntax) {
+  }
+
   /// Visiting ``KeyPathOptionalComponentSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4812,6 +4826,14 @@ open class SyntaxVisitor {
   }
 
   @inline(never)
+  private func visitKeyPathMethodComponentSyntaxImpl(_ node: Syntax) {
+    if visit(KeyPathMethodComponentSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(KeyPathMethodComponentSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
   private func visitKeyPathOptionalComponentSyntaxImpl(_ node: Syntax) {
     if visit(KeyPathOptionalComponentSyntax(unsafeCasting: node)) == .visitChildren {
       visitChildren(node)
@@ -6217,6 +6239,8 @@ open class SyntaxVisitor {
       return self.visitKeyPathComponentSyntaxImpl(_:)
     case .keyPathExpr:
       return self.visitKeyPathExprSyntaxImpl(_:)
+    case .keyPathMethodComponent:
+      return self.visitKeyPathMethodComponentSyntaxImpl(_:)
     case .keyPathOptionalComponent:
       return self.visitKeyPathOptionalComponentSyntaxImpl(_:)
     case .keyPathPropertyComponent:
@@ -6807,6 +6831,8 @@ open class SyntaxVisitor {
       self.visitKeyPathComponentSyntaxImpl(node)
     case .keyPathExpr:
       self.visitKeyPathExprSyntaxImpl(node)
+    case .keyPathMethodComponent:
+      self.visitKeyPathMethodComponentSyntaxImpl(node)
     case .keyPathOptionalComponent:
       self.visitKeyPathOptionalComponentSyntaxImpl(node)
     case .keyPathPropertyComponent:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
@@ -66,16 +66,21 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
 public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
   public enum Component: RawSyntaxNodeProtocol {
     case property(RawKeyPathPropertyComponentSyntax)
+    /// - Note: Requires experimental feature `keypathWithMethodMembers`.
+    @_spi(ExperimentalLanguageFeatures)
+    case method(RawKeyPathMethodComponentSyntax)
     case `subscript`(RawKeyPathSubscriptComponentSyntax)
     case optional(RawKeyPathOptionalComponentSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      RawKeyPathPropertyComponentSyntax.isKindOf(raw) || RawKeyPathSubscriptComponentSyntax.isKindOf(raw) || RawKeyPathOptionalComponentSyntax.isKindOf(raw)
+      RawKeyPathPropertyComponentSyntax.isKindOf(raw) || RawKeyPathMethodComponentSyntax.isKindOf(raw) || RawKeyPathSubscriptComponentSyntax.isKindOf(raw) || RawKeyPathOptionalComponentSyntax.isKindOf(raw)
     }
 
     public var raw: RawSyntax {
       switch self {
       case .property(let node):
+        return node.raw
+      case .method(let node):
         return node.raw
       case .subscript(let node):
         return node.raw
@@ -87,6 +92,8 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
     public init?(_ node: __shared some RawSyntaxNodeProtocol) {
       if let node = node.as(RawKeyPathPropertyComponentSyntax.self) {
         self = .property(node)
+      } else if let node = node.as(RawKeyPathMethodComponentSyntax.self) {
+        self = .method(node)
       } else if let node = node.as(RawKeyPathSubscriptComponentSyntax.self) {
         self = .subscript(node)
       } else if let node = node.as(RawKeyPathOptionalComponentSyntax.self) {
@@ -244,6 +251,101 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol {
 
   public var unexpectedAfterComponents: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(ExperimentalLanguageFeatures)
+@_spi(RawSyntax)
+public struct RawKeyPathMethodComponentSyntax: RawSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .keyPathMethodComponent
+  }
+
+  public var raw: RawSyntax
+
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+
+  public init?(_ other: some RawSyntaxNodeProtocol) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeDeclName: RawUnexpectedNodesSyntax? = nil,
+    declName: RawDeclReferenceExprSyntax,
+    _ unexpectedBetweenDeclNameAndLeftParen: RawUnexpectedNodesSyntax? = nil,
+    leftParen: RawTokenSyntax,
+    _ unexpectedBetweenLeftParenAndArguments: RawUnexpectedNodesSyntax? = nil,
+    arguments: RawLabeledExprListSyntax,
+    _ unexpectedBetweenArgumentsAndRightParen: RawUnexpectedNodesSyntax? = nil,
+    rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
+    arena: __shared RawSyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .keyPathMethodComponent, uninitializedCount: 9, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeDeclName?.raw
+      layout[1] = declName.raw
+      layout[2] = unexpectedBetweenDeclNameAndLeftParen?.raw
+      layout[3] = leftParen.raw
+      layout[4] = unexpectedBetweenLeftParenAndArguments?.raw
+      layout[5] = arguments.raw
+      layout[6] = unexpectedBetweenArgumentsAndRightParen?.raw
+      layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
+    }
+    self.init(unchecked: raw)
+  }
+
+  public var unexpectedBeforeDeclName: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var declName: RawDeclReferenceExprSyntax {
+    layoutView.children[1].map(RawDeclReferenceExprSyntax.init(raw:))!
+  }
+
+  public var unexpectedBetweenDeclNameAndLeftParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var leftParen: RawTokenSyntax {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+
+  public var unexpectedBetweenLeftParenAndArguments: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var arguments: RawLabeledExprListSyntax {
+    layoutView.children[5].map(RawLabeledExprListSyntax.init(raw:))!
+  }
+
+  public var unexpectedBetweenArgumentsAndRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var rightParen: RawTokenSyntax {
+    layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1822,6 +1822,18 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 5, verify(layout[5], as: RawKeyPathComponentListSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   }
+  func validateKeyPathMethodComponentSyntax(kind: SyntaxKind, layout: RawSyntaxBuffer) {
+    assert(layout.count == 9)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawDeclReferenceExprSyntax.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.leftParen)]))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawLabeledExprListSyntax.self))
+    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.rightParen)]))
+    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
+  }
   func validateKeyPathOptionalComponentSyntax(kind: SyntaxKind, layout: RawSyntaxBuffer) {
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -3462,6 +3474,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     validateKeyPathComponentSyntax(kind: kind, layout: layout)
   case .keyPathExpr:
     validateKeyPathExprSyntax(kind: kind, layout: layout)
+  case .keyPathMethodComponent:
+    validateKeyPathMethodComponentSyntax(kind: kind, layout: layout)
   case .keyPathOptionalComponent:
     validateKeyPathOptionalComponentSyntax(kind: kind, layout: layout)
   case .keyPathPropertyComponent:

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -982,6 +982,37 @@ extension InitializerDeclSyntax {
   }
 }
 
+extension KeyPathMethodComponentSyntax {
+  /// A convenience initializer that allows initializing syntax collections using result builders
+  public init(
+    leadingTrivia: Trivia? = nil,
+    unexpectedBeforeDeclName: UnexpectedNodesSyntax? = nil,
+    declName: DeclReferenceExprSyntax,
+    unexpectedBetweenDeclNameAndLeftParen: UnexpectedNodesSyntax? = nil,
+    leftParen: TokenSyntax = .leftParenToken(),
+    unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil,
+    unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil,
+    rightParen: TokenSyntax = .rightParenToken(),
+    unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    @LabeledExprListBuilder argumentsBuilder: () throws -> LabeledExprListSyntax,
+    trailingTrivia: Trivia? = nil
+  ) rethrows {
+    try self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeDeclName,
+      declName: declName,
+      unexpectedBetweenDeclNameAndLeftParen,
+      leftParen: leftParen,
+      unexpectedBetweenLeftParenAndArguments,
+      arguments: argumentsBuilder(),
+      unexpectedBetweenArgumentsAndRightParen,
+      rightParen: rightParen,
+      unexpectedAfterRightParen,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 extension KeyPathSubscriptComponentSyntax {
   /// A convenience initializer that allows initializing syntax collections using result builders
   public init(

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 @_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
@@ -253,6 +254,364 @@ final class ExpressionTests: ParserTestCase {
       _ = distinctUntilChanged(\ .?.status)
       _ = distinctUntilChanged(\.?.status)
       """#
+    )
+  }
+
+  func testKeyPathMethodAndInitializers() {
+    assertParse(
+      #"\Foo.method()"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax("Foo"),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: KeyPathComponentSyntax.Component(
+              KeyPathMethodComponentSyntax(
+                declName: DeclReferenceExprSyntax(baseName: .identifier("method")),
+                leftParen: .leftParenToken(),
+                arguments: LabeledExprListSyntax([]),
+                rightParen: .rightParenToken()
+              )
+            )
+          )
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.method(10)"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax("Foo"),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: .init(
+              KeyPathMethodComponentSyntax(
+                declName: DeclReferenceExprSyntax(baseName: .identifier("method")),
+                leftParen: .leftParenToken(),
+                arguments: LabeledExprListSyntax([
+                  LabeledExprSyntax(
+                    label: nil,
+                    colon: nil,
+                    expression: ExprSyntax("10")
+                  )
+                ]),
+                rightParen: .rightParenToken()
+              )
+            )
+          )
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.method(arg: 10)"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax("Foo"),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: .init(
+              KeyPathMethodComponentSyntax(
+                declName: DeclReferenceExprSyntax(baseName: .identifier("method")),
+                leftParen: .leftParenToken(),
+                arguments: LabeledExprListSyntax([
+                  LabeledExprSyntax(
+                    label: .identifier("arg"),
+                    colon: .colonToken(),
+                    expression: ExprSyntax("10")
+                  )
+                ]),
+                rightParen: .rightParenToken()
+              )
+            )
+          )
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.method(_:)"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax("Foo"),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: .init(
+              KeyPathPropertyComponentSyntax(
+                declName: DeclReferenceExprSyntax(
+                  baseName: .identifier("method"),
+                  argumentNames: DeclNameArgumentsSyntax(
+                    leftParen: .leftParenToken(),
+                    arguments: [
+                      DeclNameArgumentSyntax(name: .wildcardToken(), colon: .colonToken())
+                    ],
+                    rightParen: .rightParenToken()
+                  )
+                )
+              )
+            )
+          )
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.method(arg:)"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax("Foo"),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: .init(
+              KeyPathPropertyComponentSyntax(
+                declName: DeclReferenceExprSyntax(
+                  baseName: .identifier("method"),
+                  argumentNames: DeclNameArgumentsSyntax(
+                    leftParen: .leftParenToken(),
+                    arguments: [
+                      DeclNameArgumentSyntax(name: .identifier("arg"), colon: .colonToken())
+                    ],
+                    rightParen: .rightParenToken()
+                  )
+                )
+              )
+            )
+          )
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.method().anotherMethod(arg: 10)"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax("Foo"),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: .init(
+              KeyPathMethodComponentSyntax(
+                declName: DeclReferenceExprSyntax(baseName: .identifier("method")),
+                leftParen: .leftParenToken(),
+                arguments: LabeledExprListSyntax([]),
+                rightParen: .rightParenToken()
+              )
+            )
+          ),
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: .init(
+              KeyPathMethodComponentSyntax(
+                declName: DeclReferenceExprSyntax(baseName: .identifier("anotherMethod")),
+                leftParen: .leftParenToken(),
+                arguments: LabeledExprListSyntax([
+                  LabeledExprSyntax(
+                    label: .identifier("arg"),
+                    colon: .colonToken(),
+                    expression: ExprSyntax("10")
+                  )
+                ]),
+                rightParen: .rightParenToken()
+              )
+            )
+          ),
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.Type.init()"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax(
+          MetatypeTypeSyntax(baseType: TypeSyntax("Foo"), metatypeSpecifier: .keyword(.Type))
+        ),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: KeyPathComponentSyntax.Component(
+              KeyPathMethodComponentSyntax(
+                declName: DeclReferenceExprSyntax(baseName: .keyword(.init("init")!)),
+                leftParen: .leftParenToken(),
+                arguments: LabeledExprListSyntax([]),
+                rightParen: .rightParenToken()
+              )
+            )
+          )
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.t(a:)(2)"#,
+      substructure: KeyPathExprSyntax(
+        root: TypeSyntax("Foo"),
+        components: KeyPathComponentListSyntax([
+          KeyPathComponentSyntax(
+            period: .periodToken(),
+            component: .init(
+              KeyPathMethodComponentSyntax(
+                declName: DeclReferenceExprSyntax(
+                  baseName: .identifier("t"),
+                  argumentNames: DeclNameArgumentsSyntax(
+                    leftParen: .leftParenToken(),
+                    arguments: [
+                      DeclNameArgumentSyntax(name: .identifier("a"), colon: .colonToken())
+                    ],
+                    rightParen: .rightParenToken()
+                  )
+                ),
+                leftParen: .leftParenToken(),
+                arguments: LabeledExprListSyntax([
+                  LabeledExprSyntax(
+                    label: nil,
+                    colon: nil,
+                    expression: ExprSyntax("2")
+                  )
+                ]),
+                rightParen: .rightParenToken()
+              )
+            )
+          )
+        ])
+      ),
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      \Foo.method(1️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected value and ')' to end key path method component",
+          fixIts: ["insert value and ')'"]
+        )
+      ],
+      fixedSource: #"\Foo.method(<#expression#>)"#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.1️⃣()"#,
+      diagnostics: [
+        DiagnosticSpec(message: "expected identifier in key path method component", fixIts: ["insert identifier"])
+      ],
+      fixedSource: #"\Foo.<#identifier#>()"#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.method1️⃣<Int>()"#,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "unexpected code '<Int>' in key path method component"
+        )
+      ],
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"\Foo.method1️⃣<Int>(arg:2️⃣)"#,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "unexpected code '<Int>' in key path method component"
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected value in key path method component",
+          fixIts: ["insert value"]
+        ),
+      ],
+      fixedSource: #"\Foo.method<Int>(arg: <#expression#>)"#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      S()[keyPath: \.i] = 1
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      public let keyPath2FromLibB = \AStruct.Type.property
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      public let keyPath9FromLibB = \AStruct.Type.init(val: 2025)
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      _ = ([S]()).map(\.i)
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      let some = Some(keyPath: \Demo.here)
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      _ = ([S.Type]()).map(\.init)
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      \Lens<Lens<Point>>.obj.x
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      _ = \Lens<Point>.y
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      _ = f(\String?.!.count)
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      let _ = \K.Type.init(val: 2025)
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
+    )
+
+    assertParse(
+      #"""
+      let _ = \K.Type.init
+      let _ = \K.Type.init()
+      """#,
+      experimentalFeatures: .keypathWithMethodMembers
     )
   }
 


### PR DESCRIPTION
This accompanies the [swift-foundation](https://github.com/swiftlang/swift-foundation/pull/1179) and [compiler implementation](https://github.com/swiftlang/swift/pull/78823) for [Method and Initializer Keypaths](https://github.com/swiftlang/swift-evolution/pull/2675) which extends keypath usage to include references to methods and initializers:

```
struct S {
  static let millenium = 3
  var year = 2024
  init() {}
  init(val value: Int = 2024) { year = value }
  
  func add(this: Int) -> Int { this + this}
  func add(that: Int) -> Int { that + that }
  static func subtract(_ val: Int) -> Int { return millenium - val }
  nonisolated func nonisolatedNextYear() -> Int { return year + 1 }
  consuming func consume() { print(year) }

  subscript(index: Int) -> Int { return year + index }
}

let kp1: KeyPath<S, () -> S> = \S.Type.init
let kp2: KeyPath<S, S> = \S.Type.init()
let kp3: KeyPath<S, (Int) -> S> = \S.Type.init(val:)
let kp4: KeyPath<S, S> = \S.Type.init(val: 2025)
let kp5: KeyPath<S, (Int) -> Int> = \S.add(this:)
let kp6: KeyPath<S, Int> = \S.add(that: 1)
let kp7: KeyPath<S, Int> = \S.Type.subtract(1)
let kp8: KeyPath<S, Int> = \S.nonisolatedNextYear()
let kp9: KeyPath<S, Int> = \S.nonisolatedNextYear().signum()
let kp10: KeyPath<S, String> = \S.nonisolatedNextYear().description
let kp11: KeyPath<S, ()> = \S.consume()
let kp12: KeyPath<S, Int> = \S.Type.init()[1]
```