### PR TITLE
Change default release version for GitHub action to 603.0.0 + add version marker module

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -11,7 +11,7 @@ on:
         required: true
       swift_syntax_version:
         type: string
-        default: 601.0.0
+        default: 603.0.0
         description: "swift-syntax version"
         # The version of swift-syntax to tag. If this is a prerelease, `-prerelease-<date>` is added to this version.
         required: true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -221,6 +221,7 @@ swift_syntax_library(
         ":SwiftSyntax600",
         ":SwiftSyntax601",
         ":SwiftSyntax602",
+        ":SwiftSyntax603",
         ":_SwiftSyntaxCShims",
     ],
 )
@@ -256,6 +257,13 @@ swift_syntax_library(
 swift_syntax_library(
     name = "SwiftSyntax602",
     srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax602/**/*.swift"]),
+    deps = [
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntax603",
+    srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax603/**/*.swift"]),
     deps = [
     ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -212,6 +212,7 @@ let package = Package(
       name: "SwiftSyntax",
       dependencies: [
         "_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601", "SwiftSyntax602",
+        "SwiftSyntax603",
       ],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
@@ -248,6 +249,11 @@ let package = Package(
     .target(
       name: "SwiftSyntax602",
       path: "Sources/VersionMarkerModules/SwiftSyntax602"
+    ),
+
+    .target(
+      name: "SwiftSyntax603",
+      path: "Sources/VersionMarkerModules/SwiftSyntax603"
     ),
 
     // MARK: SwiftSyntaxBuilder

--- a/Sources/VersionMarkerModules/CMakeLists.txt
+++ b/Sources/VersionMarkerModules/CMakeLists.txt
@@ -11,10 +11,12 @@
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax509 STATIC
   SwiftSyntax509/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax510 STATIC
-  SwiftSyntax509/Empty.swift)
+  SwiftSyntax510/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax600 STATIC
-  SwiftSyntax509/Empty.swift)
+  SwiftSyntax600/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax601 STATIC
-  SwiftSyntax509/Empty.swift)
+  SwiftSyntax601/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax602 STATIC
-  SwiftSyntax509/Empty.swift)
+  SwiftSyntax602/Empty.swift)
+add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax603 STATIC
+  SwiftSyntax603/Empty.swift)

--- a/Sources/VersionMarkerModules/SwiftSyntax603/Empty.swift
+++ b/Sources/VersionMarkerModules/SwiftSyntax603/Empty.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// The SwiftSyntax603 module is intentionally empty.
+// It serves as an indicator which version of swift-syntax a package is building against.
+// See the 'Macro Versioning.md' document for more details.


### PR DESCRIPTION
We don’t release any prereleases from main (we only do for release branches) but this makes us ready for the 6.3 branch when it comes up.