### PR TITLE
[SwiftSyntax] Add #_objectFileFormat compilation conditional

### DIFF
--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -216,7 +216,7 @@ public protocol BuildConfiguration {
 
   /// Determine whether the given name is the active target object file format (e.g., ELF).
   ///
-  /// The target object file format can only be queried by an experimental 
+  /// The target object file format can only be queried by an experimental
   /// syntax `_objectFileFormat(<name>)`, e.g.,
   ///
   /// ```swift

--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -291,3 +291,11 @@ public protocol BuildConfiguration {
   /// #endif
   var compilerVersion: VersionTuple { get }
 }
+
+/// Default implementation of BuildConfiguration, to avoid a revlock with the
+/// swift repo.
+extension BuildConfiguration {
+  func isActiveTargetObjectFileFormat(name: String) throws -> Bool {
+    return false
+  }
+}

--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -214,6 +214,21 @@ public protocol BuildConfiguration {
   /// pointer authentication scheme.
   func isActiveTargetPointerAuthentication(name: String) throws -> Bool
 
+  /// Determine whether the given name is the active target object file format (e.g., ELF).
+  ///
+  /// The target object file format can only be queried by an experimental 
+  /// syntax `_objectFileFormat(<name>)`, e.g.,
+  ///
+  /// ```swift
+  /// #if _objectFileFormat(ELF)
+  /// // Special logic for ELF object file formats
+  /// #endif
+  /// ```
+  /// - Parameters:
+  ///   - name: The name of the object file format.
+  /// - Returns: Whether the target object file format matches the given name.
+  func isActiveTargetObjectFileFormat(name: String) throws -> Bool
+
   /// The bit width of a data pointer for the target architecture.
   ///
   /// The target's pointer bit width (which also corresponds to the number of

--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -164,7 +164,8 @@ extension IfConfigDiagnostic: DiagnosticMessage {
   var severity: SwiftDiagnostics.DiagnosticSeverity {
     switch self {
     case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents,
-      .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch, .objectFileFormatDoesNotMatch, .macabiIsMacCatalyst:
+      .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch, .objectFileFormatDoesNotMatch,
+      .macabiIsMacCatalyst:
       return .warning
     default: return .error
     }

--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -36,6 +36,7 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
   case likelySimulatorPlatform(syntax: ExprSyntax)
   case likelyTargetOS(syntax: ExprSyntax, replacement: ExprSyntax?)
   case endiannessDoesNotMatch(syntax: ExprSyntax, argument: String)
+  case objectFileFormatDoesNotMatch(syntax: ExprSyntax, argument: String)
   case macabiIsMacCatalyst(syntax: ExprSyntax)
   case expectedModuleName(syntax: ExprSyntax)
   case badInfixOperator(syntax: ExprSyntax)
@@ -102,6 +103,9 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
     case .endiannessDoesNotMatch:
       return "unknown endianness for build configuration '_endian' (must be 'big' or 'little')"
 
+    case .objectFileFormatDoesNotMatch:
+      return "unknown object file format for build configuration '_objectFileFormat'"
+
     case .expectedModuleName:
       return "expected module name"
 
@@ -136,6 +140,7 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
       .likelySimulatorPlatform(syntax: let syntax),
       .likelyTargetOS(syntax: let syntax, replacement: _),
       .endiannessDoesNotMatch(syntax: let syntax, argument: _),
+      .objectFileFormatDoesNotMatch(syntax: let syntax, argument: _),
       .macabiIsMacCatalyst(syntax: let syntax),
       .expectedModuleName(syntax: let syntax),
       .badInfixOperator(syntax: let syntax),
@@ -159,7 +164,7 @@ extension IfConfigDiagnostic: DiagnosticMessage {
   var severity: SwiftDiagnostics.DiagnosticSeverity {
     switch self {
     case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents,
-      .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch, .macabiIsMacCatalyst:
+      .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch, .objectFileFormatDoesNotMatch, .macabiIsMacCatalyst:
       return .warning
     default: return .error
     }

--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -36,7 +36,6 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
   case likelySimulatorPlatform(syntax: ExprSyntax)
   case likelyTargetOS(syntax: ExprSyntax, replacement: ExprSyntax?)
   case endiannessDoesNotMatch(syntax: ExprSyntax, argument: String)
-  case objectFileFormatDoesNotMatch(syntax: ExprSyntax, argument: String)
   case macabiIsMacCatalyst(syntax: ExprSyntax)
   case expectedModuleName(syntax: ExprSyntax)
   case badInfixOperator(syntax: ExprSyntax)
@@ -103,9 +102,6 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
     case .endiannessDoesNotMatch:
       return "unknown endianness for build configuration '_endian' (must be 'big' or 'little')"
 
-    case .objectFileFormatDoesNotMatch:
-      return "unknown object file format for build configuration '_objectFileFormat'"
-
     case .expectedModuleName:
       return "expected module name"
 
@@ -140,7 +136,6 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
       .likelySimulatorPlatform(syntax: let syntax),
       .likelyTargetOS(syntax: let syntax, replacement: _),
       .endiannessDoesNotMatch(syntax: let syntax, argument: _),
-      .objectFileFormatDoesNotMatch(syntax: let syntax, argument: _),
       .macabiIsMacCatalyst(syntax: let syntax),
       .expectedModuleName(syntax: let syntax),
       .badInfixOperator(syntax: let syntax),
@@ -164,7 +159,7 @@ extension IfConfigDiagnostic: DiagnosticMessage {
   var severity: SwiftDiagnostics.DiagnosticSeverity {
     switch self {
     case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents,
-      .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch, .objectFileFormatDoesNotMatch,
+      .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch,
       .macabiIsMacCatalyst:
       return .warning
     default: return .error

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -307,6 +307,9 @@ func evaluateIfConfig(
     case .targetEnvironment:
       return doSingleIdentifierArgumentCheck(configuration.isActiveTargetEnvironment, role: "environment")
 
+    case ._objectFileFormat:
+      return doSingleIdentifierArgumentCheck(configuration.isActiveTargetObjectFileFormat, role: "object file format")
+
     case ._runtime:
       return doSingleIdentifierArgumentCheck(configuration.isActiveTargetRuntime, role: "runtime")
 
@@ -816,6 +819,10 @@ private struct CanImportSuppressingBuildConfiguration<Other: BuildConfiguration>
 
   func isActiveTargetPointerAuthentication(name: String) throws -> Bool {
     return try other.isActiveTargetPointerAuthentication(name: name)
+  }
+
+  func isActiveTargetObjectFileFormat(name: String) throws -> Bool {
+    return try other.isActiveTargetObjectFileFormat(name: name)
   }
 
   var targetPointerBitWidth: Int { return other.targetPointerBitWidth }

--- a/Sources/SwiftIfConfig/IfConfigFunctions.swift
+++ b/Sources/SwiftIfConfig/IfConfigFunctions.swift
@@ -49,6 +49,9 @@ enum IfConfigFunctions: String {
   /// A check for the target bit width of a pointer (e.g., _64)
   case _pointerBitWidth
 
+  /// A check for the target object file format (e.g., ELF)
+  case _objectFileFormat
+
   /// A check for the target runtime paired with the Swift runtime (e.g., _ObjC)
   /// via `_runtime(<name>)`.
   case _runtime
@@ -69,7 +72,7 @@ enum IfConfigFunctions: String {
       return true
 
     case .hasAttribute, .hasFeature, .canImport, .os, .arch, .targetEnvironment,
-      ._hasAtomicBitWidth, ._endian, ._pointerBitWidth, ._runtime, ._ptrauth, .defined:
+      ._hasAtomicBitWidth, ._endian, ._pointerBitWidth, ._objectFileFormat, ._runtime, ._ptrauth, .defined:
       return false
     }
   }

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -208,6 +208,8 @@ public class EvaluateTests: XCTestCase {
     assertIfConfig("_pointerBitWidth(_32)", .inactive)
     assertIfConfig("_hasAtomicBitWidth(_64)", .active)
     assertIfConfig("_hasAtomicBitWidth(_128)", .inactive)
+    assertIfConfig("_objectFileFormat(ELF)", .active)
+    assertIfConfig("_objectFileFormat(MachO)", .inactive)
 
     assertIfConfig(
       "_endian(mid)",

--- a/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
+++ b/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
@@ -99,6 +99,10 @@ struct TestingBuildConfiguration: BuildConfiguration {
     name == "arm64e"
   }
 
+  func isActiveTargetObjectFileFormat(name: String) throws -> Bool {
+    name == "ELF"
+  }
+
   var targetPointerBitWidth: Int { 64 }
 
   var targetAtomicBitWidths: [Int] { [32, 64] }


### PR DESCRIPTION
SwiftSyntax part for https://github.com/swiftlang/swift/pull/80212.

> This implements the relevant part of the "Section Placement" proposal (draft: https://github.com/kubamracek/swift-evolution/blob/section-placement-control/proposals/0nnn-section-control.md, forum thread: https://forums.swift.org/t/pitch-3-section-placement-control/77435). Namely the ability to conditionalize on the object file format that the compiler is targeting (MachO, ELF, COFF of Wasm).

> Adding with an underscored name (#_objectFileFormat) until the proposal is codified.

rdar://147505228
