### PR TITLE
[CMake] '-no-emit-module-separately-wmo' for swift modules

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -136,6 +136,7 @@ function(add_swift_syntax_library name)
     $<$<COMPILE_LANGUAGE:Swift>:
       "SHELL:-module-name ${name}"
       "SHELL:-Xfrontend -module-abi-name -Xfrontend ${SWIFT_MODULE_ABI_NAME_PREFIX}${name}"
+      "-no-emit-module-separately-wmo"
     >)
 
   if(CMAKE_VERSION VERSION_LESS 3.26.0 AND SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26)


### PR DESCRIPTION
Emitting modules in separate frontend job doesn't give any benefits because single add_library is just a single job from CMake's point of view. Clients need to wait for `.dylib`/`.so` being emitted before using the `.swiftmodule`. *Not* emitting modules separately is actually faster in CMake because it doesn't parse and typecheck the source code twice.