### PR TITLE
[SE-0458] Improved disambiguation for `unsafe` expressions

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -450,6 +450,11 @@ extension Parser {
         || self.peek(isAt: .rightParen, .rightSquare, .rightBrace)
         // Assignment
         || self.peek(isAt: .equal)
+        // As an argument label or in a list context.
+        || self.peek(isAt: .colon, .comma)
+        // Start of a closure in a context where it should be interpreted as
+        // being part of a statement.
+        || (flavor == .stmtCondition && self.peek(isAt: .leftBrace))
         // `unsafe.something` with no trivia
         || (self.peek(isAt: .period) && self.peek().leadingTriviaByteLength == 0
           && self.currentToken.trailingTriviaByteLength == 0)

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2258,6 +2258,43 @@ final class StatementExpressionTests: ParserTestCase {
       """,
       substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
     )
+
+    assertParse(
+      """
+      func f() {
+        let unsafe = 17
+      }
+      """,
+      substructure: IdentifierPatternSyntax(identifier: .identifier("unsafe"))
+    )
+
+    assertParse(
+      """
+      func f() {
+        f(1️⃣unsafe, blah: unsafe, unsafe, unsafe: unsafe, unsafe)
+      }
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe")),
+      substructureAfterMarker: "1️⃣"
+    )
+
+    assertParse(
+      """
+      func f() {
+        guard let unsafe = a else { }
+      }
+      """,
+      substructure: IdentifierPatternSyntax(identifier: .identifier("unsafe"))
+    )
+
+    assertParse(
+      """
+      func f() {
+        if unsafe { }
+      }
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
+    )
   }
 
   func testUnterminatedInterpolationAtEndOfMultilineStringLiteral() {


### PR DESCRIPTION
Disambiguate `unsafe` in a few more common contexts:
* Before a comma in a list of whatever form
* Before a left brace somewhere that we cannot have a closure

Fixes a few more source compatibility regressions found in the wild, rdar://146125433.