### PR TITLE
Drop '#if compiler(>=5.8)' guards

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -38,17 +38,12 @@ public struct KeywordSpec: IdentifierConvertible {
   ///
   /// This is typically used to mark APIs as SPI when the keyword is part of an experimental language feature.
   public var apiAttributes: AttributeListSyntax {
-    let attrList = AttributeListSyntax {
+    AttributeListSyntax {
       if isExperimental {
-        let experimentalSPI: AttributeListSyntax = """
-          #if compiler(>=5.8)
-          @_spi(ExperimentalLanguageFeatures)
-          #endif
-          """
-        experimentalSPI.with(\.trailingTrivia, .newline)
+        AttributeSyntax("@_spi(ExperimentalLanguageFeatures)")
+          .with(\.trailingTrivia, .newline)
       }
     }
-    return attrList.with(\.trailingTrivia, attrList.isEmpty ? [] : .newline)
   }
 
   /// Initializes a new `KeywordSpec` instance.

--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -96,29 +96,20 @@ public class Node: NodeChoiceConvertible {
   /// Retrieve the attributes that should be printed on any API for the
   /// generated node. If `forRaw` is true, this is for the raw syntax node.
   public func apiAttributes(forRaw: Bool = false) -> AttributeListSyntax {
-    let attrList = AttributeListSyntax {
+    AttributeListSyntax {
       if isExperimental {
-        // SPI for enum cases currently requires Swift 5.8 to work correctly.
-        let experimentalSPI: AttributeListSyntax = """
-          #if compiler(>=5.8)
-          @_spi(ExperimentalLanguageFeatures)
-          #endif
-          """
-        experimentalSPI.with(\.trailingTrivia, .newline)
+        AttributeSyntax("@_spi(ExperimentalLanguageFeatures)")
+          .with(\.trailingTrivia, .newline)
       }
       if let spi = self.spi {
-        let spiAttr: AttributeListSyntax = """
-          #if compiler(>=5.8)
-          @_spi(\(spi))
-          #endif
-          """
-        spiAttr.with(\.trailingTrivia, .newline)
+        AttributeSyntax("@_spi(\(spi))")
+          .with(\.trailingTrivia, .newline)
       }
       if forRaw {
-        "@_spi(RawSyntax)"
+        AttributeSyntax("@_spi(RawSyntax)")
+          .with(\.trailingTrivia, .newline)
       }
     }
-    return attrList.with(\.trailingTrivia, attrList.isEmpty ? [] : .newline)
   }
 
   public var apiAttributes: AttributeListSyntax {

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -32,14 +32,10 @@ extension AccessorDeclSyntax {
     case mutableAddressWithOwner
     case mutableAddressWithNativeOwner
     case _read
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case read
     case _modify
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case modify
     case `init`
 
@@ -3085,14 +3081,10 @@ extension OptionalBindingConditionSyntax {
     case `let`
     case `var`
     case `inout`
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _mutating
     case _borrowing
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _consuming
 
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -4049,14 +4041,10 @@ extension ValueBindingPatternSyntax {
     case `let`
     case `var`
     case `inout`
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _mutating
     case _borrowing
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _consuming
     case borrowing
 
@@ -4152,14 +4140,10 @@ extension VariableDeclSyntax {
     case `let`
     case `var`
     case `inout`
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _mutating
     case _borrowing
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _consuming
 
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -26,9 +26,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case _Class
   case _compilerInitialized
   case _const
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case _consuming
   case _documentation
   case _dynamicReplacement
@@ -40,9 +38,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case _local
   case _modify
   case _move
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case _mutating
   case _NativeClass
   case _NativeRefCountedObject
@@ -71,9 +67,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case _underlyingVersion
   case _UnknownLayout
   case _version
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case abi
   case accesses
   case actor
@@ -112,9 +106,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case `default`
   case `defer`
   case `deinit`
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case dependsOn
   case deprecated
   case derivative
@@ -166,9 +158,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case macro
   case message
   case metadata
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case modify
   case module
   case mutableAddressWithNativeOwner
@@ -197,9 +187,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case `Protocol`
   case `protocol`
   case `public`
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case read
   case reasync
   case renamed
@@ -211,9 +199,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case reverse
   case right
   case safe
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case scoped
   case `self`
   case sending

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -56,16 +56,12 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visit(_ node: ABIAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visitPost(_ node: ABIAttributeArgumentsSyntax) {
     visitAnyPost(node._syntaxNode)
   }
@@ -238,16 +234,12 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(Compiler)
-  #endif
   override open func visit(_ node: AvailabilityMacroDefinitionSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(Compiler)
-  #endif
   override open func visitPost(_ node: AvailabilityMacroDefinitionSyntax) {
     visitAnyPost(node._syntaxNode)
   }
@@ -756,16 +748,12 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visit(_ node: DoExprSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visitPost(_ node: DoExprSyntax) {
     visitAnyPost(node._syntaxNode)
   }
@@ -1370,44 +1358,32 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visit(_ node: LifetimeSpecifierArgumentListSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visitPost(_ node: LifetimeSpecifierArgumentListSyntax) {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visit(_ node: LifetimeSpecifierArgumentSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visitPost(_ node: LifetimeSpecifierArgumentSyntax) {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visit(_ node: LifetimeTypeSpecifierSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visitPost(_ node: LifetimeTypeSpecifierSyntax) {
     visitAnyPost(node._syntaxNode)
   }
@@ -2092,16 +2068,12 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visit(_ node: ThenStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visitPost(_ node: ThenStmtSyntax) {
     visitAnyPost(node._syntaxNode)
   }
@@ -2282,16 +2254,12 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visit(_ node: UnsafeExprSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   override open func visitPost(_ node: UnsafeExprSyntax) {
     visitAnyPost(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -1048,9 +1048,7 @@ public struct LabeledExprListSyntax: SyntaxCollection, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - `LifetimeTypeSpecifierSyntax`.`LifetimeTypeSpecifierSyntax/arguments`
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 public struct LifetimeSpecifierArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = LifetimeSpecifierArgumentSyntax
 
@@ -1925,9 +1923,7 @@ public struct TypeSpecifierListSyntax: SyntaxCollection, SyntaxHashable {
     case simpleTypeSpecifier(SimpleTypeSpecifierSyntax)
     /// A specifier that specifies function parameter on whose lifetime a type depends
     /// - Note: Requires experimental feature `nonescapableTypes`.
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case lifetimeTypeSpecifier(LifetimeTypeSpecifierSyntax)
 
     public var _syntaxNode: Syntax {
@@ -1944,9 +1940,7 @@ public struct TypeSpecifierListSyntax: SyntaxCollection, SyntaxHashable {
     }
 
     /// - Note: Requires experimental feature `nonescapableTypes`.
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     public init(_ node: LifetimeTypeSpecifierSyntax) {
       self = .lifetimeTypeSpecifier(node)
     }
@@ -1991,9 +1985,7 @@ public struct TypeSpecifierListSyntax: SyntaxCollection, SyntaxHashable {
     ///
     /// - Returns: `true` if the node can be cast, `false` otherwise.
     /// - Note: Requires experimental feature `nonescapableTypes`.
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     public func `is`(_ syntaxType: LifetimeTypeSpecifierSyntax.Type) -> Bool {
       return self.as(syntaxType) != nil
     }
@@ -2002,9 +1994,7 @@ public struct TypeSpecifierListSyntax: SyntaxCollection, SyntaxHashable {
     ///
     /// - Returns: An instance of `LifetimeTypeSpecifierSyntax`, or `nil` if the cast fails.
     /// - Note: Requires experimental feature `nonescapableTypes`.
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     public func `as`(_ syntaxType: LifetimeTypeSpecifierSyntax.Type) -> LifetimeTypeSpecifierSyntax? {
       return LifetimeTypeSpecifierSyntax.init(self)
     }
@@ -2014,9 +2004,7 @@ public struct TypeSpecifierListSyntax: SyntaxCollection, SyntaxHashable {
     /// - Returns: An instance of `LifetimeTypeSpecifierSyntax`.
     /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
     /// - Note: Requires experimental feature `nonescapableTypes`.
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     public func cast(_ syntaxType: LifetimeTypeSpecifierSyntax.Type) -> LifetimeTypeSpecifierSyntax {
       return self.as(LifetimeTypeSpecifierSyntax.self)!
     }

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -15,9 +15,7 @@
 /// Enum to exhaustively switch over all different syntax nodes.
 public enum SyntaxEnum: Sendable {
   case token(TokenSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case abiAttributeArguments(ABIAttributeArgumentsSyntax)
   case accessorBlock(AccessorBlockSyntax)
   case accessorDeclList(AccessorDeclListSyntax)
@@ -40,9 +38,7 @@ public enum SyntaxEnum: Sendable {
   case availabilityArgument(AvailabilityArgumentSyntax)
   case availabilityCondition(AvailabilityConditionSyntax)
   case availabilityLabeledArgument(AvailabilityLabeledArgumentSyntax)
-  #if compiler(>=5.8)
   @_spi(Compiler)
-  #endif
   case availabilityMacroDefinition(AvailabilityMacroDefinitionSyntax)
   case awaitExpr(AwaitExprSyntax)
   case backDeployedAttributeArguments(BackDeployedAttributeArgumentsSyntax)
@@ -107,9 +103,7 @@ public enum SyntaxEnum: Sendable {
   case differentiableAttributeArguments(DifferentiableAttributeArgumentsSyntax)
   case discardAssignmentExpr(DiscardAssignmentExprSyntax)
   case discardStmt(DiscardStmtSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case doExpr(DoExprSyntax)
   case doStmt(DoStmtSyntax)
   case documentationAttributeArgumentList(DocumentationAttributeArgumentListSyntax)
@@ -186,17 +180,11 @@ public enum SyntaxEnum: Sendable {
   case labeledSpecializeArgument(LabeledSpecializeArgumentSyntax)
   case labeledStmt(LabeledStmtSyntax)
   case layoutRequirement(LayoutRequirementSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case lifetimeSpecifierArgumentList(LifetimeSpecifierArgumentListSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case lifetimeSpecifierArgument(LifetimeSpecifierArgumentSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case lifetimeTypeSpecifier(LifetimeTypeSpecifierSyntax)
   case macroDecl(MacroDeclSyntax)
   case macroExpansionDecl(MacroExpansionDeclSyntax)
@@ -283,9 +271,7 @@ public enum SyntaxEnum: Sendable {
   case switchDefaultLabel(SwitchDefaultLabelSyntax)
   case switchExpr(SwitchExprSyntax)
   case ternaryExpr(TernaryExprSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case thenStmt(ThenStmtSyntax)
   case throwStmt(ThrowStmtSyntax)
   case throwsClause(ThrowsClauseSyntax)
@@ -309,9 +295,7 @@ public enum SyntaxEnum: Sendable {
   case unresolvedAsExpr(UnresolvedAsExprSyntax)
   case unresolvedIsExpr(UnresolvedIsExprSyntax)
   case unresolvedTernaryExpr(UnresolvedTernaryExprSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case unsafeExpr(UnsafeExprSyntax)
   case valueBindingPattern(ValueBindingPatternSyntax)
   case variableDecl(VariableDeclSyntax)
@@ -1013,9 +997,7 @@ public enum ExprSyntaxEnum {
   case declReferenceExpr(DeclReferenceExprSyntax)
   case dictionaryExpr(DictionaryExprSyntax)
   case discardAssignmentExpr(DiscardAssignmentExprSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case doExpr(DoExprSyntax)
   case editorPlaceholderExpr(EditorPlaceholderExprSyntax)
   case floatLiteralExpr(FloatLiteralExprSyntax)
@@ -1053,9 +1035,7 @@ public enum ExprSyntaxEnum {
   case unresolvedAsExpr(UnresolvedAsExprSyntax)
   case unresolvedIsExpr(UnresolvedIsExprSyntax)
   case unresolvedTernaryExpr(UnresolvedTernaryExprSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case unsafeExpr(UnsafeExprSyntax)
 }
 
@@ -1227,9 +1207,7 @@ public enum StmtSyntaxEnum {
   case missingStmt(MissingStmtSyntax)
   case repeatStmt(RepeatStmtSyntax)
   case returnStmt(ReturnStmtSyntax)
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case thenStmt(ThenStmtSyntax)
   case throwStmt(ThrowStmtSyntax)
   case whileStmt(WhileStmtSyntax)

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -15,9 +15,7 @@
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
 public enum SyntaxKind: Sendable {
   case token
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case abiAttributeArguments
   case accessorBlock
   case accessorDeclList
@@ -40,9 +38,7 @@ public enum SyntaxKind: Sendable {
   case availabilityArgument
   case availabilityCondition
   case availabilityLabeledArgument
-  #if compiler(>=5.8)
   @_spi(Compiler)
-  #endif
   case availabilityMacroDefinition
   case awaitExpr
   case backDeployedAttributeArguments
@@ -107,9 +103,7 @@ public enum SyntaxKind: Sendable {
   case differentiableAttributeArguments
   case discardAssignmentExpr
   case discardStmt
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case doExpr
   case doStmt
   case documentationAttributeArgumentList
@@ -186,17 +180,11 @@ public enum SyntaxKind: Sendable {
   case labeledSpecializeArgument
   case labeledStmt
   case layoutRequirement
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case lifetimeSpecifierArgumentList
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case lifetimeSpecifierArgument
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case lifetimeTypeSpecifier
   case macroDecl
   case macroExpansionDecl
@@ -283,9 +271,7 @@ public enum SyntaxKind: Sendable {
   case switchDefaultLabel
   case switchExpr
   case ternaryExpr
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case thenStmt
   case throwStmt
   case throwsClause
@@ -309,9 +295,7 @@ public enum SyntaxKind: Sendable {
   case unresolvedAsExpr
   case unresolvedIsExpr
   case unresolvedTernaryExpr
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   case unsafeExpr
   case valueBindingPattern
   case variableDecl

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -101,9 +101,7 @@ open class SyntaxRewriter {
   /// Visit a `ABIAttributeArgumentsSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: ABIAttributeArgumentsSyntax) -> ABIAttributeArgumentsSyntax {
     return ABIAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
@@ -258,9 +256,7 @@ open class SyntaxRewriter {
   /// Visit a ``AvailabilityMacroDefinitionSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(Compiler)
-  #endif
   open func visit(_ node: AvailabilityMacroDefinitionSyntax) -> AvailabilityMacroDefinitionSyntax {
     return AvailabilityMacroDefinitionSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
@@ -709,9 +705,7 @@ open class SyntaxRewriter {
   /// Visit a `DoExprSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: DoExprSyntax) -> ExprSyntax {
     return ExprSyntax(DoExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
@@ -1244,9 +1238,7 @@ open class SyntaxRewriter {
   /// Visit a `LifetimeSpecifierArgumentListSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: LifetimeSpecifierArgumentListSyntax) -> LifetimeSpecifierArgumentListSyntax {
     return LifetimeSpecifierArgumentListSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
@@ -1254,9 +1246,7 @@ open class SyntaxRewriter {
   /// Visit a `LifetimeSpecifierArgumentSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: LifetimeSpecifierArgumentSyntax) -> LifetimeSpecifierArgumentSyntax {
     return LifetimeSpecifierArgumentSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
@@ -1264,9 +1254,7 @@ open class SyntaxRewriter {
   /// Visit a `LifetimeTypeSpecifierSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: LifetimeTypeSpecifierSyntax) -> LifetimeTypeSpecifierSyntax {
     return LifetimeTypeSpecifierSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }
@@ -1869,9 +1857,7 @@ open class SyntaxRewriter {
   /// Visit a `ThenStmtSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: ThenStmtSyntax) -> StmtSyntax {
     return StmtSyntax(ThenStmtSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
@@ -2033,9 +2019,7 @@ open class SyntaxRewriter {
   /// Visit a `UnsafeExprSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: UnsafeExprSyntax) -> ExprSyntax {
     return ExprSyntax(UnsafeExprSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -37,18 +37,14 @@ open class SyntaxVisitor {
   /// Visiting `ABIAttributeArgumentsSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: ABIAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting `ABIAttributeArgumentsSyntax` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visitPost(_ node: ABIAttributeArgumentsSyntax) {
   }
 
@@ -307,18 +303,14 @@ open class SyntaxVisitor {
   /// Visiting ``AvailabilityMacroDefinitionSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(Compiler)
-  #endif
   open func visit(_ node: AvailabilityMacroDefinitionSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting ``AvailabilityMacroDefinitionSyntax`` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(Compiler)
-  #endif
   open func visitPost(_ node: AvailabilityMacroDefinitionSyntax) {
   }
 
@@ -1081,18 +1073,14 @@ open class SyntaxVisitor {
   /// Visiting `DoExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: DoExprSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting `DoExprSyntax` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visitPost(_ node: DoExprSyntax) {
   }
 
@@ -1999,54 +1987,42 @@ open class SyntaxVisitor {
   /// Visiting `LifetimeSpecifierArgumentListSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: LifetimeSpecifierArgumentListSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting `LifetimeSpecifierArgumentListSyntax` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visitPost(_ node: LifetimeSpecifierArgumentListSyntax) {
   }
 
   /// Visiting `LifetimeSpecifierArgumentSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: LifetimeSpecifierArgumentSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting `LifetimeSpecifierArgumentSyntax` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visitPost(_ node: LifetimeSpecifierArgumentSyntax) {
   }
 
   /// Visiting `LifetimeTypeSpecifierSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: LifetimeTypeSpecifierSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting `LifetimeTypeSpecifierSyntax` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visitPost(_ node: LifetimeTypeSpecifierSyntax) {
   }
 
@@ -3073,18 +3049,14 @@ open class SyntaxVisitor {
   /// Visiting `ThenStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: ThenStmtSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting `ThenStmtSyntax` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visitPost(_ node: ThenStmtSyntax) {
   }
 
@@ -3355,18 +3327,14 @@ open class SyntaxVisitor {
   /// Visiting `UnsafeExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visit(_ node: UnsafeExprSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
   /// The function called after visiting `UnsafeExprSyntax` and its descendants.
   ///   - node: the node we just finished visiting.
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   open func visitPost(_ node: UnsafeExprSyntax) {
   }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
@@ -12,9 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @_spi(RawSyntax)
 public struct RawABIAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public enum Provider: RawSyntaxNodeProtocol {
@@ -2098,9 +2096,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
   }
 }
 
-#if compiler(>=5.8)
 @_spi(Compiler)
-#endif
 @_spi(RawSyntax)
 public struct RawAvailabilityMacroDefinitionSyntax: RawSyntaxNodeProtocol {
   @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
@@ -1921,9 +1921,7 @@ public struct RawDiscardStmtSyntax: RawStmtSyntaxNodeProtocol {
   }
 }
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @_spi(RawSyntax)
 public struct RawDoExprSyntax: RawExprSyntaxNodeProtocol {
   @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
@@ -919,9 +919,7 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
   }
 }
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @_spi(RawSyntax)
 public struct RawLifetimeSpecifierArgumentListSyntax: RawSyntaxNodeProtocol {
   @_spi(RawSyntax)
@@ -972,9 +970,7 @@ public struct RawLifetimeSpecifierArgumentListSyntax: RawSyntaxNodeProtocol {
   }
 }
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @_spi(RawSyntax)
 public struct RawLifetimeSpecifierArgumentSyntax: RawSyntaxNodeProtocol {
   @_spi(RawSyntax)
@@ -1045,9 +1041,7 @@ public struct RawLifetimeSpecifierArgumentSyntax: RawSyntaxNodeProtocol {
   }
 }
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @_spi(RawSyntax)
 public struct RawLifetimeTypeSpecifierSyntax: RawSyntaxNodeProtocol {
   @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
@@ -121,9 +121,7 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
   }
 }
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @_spi(RawSyntax)
 public struct RawThenStmtSyntax: RawStmtSyntaxNodeProtocol {
   @_spi(RawSyntax)
@@ -1415,9 +1413,7 @@ public struct RawTypeSpecifierListSyntax: RawSyntaxNodeProtocol {
     case simpleTypeSpecifier(RawSimpleTypeSpecifierSyntax)
     /// A specifier that specifies function parameter on whose lifetime a type depends
     /// - Note: Requires experimental feature `nonescapableTypes`.
-    #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
-    #endif
     case lifetimeTypeSpecifier(RawLifetimeTypeSpecifierSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
@@ -1955,9 +1951,7 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
   }
 }
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @_spi(RawSyntax)
 public struct RawUnsafeExprSyntax: RawExprSyntaxNodeProtocol {
   @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -25,9 +25,7 @@
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 public struct ABIAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Provider: SyntaxChildChoices, SyntaxHashable {
     case associatedType(AssociatedTypeDeclSyntax)
@@ -4573,9 +4571,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable,
 ///  - `platformVersion`: ``PlatformVersionSyntax``
 ///  - `colon`: `:`
 ///  - `specs`: ``AvailabilityArgumentListSyntax``
-#if compiler(>=5.8)
 @_spi(Compiler)
-#endif
 public struct AvailabilityMacroDefinitionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -3270,9 +3270,7 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
 ///  - `doKeyword`: `do`
 ///  - `body`: ``CodeBlockSyntax``
 ///  - `catchClauses`: ``CatchClauseListSyntax``
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 public struct DoExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -1674,9 +1674,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 /// ### Contained in
 /// 
 ///  - `LifetimeSpecifierArgumentListSyntax`
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -1817,9 +1815,7 @@ public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
 /// ### Contained in
 /// 
 ///  - ``TypeSpecifierListSyntax``
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 public struct LifetimeTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -240,9 +240,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 /// 
 ///  - `thenKeyword`: `then`
 ///  - `expression`: ``ExprSyntax``
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -3280,9 +3278,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
 /// 
 ///  - `unsafeKeyword`: `unsafe`
 ///  - `expression`: ``ExprSyntax``
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 public struct UnsafeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -431,9 +431,7 @@ extension LabeledExprListSyntax {
 
 // MARK: - LifetimeSpecifierArgumentListBuilder
 
-#if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
-#endif
 @resultBuilder
 public struct LifetimeSpecifierArgumentListBuilder: ListBuilder {
   public typealias FinalResult = LifetimeSpecifierArgumentListSyntax
@@ -694,9 +692,7 @@ public struct TypeSpecifierListBuilder: ListBuilder {
     buildExpression(.init(expression))
   }
 
-  #if compiler(>=5.8)
   @_spi(ExperimentalLanguageFeatures)
-  #endif
   public static func buildExpression(_ expression: LifetimeTypeSpecifierSyntax) -> Component {
     buildExpression(.init(expression))
   }


### PR DESCRIPTION
swift-syntax does not support pre-5.8 compilers anymore. `#if compiler(>=5.8)` guards are meaningless.