### PR TITLE
Fix build warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -184,7 +184,8 @@ let package = Package(
 
     .target(
       name: "SwiftLexicalLookup",
-      dependencies: ["SwiftSyntax", "SwiftIfConfig"]
+      dependencies: ["SwiftSyntax", "SwiftIfConfig"],
+      exclude: ["CMakeLists.txt"]
     ),
 
     .testTarget(

--- a/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
+#if compiler(>=6) && RESILIENT_LIBRARIES
 @_implementationOnly private import _SwiftSyntaxCShims
+#elseif compiler(>=6) && !RESILIENT_LIBRARIES
+private import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && RESILIENT_LIBRARIES
+@_implementationOnly import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && !RESILIENT_LIBRARIES
+import _SwiftSyntaxCShims
+#endif
+
+#if compiler(>=6)
 public import SwiftSyntaxMacros
 #else
-@_implementationOnly import _SwiftSyntaxCShims
 import SwiftSyntaxMacros
 #endif
 

--- a/Sources/SwiftCompilerPluginMessageHandling/JSON/JSONDecoding.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/JSON/JSONDecoding.swift
@@ -10,10 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
+#if compiler(>=6) && RESILIENT_LIBRARIES
 @_implementationOnly private import _SwiftSyntaxCShims
-#else
+#elseif compiler(>=6) && !RESILIENT_LIBRARIES
+private import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && RESILIENT_LIBRARIES
 @_implementationOnly import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && !RESILIENT_LIBRARIES
+import _SwiftSyntaxCShims
 #endif
 
 func decodeFromJSON<T: Decodable>(json: UnsafeBufferPointer<UInt8>) throws -> T {

--- a/Sources/SwiftLibraryPluginProvider/LibraryPluginProvider.swift
+++ b/Sources/SwiftLibraryPluginProvider/LibraryPluginProvider.swift
@@ -14,6 +14,7 @@
 public import SwiftSyntaxMacros
 @_spi(PluginMessage) public import SwiftCompilerPluginMessageHandling
 private import _SwiftLibraryPluginProviderCShims
+
 // NOTE: Do not use '_SwiftSyntaxCShims' for 'dlopen' and 'LoadLibraryW' (Windows)
 // because we don't want other modules depend on 'WinSDK'.
 #if canImport(Darwin)
@@ -24,10 +25,15 @@ private import Glibc
 private import Musl
 #elseif canImport(Android)
 private import Android
-#endif
-#else
+#endif  // canImport
+
+#else  // compiler(>=6)
+
 import SwiftSyntaxMacros
 @_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
+
+#if RESILIENT_LIBRARIES
+
 @_implementationOnly import _SwiftLibraryPluginProviderCShims
 #if canImport(Darwin)
 @_implementationOnly import Darwin
@@ -35,8 +41,22 @@ import SwiftSyntaxMacros
 @_implementationOnly import Glibc
 #elseif canImport(Musl)
 @_implementationOnly import Musl
-#endif
-#endif
+#endif  // canImport
+
+#else  // RESILIENT_LIBRARIES
+
+import _SwiftLibraryPluginProviderCShims
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif  // canImport
+
+#endif  // RESILIENT_LIBRARIES
+
+#endif  // compiler(>=6)
 
 /// Singleton 'PluginProvider' that can serve shared library plugins.
 @_spi(PluginMessage)

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -83,5 +83,12 @@ add_swift_syntax_library(SwiftSyntax
   generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
 )
 
-target_link_swift_syntax_libraries(SwiftSyntax PRIVATE
-  _SwiftSyntaxCShims)
+if (SWIFTSYNTAX_EMIT_MODULE)
+  target_link_swift_syntax_libraries(SwiftSyntax PRIVATE
+    _SwiftSyntaxCShims)
+else()
+  # We can't use @_implementationOnly if we don't enable library evolution, so we need
+  # to link _SwiftSyntaxCShims publicly.
+  target_link_swift_syntax_libraries(SwiftSyntax PUBLIC
+    _SwiftSyntaxCShims)
+endif()

--- a/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
@@ -10,10 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
+#if compiler(>=6) && RESILIENT_LIBRARIES
 @_implementationOnly private import _SwiftSyntaxCShims
-#else
+#elseif compiler(>=6) && !RESILIENT_LIBRARIES
+private import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && RESILIENT_LIBRARIES
 @_implementationOnly import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && !RESILIENT_LIBRARIES
+import _SwiftSyntaxCShims
 #endif
 
 /// A syntax arena owns the memory for all syntax nodes within it.

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -10,10 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
+#if compiler(>=6) && RESILIENT_LIBRARIES
 @_implementationOnly private import _SwiftSyntaxCShims
-#else
+#elseif compiler(>=6) && !RESILIENT_LIBRARIES
+private import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && RESILIENT_LIBRARIES
 @_implementationOnly import _SwiftSyntaxCShims
+#elseif !compiler(>=6) && !RESILIENT_LIBRARIES
+import _SwiftSyntaxCShims
 #endif
 
 // `Syntax` is a user facing tree wrapping `RawSyntax` tree. A value is a pair


### PR DESCRIPTION
Mostly, ensure that we only use `@_implementationOnly` if we build with `RESILIENT_LIBRARIES`.

Also, `strerror` is marked as unsafe and deprecated on Windows. It looks like this is because `strerror` is not thread-safe. Switch to the thread-safe version `strerror_r` instead.