### PR TITLE
Allow parsing of "nonisolated" as a type specifier along with "isolated"

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -648,6 +648,7 @@ public let TYPE_NODES: [Node] = [
           .keyword(.__shared),
           .keyword(.__owned),
           .keyword(.isolated),
+          .keyword(.nonisolated),
           .keyword(._const),
           .keyword(.borrowing),
           .keyword(.consuming),

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -3503,6 +3503,7 @@ extension SimpleTypeSpecifierSyntax {
     case __shared
     case __owned
     case isolated
+    case nonisolated
     case _const
     case borrowing
     case consuming
@@ -3518,6 +3519,8 @@ extension SimpleTypeSpecifierSyntax {
         self = .__owned
       case TokenSpec(.isolated):
         self = .isolated
+      case TokenSpec(.nonisolated):
+        self = .nonisolated
       case TokenSpec(._const):
         self = ._const
       case TokenSpec(.borrowing):
@@ -3541,6 +3544,8 @@ extension SimpleTypeSpecifierSyntax {
         self = .__owned
       case TokenSpec(.isolated):
         self = .isolated
+      case TokenSpec(.nonisolated):
+        self = .nonisolated
       case TokenSpec(._const):
         self = ._const
       case TokenSpec(.borrowing):
@@ -3564,6 +3569,8 @@ extension SimpleTypeSpecifierSyntax {
         return .keyword(.__owned)
       case .isolated:
         return .keyword(.isolated)
+      case .nonisolated:
+        return .keyword(.nonisolated)
       case ._const:
         return .keyword(._const)
       case .borrowing:
@@ -3589,6 +3596,8 @@ extension SimpleTypeSpecifierSyntax {
         return .keyword(.__owned)
       case .isolated:
         return .keyword(.isolated)
+      case .nonisolated:
+        return .keyword(.nonisolated)
       case ._const:
         return .keyword(._const)
       case .borrowing:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2591,6 +2591,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       .keyword("__shared"),
       .keyword("__owned"),
       .keyword("isolated"),
+      .keyword("nonisolated"),
       .keyword("_const"),
       .keyword("borrowing"),
       .keyword("consuming"),

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -1287,7 +1287,7 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable,
 ///
 /// ### Children
 /// 
-///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `_const` | `borrowing` | `consuming` | `sending`)
+///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `nonisolated` | `_const` | `borrowing` | `consuming` | `sending`)
 ///
 /// ### Contained in
 /// 
@@ -1351,6 +1351,7 @@ public struct SimpleTypeSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
   ///  - `__shared`
   ///  - `__owned`
   ///  - `isolated`
+  ///  - `nonisolated`
   ///  - `_const`
   ///  - `borrowing`
   ///  - `consuming`

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -765,6 +765,21 @@ final class DeclarationTests: ParserTestCase {
     )
   }
 
+  func testParseIsolatedConformances() {
+    assertParse(
+      """
+      extension Int: nonisolated Q {}
+      """
+    )
+
+    assertParse(
+      """
+      extension Int: @MainActor P {}
+      """
+    )
+
+  }
+
   func testParseDynamicReplacement() {
     assertParse(
       """


### PR DESCRIPTION
This is used for isolated conformances.