### PR TITLE
[Syntax] Workaround for 'cannot bypass resilience' warnings

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -382,7 +382,10 @@ struct SyntaxData: Sendable {
 /// `SyntaxDataArena` manages the entire data of a `Syntax` tree.
 final class SyntaxDataArena: @unchecked Sendable {
   /// Mutex for locking the data when populating layout buffers.
-  private let mutex: PlatformMutex
+  ///
+  /// - Note: `UnsafeMutableRawPointer` + casting accessor is a workaround to silence the warning 'cannot bypass resilience'.
+  private let _mutex: UnsafeMutableRawPointer?
+  private func mutex() -> PlatformMutex { PlatformMutex(opaque: self._mutex) }
 
   /// Allocator.
   private let allocator: BumpPtrAllocator
@@ -396,7 +399,7 @@ final class SyntaxDataArena: @unchecked Sendable {
   init(raw: RawSyntax, rawNodeArena: RetainedRawSyntaxArena) {
     precondition(rawNodeArena == raw.arenaReference)
 
-    self.mutex = PlatformMutex.create()
+    self._mutex = PlatformMutex.create().opaque
     self.allocator = BumpPtrAllocator(initialSlabSize: Self.slabSize(for: raw))
     self.rawArena = rawNodeArena
     self.root = Self.createDataImpl(allocator: allocator, raw: raw, parent: nil, absoluteInfo: .forRoot(raw))
@@ -405,7 +408,7 @@ final class SyntaxDataArena: @unchecked Sendable {
   deinit {
     // Debug print for re-evaluating `slabSize(for:)`
     // print("nodeCount: \(root.pointee.raw.totalNodes), slabSize: \(Self.slabSize(for: root.pointee.raw)), allocated: \(allocator.totalByteSizeAllocated), overflowed: \(Self.slabSize(for: root.pointee.raw) < allocator.totalByteSizeAllocated)")
-    self.mutex.destroy()
+    self.mutex().destroy()
   }
 
   /// Return the childen data of the given node.
@@ -431,8 +434,8 @@ final class SyntaxDataArena: @unchecked Sendable {
       return SyntaxDataReferenceBuffer(UnsafeBufferPointer(start: baseAddress, count: childCount))
     }
 
-    mutex.lock()
-    defer { mutex.unlock() }
+    mutex().lock()
+    defer { mutex().unlock() }
 
     // Recheck, maybe some other thread has populated the buffer during acquiring the lock.
     if let baseAddress = swiftsyntax_atomic_pointer_get(baseAddressRef)?.assumingMemoryBound(


### PR DESCRIPTION
`RawSyntaxArena` and `SyntaxDataaArena` have properties with types from `_SwiftSyntaxCShims` which is `@_implementationOnly` when compiling with `-enable-library-evolution`.

But for `-allow-non-resilient-access` for the package cross module optimizations, they caused warnings in 6.1+ compilers:

```
warning: cannot bypass resilience due to member deserialization failure while attempting to access member 'mutex' of 'SyntaxDataArena' in module 'SwiftSyntax' from module 'SwiftSyntax'
warning: cannot bypass resilience due to member deserialization failure while attempting to access member 'hasParent' of 'RawSyntaxArena' in module 'SwiftSyntax' from module 'SwiftSyntax'
```

and non-resilient-access are disabled for these types.

To workaround that, use `UnsafeRawPointer` for those stored properties and use casting methods to access the actual types. Note the using computed properties were not enough to silience the warnings.