### PR TITLE
Removes duplicate trivia from UnsafeExprSyntax

### DIFF
--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -141,7 +141,6 @@ extension OperatorTable {
     if let unsafeExpr = lhs.as(UnsafeExprSyntax.self) {
       return ExprSyntax(
         UnsafeExprSyntax(
-          leadingTrivia: unsafeExpr.leadingTrivia,
           unsafeExpr.unexpectedBeforeUnsafeKeyword,
           unsafeKeyword: unsafeExpr.unsafeKeyword,
           unsafeExpr.unexpectedBetweenUnsafeKeywordAndExpression,
@@ -150,8 +149,7 @@ extension OperatorTable {
             op: op,
             rhs: rhs
           ),
-          unsafeExpr.unexpectedAfterExpression,
-          trailingTrivia: unsafeExpr.trailingTrivia
+          unsafeExpr.unexpectedAfterExpression
         )
       )
     }

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -435,4 +435,10 @@ class OperatorPrecedenceTests: XCTestCase {
     }
 
   }
+
+  func testTriviaAroundUnsafeExpr() throws {
+    let original = ExprSyntax("/*leading*/ unsafe a /*trailing*/ + b")
+    let folded = try OperatorTable.standardOperators.foldAll(original)
+    XCTAssertEqual(original.description, folded.description)
+  }
 }


### PR DESCRIPTION
When creating `UnsafeExprSyntax`, the `leadingTrivia` passed as an argument from `unsafeExpr.leadingTrivia` is already included in `unsafeExpr.unsafeKeyword`, which causes the trivia to be duplicated if it exists. To fix this, I modified the code to avoid passing `leadingTrivia` as an argument. (Similarly, the same applies to `trailingTrivia`.)

I couldn’t find a suitable way to directly test `UnsafeExprSyntax` created via `OperatorTable`, so I verified the change by integrating my local modifications into `swift-format`.
Please let me know if there’s a better way to test this.