### PR TITLE
Fix build warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -184,7 +184,8 @@ let package = Package(
 
     .target(
       name: "SwiftLexicalLookup",
-      dependencies: ["SwiftSyntax", "SwiftIfConfig"]
+      dependencies: ["SwiftSyntax", "SwiftIfConfig"],
+      exclude: ["CMakeLists.txt"]
     ),
 
     .testTarget(


### PR DESCRIPTION
This fixes the build warning

```bash
warning: 'swift-syntax': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    .../.build/checkouts/swift-syntax/Sources/SwiftLexicalLookup/CMakeLists.txt
```

which was fixed on `main` but not for the 601.0.0 release.