### PR TITLE
Check `thenStatements` feature in `CanBeStatementStart`

### DIFF
--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -126,9 +126,9 @@ extension Parser {
       return label(self.parseDeferStatement(deferHandle: handle), with: optLabel)
     case (.yield, let handle)?:
       return label(self.parseYieldStatement(yieldHandle: handle), with: optLabel)
-    case (.then, let handle)? where experimentalFeatures.contains(.thenStatements):
+    case (.then, let handle)?:
       return label(self.parseThenStatement(handle: handle), with: optLabel)
-    case nil, (.then, _)?:
+    case nil:
       return label(RawMissingStmtSyntax(arena: self.arena), with: optLabel)
     }
   }
@@ -986,10 +986,10 @@ extension Parser.Lookahead {
         return false
       }
 
-    case .then where experimentalFeatures.contains(.thenStatements):
+    case .then:
       return atStartOfThenStatement(preferExpr: preferExpr)
 
-    case nil, .then:
+    case nil:
       return false
     }
   }

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -121,7 +121,7 @@ enum CanBeStatementStart: TokenSpecSet {
     case TokenSpec(.repeat): self = .repeat
     case TokenSpec(.return): self = .return
     case TokenSpec(.switch): self = .switch
-    case TokenSpec(.then): self = .then
+    case TokenSpec(.then) where experimentalFeatures.contains(.thenStatements): self = .then
     case TokenSpec(.throw): self = .throw
     case TokenSpec(.while): self = .while
     case TokenSpec(.yield): self = .yield


### PR DESCRIPTION
I added the `experimentalFeatures` parameter in the TokenSpecSet initializer for `do` statements but never went back to apply the change to `then` statements. Should be NFC.