### PR TITLE
Disambiguate "unsafe" expressions better

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -445,7 +445,15 @@ extension Parser {
         )
       )
     case (.unsafe, let handle)?:
-      if self.peek().isAtStartOfLine || self.peek(isAt: .rightParen) {
+      if self.peek().isAtStartOfLine
+        // Closing paired syntax
+        || self.peek(isAt: .rightParen, .rightSquare, .rightBrace)
+        // Assignment
+        || self.peek(isAt: .equal)
+        // `unsafe.something` with no trivia
+        || (self.peek(isAt: .period) && self.peek().leadingTriviaByteLength == 0
+          && self.currentToken.trailingTriviaByteLength == 0)
+      {
         break EXPR_PREFIX
       }
 

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2206,6 +2206,58 @@ final class StatementExpressionTests: ParserTestCase {
       """,
       substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
     )
+
+    assertParse(
+      """
+      func f() {
+        1️⃣unsafe.lock()
+      }
+      """,
+      substructure: MemberAccessExprSyntax(
+        base: DeclReferenceExprSyntax(baseName: .identifier("unsafe")),
+        period: .periodToken(),
+        declName: DeclReferenceExprSyntax(baseName: .identifier("lock"))
+      ),
+      substructureAfterMarker: "1️⃣"
+    )
+
+    assertParse(
+      """
+      func f() {
+        unsafe .lock
+      }
+      """,
+      substructure: UnsafeExprSyntax(
+        expression: MemberAccessExprSyntax(name: .identifier("lock"))
+      )
+    )
+
+    assertParse(
+      """
+      func f() {
+        _ = [unsafe]
+      }
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
+    )
+
+    assertParse(
+      """
+      func f() {
+        _ = [unsafe]
+      }
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
+    )
+
+    assertParse(
+      """
+      func f() {
+        unsafe = 17
+      }
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
+    )
   }
 
   func testUnterminatedInterpolationAtEndOfMultilineStringLiteral() {


### PR DESCRIPTION
Fixes rdar://145870868 / #79704