### PR TITLE
[Diagnostics] Make the node and position of Diagnostic and Note optional

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -68,10 +68,12 @@ extension PluginMessage.Diagnostic.Severity {
 
 extension PluginMessage.Diagnostic {
   init(from syntaxDiag: SwiftDiagnostics.Diagnostic, in sourceManager: SourceManager) {
-    if let position = sourceManager.position(
-      of: syntaxDiag.node,
-      at: .afterLeadingTrivia
-    ) {
+    if let node = syntaxDiag.node,
+      let position = sourceManager.position(
+        of: node,
+        at: .afterLeadingTrivia
+      )
+    {
       self.position = .init(fileName: position.fileName, offset: position.utf8Offset)
     } else {
       self.position = .invalid
@@ -92,7 +94,7 @@ extension PluginMessage.Diagnostic {
     }
 
     self.notes = syntaxDiag.notes.compactMap {
-      guard let pos = sourceManager.position(of: $0.node, at: .afterLeadingTrivia) else {
+      guard let node = $0.node, let pos = sourceManager.position(of: node, at: .afterLeadingTrivia) else {
         return nil
       }
       let position = PluginMessage.Diagnostic.Position(

--- a/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
@@ -157,7 +157,18 @@ func assertNote(
     location: spec.failureLocation.underlying,
     failureHandler: { failureHandler(TestFailureSpec(underlying: $0)) }
   )
-  let location = expansionContext.location(for: note.position, anchoredAt: note.node, fileName: "")
+  guard let position = note.position, let node = note.node else {
+    failureHandler(
+      TestFailureSpec(
+        message: "note has no position",
+        location: spec.failureLocation
+      )
+    )
+
+    return
+  }
+
+  let location = expansionContext.location(for: position, anchoredAt: node, fileName: "")
   if location.line != spec.line {
     failureHandler(
       TestFailureSpec(
@@ -387,7 +398,19 @@ public func assertDiagnostic(
     location: spec.failureLocation.underlying,
     failureHandler: { failureHandler(TestFailureSpec(underlying: $0)) }
   )
-  let location = expansionContext.location(for: diag.position, anchoredAt: diag.node, fileName: "")
+  guard let position = diag.position,
+    let node = diag.node
+  else {
+    failureHandler(
+      TestFailureSpec(
+        message: "diagnostic missing location info",
+        location: spec.failureLocation
+      )
+    )
+    return
+  }
+
+  let location = expansionContext.location(for: position, anchoredAt: node, fileName: "")
   if location.line != spec.line {
     failureHandler(
       TestFailureSpec(

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -85,6 +85,43 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
     )
   }
 
+  func testFloatingDiagnostics() {
+    var group = GroupedDiagnostics()
+    _ = group.addTestFile(
+      """
+      func f() { }
+      """,
+      displayName: "main.swift",
+      diagnosticDescriptors: []
+    )
+
+    group.addDiagnostic(
+      Diagnostic(
+        node: nil as Syntax?,
+        message: SimpleDiagnosticMessage(
+          message: "this is bad",
+          diagnosticID: MessageID(
+            domain: "swift-syntax",
+            id: "diagnostic test"
+          ),
+          severity: .error,
+          category: DiagnosticCategory(
+            name: "Badness",
+            documentationURL: nil
+          )
+        )
+      )
+    )
+
+    let annotated = DiagnosticsFormatter.annotateSources(in: group)
+    assertStringsEqualWithDiff(
+      annotated,
+      """
+      <unknown>:0:0: error: this is bad [#Badness]
+      """
+    )
+  }
+
   func testGroupingForMacroExpansion() {
     var group = GroupedDiagnostics()
 
@@ -259,4 +296,5 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       """
     )
   }
+
 }

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftDiagnostics
+@_spi(Testing) import SwiftDiagnostics
 @_spi(FixItApplier) import SwiftIDEUtils
 @_spi(Testing) @_spi(RawSyntax) @_spi(AlternateTokenIntrospection) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) import SwiftParserDiagnostics
@@ -324,7 +324,7 @@ func assertNote(
   XCTAssertEqual(note.message, spec.message, file: spec.file, line: spec.line)
   let locationConverter = SourceLocationConverter(fileName: "", tree: tree)
   assertLocation(
-    note.location(converter: locationConverter),
+    note.location(converter: locationConverter)!,
     in: tree,
     markerLocations: markerLocations,
     expectedLocationMarker: spec.locationMarker,
@@ -343,7 +343,7 @@ func assertDiagnostic(
 ) {
   let locationConverter = SourceLocationConverter(fileName: "", tree: tree)
   assertLocation(
-    diag.location(converter: locationConverter),
+    diag.location(converter: locationConverter)!,
     in: tree,
     markerLocations: markerLocations,
     expectedLocationMarker: spec.locationMarker,
@@ -368,7 +368,7 @@ func assertDiagnostic(
     )
   }
 
-  let highlight = spec.highlight ?? diag.node.description
+  let highlight = spec.highlight ?? diag.node?.description ?? DiagnosticsFormatter.unknownFileName
   assertStringsEqualWithDiff(
     diag.highlights.map(\.description).joined().trimmingTrailingWhitespace(),
     highlight.trimmingTrailingWhitespace(),


### PR DESCRIPTION
Some tools that wish to make use of the diagnostics machinery don't have source locations, or even a Swift source file to point into. For example, the compiler and driver both have diagnostics that don't involve anything in source code, e.g., because they are diagnosing problems at the module level such as conflicting or incorrect compiler options. At present, the driver uses a different scheme for emitting diagnostics, and the compiler falls back to using the LLVM diagnostics machinery when there is no source location information.

Making the "node" and "position" of a Diagnostic optional make it possible to express diagnostics that aren't associated with sources. Do so, and update the diagnostic formatter to support displaying diagnostics with no source location using the same `<unknown>:0:0:` scheme the compiler users.