### PR TITLE
Disable the API breakage check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
-      api_breakage_check_allowlist_path: "api-breakages.txt"
+      api_breakage_check_enabled: false  # https://github.com/swiftlang/swift-syntax/issues/3010
       docs_check_additional_arguments: "--disable-parameters-and-returns-validation"
   verify_source_code:
     name: Validate generated code

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -1,3 +1,0 @@
-6.2
----
-API breakage: func DiagnosticsFormatter.categoryFootnotes(_:leadingText:) has parameter 0 type change from [SwiftDiagnostics.DiagnosticCategory] to some Swift.Sequence<SwiftDiagnostics.DiagnosticCategory>


### PR DESCRIPTION
`swift package diagnose-api-breaking-changes` reports changes to SPI as API-breaking changes. This generates too much noise for the API breakage check to be useful for swift-syntax.

I filed https://github.com/swiftlang/swift-package-manager/issues/8352 to track this limitation in SwiftPM.