### PR TITLE
Enable library evolution in Bazel builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,6 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "apple_support", version = "1.13.0", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_apple", version = "3.3.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "apple_support", version = "1.15.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "rules_apple", version = "3.11.2", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "2.2.0", repo_name = "build_bazel_rules_swift")

--- a/utils/bazel/swift_syntax_library.bzl
+++ b/utils/bazel/swift_syntax_library.bzl
@@ -24,6 +24,7 @@ def swift_syntax_library(name, deps, srcs = None, testonly = False):
             exclude = ["**/*.docc/**"],
             allow_empty = False,
         ),
+        library_evolution = True,
         module_name = name,
         deps = deps,
         testonly = testonly,


### PR DESCRIPTION
Updating Bazel builds to use library evolution