### PR TITLE
Don’t exclude 5.8 in PR testing

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,8 +8,6 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
-    with:
-      linux_exclude_swift_versions: "[{\"swift_version\": \"5.8\"}]"
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
Swift 5.8 was removed from the underlying workflow in https://github.com/swiftlang/github-workflows/pull/107