### PR TITLE
Remove experimental feature unsafeExpression

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -21,7 +21,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case coroutineAccessors
   case valueGenerics
   case abiAttribute
-  case unsafeExpression
 
   /// The name of the feature as it is written in the compiler's `Features.def` file.
   public var featureName: String {
@@ -42,8 +41,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "ValueGenerics"
     case .abiAttribute:
       return "ABIAttribute"
-    case .unsafeExpression:
-      return "WarnUnsafe"
     }
   }
 
@@ -66,8 +63,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "value generics"
     case .abiAttribute:
       return "@abi attribute"
-    case .unsafeExpression:
-      return "'unsafe' expression"
     }
   }
 

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -48,9 +48,6 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of @abi attribute.
   public static let abiAttribute = Self (rawValue: 1 << 7)
 
-  /// Whether to enable the parsing of 'unsafe' expression.
-  public static let unsafeExpression = Self (rawValue: 1 << 8)
-
   /// Creates a new value representing the experimental feature with the
   /// given name, or returns nil if the name is not recognized.
   public init?(name: String) {
@@ -71,8 +68,6 @@ extension Parser.ExperimentalFeatures {
       self = .valueGenerics
     case "ABIAttribute":
       self = .abiAttribute
-    case "WarnUnsafe":
-      self = .unsafeExpression
     default:
       return nil
     }


### PR DESCRIPTION
With SE-0458 being enabled by default, we no longer need this.