### PR TITLE
[6.1] Add dependency to 601 marker module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -171,6 +171,7 @@ swift_syntax_library(
         ":SwiftSyntax509",
         ":SwiftSyntax510",
         ":SwiftSyntax600",
+        ":SwiftSyntax601",
         ":_SwiftSyntaxCShims",
     ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -209,8 +209,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600",
-      "SwiftSyntax601"],
+      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -209,7 +209,8 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600"],
+      dependencies: ["_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600",
+      "SwiftSyntax601"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),

--- a/Sources/VersionMarkerModules/CMakeLists.txt
+++ b/Sources/VersionMarkerModules/CMakeLists.txt
@@ -14,3 +14,5 @@ add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax510 STATIC
   SwiftSyntax509/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax600 STATIC
   SwiftSyntax509/Empty.swift)
+add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax601 STATIC
+  SwiftSyntax509/Empty.swift)


### PR DESCRIPTION
- **Explanation**: 601.0.0 is missing a dependency from SwiftSyntax to the 601 marker module, causing `canImport` checks on it to fail. This prevents adoption of 601 for macros following the versioning guide.
- **Scope**: Primarily macros
- **Issue**: n/a
- **Original PR**: https://github.com/swiftlang/swift-syntax/pull/3034
- **Risk**: None, just adds a dependency to an otherwise empty module
- **Testing**: Checked `canImport` now returns true for 601
- **Reviewer**: @bnbarham 