### PR TITLE
[Parser] Remove `abiAttribute` experimental feature

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -20,7 +20,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case trailingComma
   case coroutineAccessors
   case valueGenerics
-  case abiAttribute
   case keypathWithMethodMembers
   case oldOwnershipOperatorSpellings
 
@@ -41,8 +40,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "CoroutineAccessors"
     case .valueGenerics:
       return "ValueGenerics"
-    case .abiAttribute:
-      return "ABIAttribute"
     case .keypathWithMethodMembers:
       return "KeypathWithMethodMembers"
     case .oldOwnershipOperatorSpellings:
@@ -67,8 +64,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "coroutine accessors"
     case .valueGenerics:
       return "value generics"
-    case .abiAttribute:
-      return "@abi attribute"
     case .keypathWithMethodMembers:
       return "keypaths with method members"
     case .oldOwnershipOperatorSpellings:

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -96,7 +96,7 @@ extension Parser {
       case TokenSpec(._typeEraser): self = ._typeEraser
       case TokenSpec(._unavailableFromAsync): self = ._unavailableFromAsync
       case TokenSpec(.`rethrows`): self = .rethrows
-      case TokenSpec(.abi) where experimentalFeatures.contains(.abiAttribute): self = .abi
+      case TokenSpec(.abi): self = .abi
       case TokenSpec(.attached): self = .attached
       case TokenSpec(.available): self = .available
       case TokenSpec(.backDeployed): self = .backDeployed

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -46,14 +46,11 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of value generics.
   public static let valueGenerics = Self (rawValue: 1 << 6)
 
-  /// Whether to enable the parsing of @abi attribute.
-  public static let abiAttribute = Self (rawValue: 1 << 7)
-
   /// Whether to enable the parsing of keypaths with method members.
-  public static let keypathWithMethodMembers = Self (rawValue: 1 << 8)
+  public static let keypathWithMethodMembers = Self (rawValue: 1 << 7)
 
   /// Whether to enable the parsing of `_move` and `_borrow` as ownership operators.
-  public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 9)
+  public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 8)
 
   /// Creates a new value representing the experimental feature with the
   /// given name, or returns nil if the name is not recognized.
@@ -73,8 +70,6 @@ extension Parser.ExperimentalFeatures {
       self = .coroutineAccessors
     case "ValueGenerics":
       self = .valueGenerics
-    case "ABIAttribute":
-      self = .abiAttribute
     case "KeypathWithMethodMembers":
       self = .keypathWithMethodMembers
     case "OldOwnershipOperatorSpellings":

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -1008,22 +1008,20 @@ final class AttributeTests: ParserTestCase {
           returnClause: ReturnClauseSyntax(type: TypeSyntax("Int"))
         )
       ) {},
-      experimentalFeatures: [.abiAttribute]
+      experimentalFeatures: []
     )
 
     assertParse(
       """
       @abi(associatedtype AssocTy)
       associatedtype AssocTy
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(deinit)
       deinit {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
@@ -1031,50 +1029,43 @@ final class AttributeTests: ParserTestCase {
         @abi(case someCase)
         case someCase
       }
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(func fn())
       func fn()
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(init())
       init() {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(subscript(i: Int) -> Element)
       subscript(i: Int) -> Element {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(typealias Typealias = @escaping () -> Void)
       typealias Typealias = () -> Void
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(let c1, c2)
       let c1, c2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(var v1, v2)
       var v1, v2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
 
     assertParse(
@@ -1089,8 +1080,7 @@ final class AttributeTests: ParserTestCase {
       ),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "editor placeholder in source file")
-      ],
-      experimentalFeatures: [.abiAttribute]
+      ]
     )
 
     assertParse(
@@ -1114,8 +1104,7 @@ final class AttributeTests: ParserTestCase {
       ),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "import is not permitted as ABI-providing declaration")
-      ],
-      experimentalFeatures: [.abiAttribute]
+      ]
     )
 
     //
@@ -1126,15 +1115,13 @@ final class AttributeTests: ParserTestCase {
       """
       @abi(associatedtype AssocTy = T)
       associatedtype AssocTy
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(deinit {})
       deinit {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
@@ -1142,50 +1129,43 @@ final class AttributeTests: ParserTestCase {
         @abi(case someCase = 42)
         case someCase
       }
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(func fn() {})
       func fn()
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(init() {})
       init() {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(subscript(i: Int) -> Element { get {} set {} })
       subscript(i: Int) -> Element {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(let c1 = 1, c2 = 2)
       let c1, c2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(var v1 = 1, v2 = 2)
       var v1, v2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(var v3 { get {} set {} })
       var v3
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
 
     //
@@ -1207,8 +1187,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(var <#pattern#>)
         var v1
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1231,8 +1210,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(var v2)
         var v2
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1250,8 +1228,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(<#declaration#>)
         func fn2() {}
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1268,8 +1245,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(<#declaration#>)
         func fn3() {}
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1291,8 +1267,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(<#declaration#>) func fn4_abi())
         func fn4() {}
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
 
     // `#if` is banned inside an `@abi` attribute.
@@ -1325,8 +1300,7 @@ final class AttributeTests: ParserTestCase {
           func _fn<E: Error>() throws(E)
         )
         func fn<E: Error>() throws(E) {}
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
   }
 


### PR DESCRIPTION
But `ABIAttributeArgumentsSyntax` is still under `@_spi(ExperimentalLanguageFeatures)`.
Not parsing the interior of `@abi` attribute causes catastrophic breakage to the tree. Having "unknown" syntax kind in the tree is better than dealing with structually broken trees.