### PR TITLE
[SwiftParser] Use raw.arena instead of parser.arena to construct Syntax

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
@@ -41,7 +41,7 @@ let layoutNodesParsableFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             defer { withExtendedLifetime(parser) {} }
             let node = parser.\(parserFunction)()
             let raw = RawSyntax(parser.parseRemainder(into: node))
-            return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+            return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
           }
         }
         """

--- a/Sources/SwiftParser/CollectionNodes+Parsable.swift
+++ b/Sources/SwiftParser/CollectionNodes+Parsable.swift
@@ -35,7 +35,7 @@ fileprivate extension SyntaxCollection {
     let node = parse(&parser)
 
     if parser.at(.endOfFile) {
-      return Syntax(raw: node.raw, rawNodeArena: parser.arena).cast(Self.self)
+      return Syntax(raw: node.raw, rawNodeArena: node.raw.arena).cast(Self.self)
     }
 
     let layoutView = node.raw.layoutView!
@@ -45,7 +45,7 @@ fileprivate extension SyntaxCollection {
       assert(!remainingTokens.isEmpty)
       let missing = makeMissing(remainingTokens, parser.arena)
       let raw = layoutView.insertingChild(missing.raw, at: node.raw.layoutView!.children.count, arena: parser.arena)
-      return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+      return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
     } else {
       // First unwrap: We know that children.last exists because children is not empty
       // Second unwrap: This is a collection and collections never have optional children. Thus the last child can’t be nil.
@@ -55,7 +55,7 @@ fileprivate extension SyntaxCollection {
         with: lastWithRemainder,
         arena: parser.arena
       )
-      return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+      return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
     }
   }
 }

--- a/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
+++ b/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
@@ -36,7 +36,7 @@ extension AccessorBlockSyntax: SyntaxParseable {
     }
     let node = parser.parseAccessorBlock()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -54,7 +54,7 @@ extension AccessorDeclSyntax: SyntaxParseable {
     }
     let node = parser.parseAccessorDecl()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -72,7 +72,7 @@ extension AttributeSyntax: SyntaxParseable {
     }
     let node = parser.parseAttribute()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -90,7 +90,7 @@ extension AvailabilityMacroDefinitionSyntax: SyntaxParseable {
     }
     let node = parser.parseAvailabilityMacroDefinition()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -108,7 +108,7 @@ extension CatchClauseSyntax: SyntaxParseable {
     }
     let node = parser.parseCatchClause()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -126,7 +126,7 @@ extension ClosureParameterSyntax: SyntaxParseable {
     }
     let node = parser.parseClosureParameter()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -144,7 +144,7 @@ extension CodeBlockItemSyntax: SyntaxParseable {
     }
     let node = parser.parseNonOptionalCodeBlockItem()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -162,7 +162,7 @@ extension CodeBlockSyntax: SyntaxParseable {
     }
     let node = parser.parseCodeBlock()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -180,7 +180,7 @@ extension DeclSyntax: SyntaxParseable {
     }
     let node = parser.parseDeclaration()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -198,7 +198,7 @@ extension EnumCaseParameterSyntax: SyntaxParseable {
     }
     let node = parser.parseEnumCaseParameter()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -216,7 +216,7 @@ extension ExprSyntax: SyntaxParseable {
     }
     let node = parser.parseExpression()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -234,7 +234,7 @@ extension FunctionParameterSyntax: SyntaxParseable {
     }
     let node = parser.parseFunctionParameter()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -252,7 +252,7 @@ extension GenericParameterClauseSyntax: SyntaxParseable {
     }
     let node = parser.parseGenericParameters()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -270,7 +270,7 @@ extension MemberBlockSyntax: SyntaxParseable {
     }
     let node = parser.parseMemberBlock()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -288,7 +288,7 @@ extension PatternSyntax: SyntaxParseable {
     }
     let node = parser.parsePattern()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -306,7 +306,7 @@ extension SourceFileSyntax: SyntaxParseable {
     }
     let node = parser.parseSourceFile()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -324,7 +324,7 @@ extension StmtSyntax: SyntaxParseable {
     }
     let node = parser.parseStatement()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -342,7 +342,7 @@ extension SwitchCaseSyntax: SyntaxParseable {
     }
     let node = parser.parseSwitchCase()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -360,7 +360,7 @@ extension TypeSyntax: SyntaxParseable {
     }
     let node = parser.parseType()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 
@@ -378,7 +378,7 @@ extension VersionTupleSyntax: SyntaxParseable {
     }
     let node = parser.parseVersionTuple()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw, rawNodeArena: parser.arena).cast(Self.self)
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -218,6 +218,10 @@ public struct RawSyntax: Sendable {
     @_transparent unsafeAddress { pointer.pointer }
   }
 
+  public var arena: RetainedSyntaxArena {
+    arenaReference.retained
+  }
+
   internal var arenaReference: SyntaxArenaRef {
     rawData.arenaReference
   }


### PR DESCRIPTION
RawSyntax.arena is not necessarility the same instance as the parsing arena

rdar://144177851