### PR TITLE
Introduce `try` and `await` macro lexical contexts with unfolded sequence handling

### DIFF
--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -155,6 +155,8 @@ extension OperatorTable {
         )
       )
     }
+    // NOTE: If you add a new try/await/unsafe-like hoisting case here, make
+    // sure to also update `allMacroLexicalContexts` to handle it.
 
     // The form of the binary operation depends on the operator itself,
     // which will be one of the unresolved infix operators.

--- a/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
+++ b/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
@@ -67,6 +67,20 @@ extension SyntaxProtocol {
     case let freestandingMacro as FreestandingMacroExpansionSyntax:
       return Syntax(freestandingMacro.detached) as Syntax
 
+    // Try and await are preserved: A freestanding expression macro preceded
+    // by try or await may need to know whether those keywords are present so it
+    // can propagate them to any expressions in its expansion which were passed
+    // as arguments to the macro. The expression of the try or await is replaced
+    // with a trivial placeholder, though.
+    case var tryExpr as TryExprSyntax:
+      tryExpr = tryExpr.detached
+      tryExpr.expression = ExprSyntax(TypeExprSyntax(type: IdentifierTypeSyntax(name: .wildcardToken())))
+      return Syntax(tryExpr)
+    case var awaitExpr as AwaitExprSyntax:
+      awaitExpr = awaitExpr.detached
+      awaitExpr.expression = ExprSyntax(TypeExprSyntax(type: IdentifierTypeSyntax(name: .wildcardToken())))
+      return Syntax(awaitExpr)
+
     default:
       return nil
     }

--- a/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
@@ -531,7 +531,7 @@ final class LexicalContextTests: XCTestCase {
         struct S {
           let arg: C
           var contextDescription: String {
-            #lexicalContextDescription
+            try await #lexicalContextDescription
           }
         }
         return S(arg: c)
@@ -542,7 +542,9 @@ final class LexicalContextTests: XCTestCase {
           struct S {
             let arg: C
             var contextDescription: String {
-              """
+              try await """
+              await _
+              try _
               contextDescription: String
               struct S {}
               { c in
@@ -551,7 +553,7 @@ final class LexicalContextTests: XCTestCase {
                 struct S {
                   let arg: C
                   var contextDescription: String {
-                    #lexicalContextDescription
+                    try await #lexicalContextDescription
                   }
                 }
                 return S(arg: c)


### PR DESCRIPTION
This is #2724 with additional logic for handling `try` and `await` in unfolded sequence expressions. We can say that any `try`/`await` element also covers all elements to the right of it (matching the logic in swiftlang/swift#80461). Cases where this isn't true will be rejected by the compiler, e.g:

```swift
0 * try foo() + bar()
_ = try foo() ~~~ bar() // Assuming `~~~` has lower precedence than `=`
```

rdar://109470248