### PR TITLE
Drop Linux 5.8 from the release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -39,6 +39,7 @@ jobs:
       # We require that releases of swift-syntax build without warnings
       linux_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
       windows_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
+      linux_exclude_swift_versions: "[{\"swift_version\": \"5.8\"}]"
   create_tag:
     name: Create Tag
     runs-on: ubuntu-latest


### PR DESCRIPTION
We no longer support building swift-syntax using Swift 5.8