### PR TITLE
Remove ValueGenerics feature from swift-syntax

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -19,7 +19,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case nonescapableTypes
   case trailingComma
   case coroutineAccessors
-  case valueGenerics
   case abiAttribute
   case keypathWithMethodMembers
   case oldOwnershipOperatorSpellings
@@ -40,8 +39,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "TrailingComma"
     case .coroutineAccessors:
       return "CoroutineAccessors"
-    case .valueGenerics:
-      return "ValueGenerics"
     case .abiAttribute:
       return "ABIAttribute"
     case .keypathWithMethodMembers:
@@ -68,8 +65,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "trailing commas"
     case .coroutineAccessors:
       return "coroutine accessors"
-    case .valueGenerics:
-      return "value generics"
     case .abiAttribute:
       return "@abi attribute"
     case .keypathWithMethodMembers:

--- a/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
@@ -341,8 +341,7 @@ public let GENERIC_NODES: [Node] = [
           ),
           Child(
             name: "expr",
-            kind: .node(kind: .expr),
-            experimentalFeature: .valueGenerics
+            kind: .node(kind: .expr)
           ),
         ]),
         nameForDiagnostics: "left-hand type",
@@ -362,8 +361,7 @@ public let GENERIC_NODES: [Node] = [
           ),
           Child(
             name: "expr",
-            kind: .node(kind: .expr),
-            experimentalFeature: .valueGenerics
+            kind: .node(kind: .expr)
           ),
         ]),
         nameForDiagnostics: "right-hand type",

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -264,8 +264,7 @@ public let TYPE_NODES: [Node] = [
           ),
           Child(
             name: "expr",
-            kind: .node(kind: .expr),
-            experimentalFeature: .valueGenerics
+            kind: .node(kind: .expr)
           ),
         ]),
         documentation:

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -1233,12 +1233,6 @@ extension Parser {
 
 extension Parser {
   mutating func parseValueType() -> RawExprSyntax? {
-    // If the 'ValueGenerics' experimental feature hasn't been added, then don't
-    // attempt to parse values as types.
-    guard self.experimentalFeatures.contains(.valueGenerics) else {
-      return nil
-    }
-
     // Eat any '-' preceding integer literals.
     var minusSign: RawTokenSyntax? = nil
     if self.atContextualPunctuator("-"),

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -53,7 +53,7 @@ extension Parser.ExperimentalFeatures {
   public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 8)
 
   /// Whether to enable the parsing of sugar type for InlineArray.
-  public static let inlineArrayTypeSugar = Self (rawValue: 1 << 10)
+  public static let inlineArrayTypeSugar = Self (rawValue: 1 << 9)
 
   /// Creates a new value representing the experimental feature with the
   /// given name, or returns nil if the name is not recognized.

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -43,17 +43,14 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of coroutine accessors.
   public static let coroutineAccessors = Self (rawValue: 1 << 5)
 
-  /// Whether to enable the parsing of value generics.
-  public static let valueGenerics = Self (rawValue: 1 << 6)
-
   /// Whether to enable the parsing of @abi attribute.
-  public static let abiAttribute = Self (rawValue: 1 << 7)
+  public static let abiAttribute = Self (rawValue: 1 << 6)
 
   /// Whether to enable the parsing of keypaths with method members.
-  public static let keypathWithMethodMembers = Self (rawValue: 1 << 8)
+  public static let keypathWithMethodMembers = Self (rawValue: 1 << 7)
 
   /// Whether to enable the parsing of `_move` and `_borrow` as ownership operators.
-  public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 9)
+  public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 8)
 
   /// Whether to enable the parsing of sugar type for InlineArray.
   public static let inlineArrayTypeSugar = Self (rawValue: 1 << 10)
@@ -74,8 +71,6 @@ extension Parser.ExperimentalFeatures {
       self = .trailingComma
     case "CoroutineAccessors":
       self = .coroutineAccessors
-    case "ValueGenerics":
-      self = .valueGenerics
     case "ABIAttribute":
       self = .abiAttribute
     case "KeypathWithMethodMembers":

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesGHI.swift
@@ -149,8 +149,6 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
 public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
   public enum Argument: RawSyntaxNodeProtocol {
     case type(RawTypeSyntax)
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     case expr(RawExprSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
@@ -180,8 +178,6 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
       self = .type(RawTypeSyntax(type))
     }
 
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public init(expr: some RawExprSyntaxNodeProtocol) {
       self = .expr(RawExprSyntax(expr))
     }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
@@ -360,8 +360,6 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol {
 public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
   public enum LeftType: RawSyntaxNodeProtocol {
     case type(RawTypeSyntax)
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     case expr(RawExprSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
@@ -391,8 +389,6 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
       self = .type(RawTypeSyntax(type))
     }
 
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public init(expr: some RawExprSyntaxNodeProtocol) {
       self = .expr(RawExprSyntax(expr))
     }
@@ -400,8 +396,6 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
 
   public enum RightType: RawSyntaxNodeProtocol {
     case type(RawTypeSyntax)
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     case expr(RawExprSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
@@ -431,8 +425,6 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
       self = .type(RawTypeSyntax(type))
     }
 
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public init(expr: some RawExprSyntaxNodeProtocol) {
       self = .expr(RawExprSyntax(expr))
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -209,8 +209,6 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable, _Leaf
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Argument: SyntaxChildChoices, SyntaxHashable {
     case type(TypeSyntax)
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     case expr(ExprSyntax)
 
     public var _syntaxNode: Syntax {
@@ -226,8 +224,6 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
       self = .type(TypeSyntax(node))
     }
 
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public init(_ node: some ExprSyntaxProtocol) {
       self = .expr(ExprSyntax(node))
     }
@@ -271,8 +267,6 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     /// Checks if the current syntax node can be cast to the type conforming to the ``ExprSyntaxProtocol`` protocol.
     ///
     /// - Returns: `true` if the node can be cast, `false` otherwise.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func `is`(_ syntaxType: (some ExprSyntaxProtocol).Type) -> Bool {
       return self.as(syntaxType) != nil
     }
@@ -280,8 +274,6 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     /// Attempts to cast the current syntax node to the type conforming to the ``ExprSyntaxProtocol`` protocol.
     ///
     /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
       return S.init(self)
     }
@@ -290,8 +282,6 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntax
     ///
     /// - Returns: An instance of the specialized type.
     /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
       return self.as(S.self)!
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -657,8 +657,6 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyn
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum LeftType: SyntaxChildChoices, SyntaxHashable {
     case type(TypeSyntax)
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     case expr(ExprSyntax)
 
     public var _syntaxNode: Syntax {
@@ -674,8 +672,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
       self = .type(TypeSyntax(node))
     }
 
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public init(_ node: some ExprSyntaxProtocol) {
       self = .expr(ExprSyntax(node))
     }
@@ -719,8 +715,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     /// Checks if the current syntax node can be cast to the type conforming to the ``ExprSyntaxProtocol`` protocol.
     ///
     /// - Returns: `true` if the node can be cast, `false` otherwise.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func `is`(_ syntaxType: (some ExprSyntaxProtocol).Type) -> Bool {
       return self.as(syntaxType) != nil
     }
@@ -728,8 +722,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     /// Attempts to cast the current syntax node to the type conforming to the ``ExprSyntaxProtocol`` protocol.
     ///
     /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
       return S.init(self)
     }
@@ -738,8 +730,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     ///
     /// - Returns: An instance of the specialized type.
     /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
       return self.as(S.self)!
     }
@@ -747,8 +737,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 
   public enum RightType: SyntaxChildChoices, SyntaxHashable {
     case type(TypeSyntax)
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     case expr(ExprSyntax)
 
     public var _syntaxNode: Syntax {
@@ -764,8 +752,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
       self = .type(TypeSyntax(node))
     }
 
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public init(_ node: some ExprSyntaxProtocol) {
       self = .expr(ExprSyntax(node))
     }
@@ -809,8 +795,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     /// Checks if the current syntax node can be cast to the type conforming to the ``ExprSyntaxProtocol`` protocol.
     ///
     /// - Returns: `true` if the node can be cast, `false` otherwise.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func `is`(_ syntaxType: (some ExprSyntaxProtocol).Type) -> Bool {
       return self.as(syntaxType) != nil
     }
@@ -818,8 +802,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     /// Attempts to cast the current syntax node to the type conforming to the ``ExprSyntaxProtocol`` protocol.
     ///
     /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
       return S.init(self)
     }
@@ -828,8 +810,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
     ///
     /// - Returns: An instance of the specialized type.
     /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
-    /// - Note: Requires experimental feature `valueGenerics`.
-    @_spi(ExperimentalLanguageFeatures)
     public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
       return self.as(S.self)!
     }

--- a/Tests/SwiftParserTest/ExpressionTypeTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTypeTests.swift
@@ -138,7 +138,7 @@ final class ExpressionTypeTests: ParserTestCase {
         { ExprSyntax.parse(from: &$0) },
         substructure: IdentifierTypeSyntax(name: .identifier("X")),
         substructureAfterMarker: "1️⃣",
-        experimentalFeatures: [.inlineArrayTypeSugar, .valueGenerics],
+        experimentalFeatures: [.inlineArrayTypeSugar],
         line: line
       )
     }

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -541,7 +541,7 @@ final class TypeTests: ParserTestCase {
 
 final class InlineArrayTypeTests: ParserTestCase {
   override var experimentalFeatures: Parser.ExperimentalFeatures {
-    [.inlineArrayTypeSugar, .valueGenerics]
+    [.inlineArrayTypeSugar]
   }
 
   func testBasic() {

--- a/Tests/SwiftParserTest/ValueGenericsTests.swift
+++ b/Tests/SwiftParserTest/ValueGenericsTests.swift
@@ -121,64 +121,55 @@ final class ValueGenericsTests: ParserTestCase {
       ],
       fixedSource: """
         let x: <#type#> = 123
-        """,
-      experimentalFeatures: .valueGenerics
+        """
     )
 
     assertParse(
       """
       let x: Generic<123>
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       let x: Generic<-123>
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       let x = Generic<123>.self
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       let x = Generic<-123>.self
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       let x = Generic<123, Int>.self
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       let x = Generic<-123, Int>.self
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       let x = Generic<Int, 123>.self
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       let x: Generic<Int, -123>.self
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
@@ -193,36 +184,31 @@ final class ValueGenericsTests: ParserTestCase {
       ],
       fixedSource: """
         typealias One = <#type#>1
-        """,
-      experimentalFeatures: .valueGenerics
+        """
     )
 
     assertParse(
       """
       extension Vector where N == 123 {}
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       extension Vector where 123 == N {}
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       extension Vector where N == -123 {}
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
       """
       extension Vector where -123 == N {}
-      """,
-      experimentalFeatures: .valueGenerics
+      """
     )
 
     assertParse(
@@ -240,8 +226,7 @@ final class ValueGenericsTests: ParserTestCase {
       ],
       fixedSource: """
         extension Vector where N: <#type#> 123 {}
-        """,
-      experimentalFeatures: .valueGenerics
+        """
     )
 
     assertParse(
@@ -259,8 +244,7 @@ final class ValueGenericsTests: ParserTestCase {
       ],
       fixedSource: """
         extension Vector where N: <#type#> -123 {}
-        """,
-      experimentalFeatures: .valueGenerics
+        """
     )
 
     assertParse(
@@ -274,8 +258,7 @@ final class ValueGenericsTests: ParserTestCase {
         DiagnosticSpec(
           message: "unexpected code ': N' in extension"
         ),
-      ],
-      experimentalFeatures: .valueGenerics
+      ]
     )
 
     assertParse(
@@ -289,8 +272,7 @@ final class ValueGenericsTests: ParserTestCase {
         DiagnosticSpec(
           message: "unexpected code ': N' in extension"
         ),
-      ],
-      experimentalFeatures: .valueGenerics
+      ]
     )
 
     assertParse(
@@ -302,8 +284,7 @@ final class ValueGenericsTests: ParserTestCase {
         ),
         DiagnosticSpec(message: "unexpected code '-1' in tuple type"),
       ],
-      fixedSource: "func foo() -> (<#type#>-1) X",
-      experimentalFeatures: [.valueGenerics]
+      fixedSource: "func foo() -> (<#type#>-1) X"
     )
   }
 }


### PR DESCRIPTION
Now that the feature is always enabled, https://github.com/swiftlang/swift/pull/79665, remove the need of the feature here.