### PR TITLE
[CMake] Fix package CMO capability checking logic

### DIFF
--- a/cmake/modules/SwiftCompilerCapability.cmake
+++ b/cmake/modules/SwiftCompilerCapability.cmake
@@ -51,6 +51,7 @@ function(swift_get_package_cmo_support out_var)
   # > 6.0 : Fixed feature.
   swift_supports_compiler_arguments(result
     -package-name my-package
+    -enable-library-evolution
     -Xfrontend -package-cmo
     -Xfrontend -allow-non-resilient-access
   )


### PR DESCRIPTION
Package CMO requires '-enable-library-evolution' in 6.1+ compilers.

https://github.com/swiftlang/swift/pull/79884 but for swift-syntax repository.

Note that this is not used in compiler build because CMakeLists.txt in `swift` repository provides the result by FetchContent. This is for swift-syntax is built for other scenarios that wants to build `swift-syntax` as a LE enabled library, which pretty unlikely happpens.