### PR TITLE
Add missing string interpolation in IfConfig BuildConfig

### DIFF
--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -43,7 +43,7 @@ enum BuildConfigurationError: Error, CustomStringConvertible {
   var description: String {
     switch self {
     case .experimentalFeature(let name):
-      return "'name' is an experimental feature"
+      return "'\(name)' is an experimental feature"
     }
   }
 }


### PR DESCRIPTION
Seems like a silly omission mistake? 

@kubamracek @DougGregor