### PR TITLE
Make `DiagnosticSeverity` conform to `Hashable`

### DIFF
--- a/Sources/SwiftDiagnostics/Message.swift
+++ b/Sources/SwiftDiagnostics/Message.swift
@@ -26,7 +26,7 @@ public struct MessageID: Hashable, Sendable {
   }
 }
 
-public enum DiagnosticSeverity: Sendable {
+public enum DiagnosticSeverity: Sendable, Hashable {
   case error
   case warning
   case note


### PR DESCRIPTION
RFC discussion: https://forums.swift.org/t/rfc-make-diagnosticseverity-conform-to-equatable/77867

Fixes #2964
rdar://144611943