### PR TITLE
Remove warnings-as-errors from DocC

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifyDocumentation.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifyDocumentation.swift
@@ -60,7 +60,6 @@ struct VerifyDocumentation: ParsableCommand {
         "-scheme",
         product,
         "-destination", "platform=macOS",
-        "OTHER_DOCC_FLAGS='--warnings-as-errors'",
       ]
     ).run(captureStdout: false, captureStderr: false, verbose: self.verbose)
   }


### PR DESCRIPTION
Xcode 16.2 introduced a large set of the for `missing documentation`

Example: https://github.com/swiftlang/swift-syntax/issues/2961