### PR TITLE
Enable Windows tests in GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,9 +8,6 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
-    with:
-      # https://github.com/swiftlang/swift-syntax/issues/2992
-      enable_windows_checks: false
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -1594,7 +1594,7 @@ extension Lexer.Cursor {
 // MARK: Lexing a character in a string literal
 
 extension Lexer.Cursor {
-  enum CharacterLex {
+  enum CharacterLex: Equatable {
     /// A normal character as it occurs in the source file
     case success(Unicode.Scalar)
 


### PR DESCRIPTION
Fixes #2992

This exposed a bug in swift-syntax, which I’m fixing:

Normalize line ending to `\n` in `StringLiteralExprSyntax.representedLiteralValue`

This matches the specification of multi-line string literal handling:

From https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#String-Literals:
> Line breaks in a multiline string literal are normalized to use the line feed character. Even if your source file has a mix of carriage returns and line feeds, all of the line breaks in the string will be the same.

From https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170417/035923.html:

> The quoted string should normalize newlines to \n in the value of the literal, regardless of whether the source file uses \n (Unix), \r\n (Windows), or \r (classic Mac) line endings. Likewise, when the compiler strips the initial and final newline from the literal value, it will strip one of any of the \n, \r\n, or \r line-ending sequences from both ends of the literal.