### PR TITLE
SE-0458: Disambiguate postfix expressions vs. unsafe expressions more generally

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -455,8 +455,13 @@ extension Parser {
         // Start of a closure in a context where it should be interpreted as
         // being part of a statement.
         || (flavor == .stmtCondition && self.peek(isAt: .leftBrace))
-        // `unsafe.something` with no trivia
-        || (self.peek(isAt: .period) && self.peek().leadingTriviaByteLength == 0
+        // Avoid treating as an "unsafe" expression when there is no trivia
+        // following the "unsafe" and the following token could either be a
+        // postfix expression or a subexpression:
+        //   - Member access vs. leading .
+        //   - Call vs. tuple expression.
+        //   - Subscript vs. array or dictionary expression
+        || (self.peek(isAt: .period, .leftParen, .leftSquare) && self.peek().leadingTriviaByteLength == 0
           && self.currentToken.trailingTriviaByteLength == 0)
       {
         break EXPR_PREFIX

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2295,6 +2295,46 @@ final class StatementExpressionTests: ParserTestCase {
       """,
       substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
     )
+
+    assertParse(
+      """
+      func f() {
+        unsafe()
+      }
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
+    )
+
+    assertParse(
+      """
+      func f() {
+        unsafe ()
+      }
+      """,
+      substructure: UnsafeExprSyntax(
+        expression: TupleExprSyntax(elements: LabeledExprListSyntax())
+      )
+    )
+
+    assertParse(
+      """
+      func f() {
+        unsafe[]
+      }
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("unsafe"))
+    )
+
+    assertParse(
+      """
+      func f() {
+        unsafe []
+      }
+      """,
+      substructure: UnsafeExprSyntax(
+        expression: ArrayExprSyntax(expressions: [])
+      )
+    )
   }
 
   func testUnterminatedInterpolationAtEndOfMultilineStringLiteral() {


### PR DESCRIPTION
Handle call-vs-tuple and subscript-vs-collection-expr disambiguation using the same "no trivia" rule that we used to disambiguite "unsafe.x" (which we treat as a member access) from "unsafe .x" (which we treat as an unsafe expression with a leading-dot member access).

Fixes rdar://146459104.