### PR TITLE
Fix parsing `package` in @_documentation(visibility: package)

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -1170,6 +1170,7 @@ extension Parser {
           case `private`
           case `fileprivate`
           case `internal`
+          case `package`
           case `public`
           case `open`
 
@@ -1178,6 +1179,7 @@ extension Parser {
             case .private: return .keyword(.private)
             case .fileprivate: return .keyword(.fileprivate)
             case .internal: return .keyword(.internal)
+            case .package: return .keyword(.package)
             case .public: return .keyword(.public)
             case .open: return .keyword(.open)
             }
@@ -1188,6 +1190,7 @@ extension Parser {
             case TokenSpec(.private): self = .private
             case TokenSpec(.fileprivate): self = .fileprivate
             case TokenSpec(.internal): self = .internal
+            case TokenSpec(.package): self = .package
             case TokenSpec(.public): self = .public
             case TokenSpec(.open): self = .open
             default: return nil

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -671,6 +671,7 @@ final class AttributeTests: ParserTestCase {
 
   func testDocumentationAttribute() {
     assertParse("@_documentation(visibility: internal) @_exported import A")
+    assertParse("@_documentation(visibility: package) @objc final public class Klass {}")
     assertParse("@_documentation(metadata: cool_stuff) public class SomeClass {}")
     assertParse(#"@_documentation(metadata: "this is a longer string") public class OtherClass {}"#)
     assertParse(


### PR DESCRIPTION
Parsing attribute in `@_documentation(visibility: package) public class A` fails due to `package` not being recognized. This PR adds support for the access level in the argument to be parsed.  

rdar://143869986