### PR TITLE
Add GitHub action to run tests using `swift-syntax-dev-utils`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,3 +27,41 @@ jobs:
           persist-credentials: false
       - name: Validate generated code
         run: "./swift-syntax-dev-utils verify-source-code --toolchain /usr"
+  test_using_swift_syntax_dev_utils_linux:
+    name: Run tests using swift-syntax-dev-utils (Linux)
+    runs-on: ubuntu-latest
+    container:
+      image: swift:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Test
+        run: "./swift-syntax-dev-utils test --enable-rawsyntax-validation --enable-test-fuzzing --toolchain /usr"
+  test_using_swift_syntax_dev_utils_windows:
+    name: Run tests using swift-syntax-dev-utils (Windows)
+    runs-on: windows-2022
+    steps:
+      - name: Pull Docker image
+        id: pull_docker_image
+        run: |
+          $Image = "swift:windowsservercore-ltsc2022"
+          docker pull $Image
+          echo "image=$Image" >> "$env:GITHUB_OUTPUT"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Test
+        run: |
+          mkdir $env:TEMP\test-script
+          echo @'
+          Set-PSDebug -Trace 1
+          $SwiftPath = where.exe swift
+          swift.exe run --package-path "C:\Source\SwiftSyntaxDevUtils" swift-syntax-dev-utils test --enable-rawsyntax-validation --enable-test-fuzzing --toolchain "$SwiftPath\..\.."
+          if ($LastExitCode -ne 0) {
+            exit $LastExitCode
+          }
+          '@ >> $env:TEMP\test-script\run.ps1
+          docker run -v ${{ github.workspace }}:C:\source -v $env:TEMP\test-script:C:\test-script ${{ steps.pull_docker_image.outputs.image }} powershell.exe -NoLogo -File C:\test-script\run.ps1

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     .executable(name: "CodeGenerationUsingSwiftSyntaxBuilder", targets: ["CodeGenerationUsingSwiftSyntaxBuilder"]),
   ],
   dependencies: [
-    .package(path: "../")
+    .package(name: "swift-syntax", path: "../")
   ],
   targets: [
     .executableTarget(
@@ -39,15 +39,6 @@ let package = Package(
       ],
       path: "Sources/MacroExamples/Implementation"
     ),
-    .testTarget(
-      name: "MacroExamplesImplementationTests",
-      dependencies: [
-        "MacroExamplesImplementation",
-        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-      ],
-      path: "Tests/MacroExamples/Implementation"
-    ),
     .target(
       name: "MacroExamplesInterface",
       dependencies: [
@@ -64,6 +55,25 @@ let package = Package(
     ),
   ]
 )
+
+#if !os(Windows)
+// We can't write a test target for macros on Windows because that results in duplicate definitoions of `main`: Once
+// from the macro (which is effectively an executable), and once from the test bundle.
+package.targets.append(
+  .testTarget(
+    name: "MacroExamplesImplementationTests",
+    dependencies: [
+      "MacroExamplesImplementation",
+      .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+    ],
+    path: "Tests/MacroExamples/Implementation"
+  )
+)
+#else
+// Add a dummy test target on Windows so that `swift test` invocations from `swift-syntax-dev-utils` don't fail.
+package.targets.append(.testTarget(name: "Dummy", dependencies: []))
+#endif
 
 // This is a fake target that depends on all targets in the package.
 // We need to define it manually because the `Examples-Package` target doesn't exist for `swift build`.

--- a/Examples/Tests/Dummy/Empty.swift
+++ b/Examples/Tests/Dummy/Empty.swift
@@ -1,0 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//


### PR DESCRIPTION
swift-syntax-dev-utils also runs the CodeGeneration and Examples tests. It is also a convenient place where we can enable RawSyntax validation and test fuzzing.

Running this using only the latest Swift version should be sufficient because we don't expect to find differences between versions here and expect contributors to swift-syntax to use the latests released Swift version anyway.