### PR TITLE
Specify SwiftSyntax601 in more places.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -220,6 +220,7 @@ swift_syntax_library(
         ":SwiftSyntax510",
         ":SwiftSyntax600",
         ":SwiftSyntax601",
+        ":SwiftSyntax602",
         ":_SwiftSyntaxCShims",
     ],
 )
@@ -248,6 +249,13 @@ swift_syntax_library(
 swift_syntax_library(
     name = "SwiftSyntax601",
     srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax601/**/*.swift"]),
+    deps = [
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntax602",
+    srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax602/**/*.swift"]),
     deps = [
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -219,6 +219,7 @@ swift_syntax_library(
         ":SwiftSyntax509",
         ":SwiftSyntax510",
         ":SwiftSyntax600",
+        ":SwiftSyntax601",
         ":_SwiftSyntaxCShims",
     ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -211,7 +211,7 @@ let package = Package(
     .target(
       name: "SwiftSyntax",
       dependencies: [
-        "_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601", "SwiftSyntax602"
+        "_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601", "SwiftSyntax602",
       ],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings

--- a/Package.swift
+++ b/Package.swift
@@ -210,7 +210,8 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600"],
+      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600",
+      "SwiftSyntax601"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -210,8 +210,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600",
-      "SwiftSyntax601"],
+      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -210,7 +210,9 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601", "SwiftSyntax602"],
+      dependencies: [
+        "_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601", "SwiftSyntax602"
+      ],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -210,7 +210,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601"],
+      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601", "SwiftSyntax602"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),

--- a/Sources/VersionMarkerModules/CMakeLists.txt
+++ b/Sources/VersionMarkerModules/CMakeLists.txt
@@ -16,3 +16,5 @@ add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax600 STATIC
   SwiftSyntax509/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax601 STATIC
   SwiftSyntax509/Empty.swift)
+add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax602 STATIC
+  SwiftSyntax509/Empty.swift)

--- a/Sources/VersionMarkerModules/CMakeLists.txt
+++ b/Sources/VersionMarkerModules/CMakeLists.txt
@@ -14,3 +14,5 @@ add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax510 STATIC
   SwiftSyntax509/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax600 STATIC
   SwiftSyntax509/Empty.swift)
+add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax601 STATIC
+  SwiftSyntax509/Empty.swift)


### PR DESCRIPTION
Currently the trick of using version modules to conditionally access Swift syntax is broken for version 601:

```swift
#if canImport(SwiftSyntax601)
  // Code in here is never compiled
#endif
```

We use these version modules heavily to support SwiftSyntax all the way back to 509, but now multiple packages in our ecosystem are broken with no way to fix them other than rolling back all SwiftSyntax support back to 600.

I believe the fix is to simply update the dependencies of SwiftSyntax to use SwiftSyntax601, but I went ahead and fixed up other inconsistencies with version modules throughout the repo. If this is the correct fix then hopefully we can get a patch release of SwiftSyntax released soon?