### PR TITLE
Fix build warning

### DIFF
--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -43,7 +43,7 @@ enum BuildConfigurationError: Error, CustomStringConvertible {
   var description: String {
     switch self {
     case .experimentalFeature(let name):
-      return "'name' is an experimental feature"
+      return "'\(name)' is an experimental feature"
     }
   }
 }


### PR DESCRIPTION
- **Explanation**: `name` was mistakingly not referenced in string interpolation here.
- **Scope**: SwiftIfConfig
- **Issue**: n/a
- **Original PR**: https://github.com/swiftlang/swift-syntax/pull/3031
- **Risk**: Very low
- **Testing**: n/a
- **Reviewer**: @bnbarham 