### PR TITLE
Add GitHub action that automatically creates a PR to merge main into a release branch

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,14 @@
+name: Create PR to merge main into release branch
+# In the first period after branching the release branch, we typically want to include many changes from `main` in the release branch. This workflow automatically creates a PR every Monday to merge main into the release branch.
+# Later in the release cycle we should stop this practice to avoid landing risky changes by disabling this workflow. To do so, disable the workflow as described in https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow
+on:
+  schedule:
+    - cron: '0 9 * * MON'
+  workflow_dispatch:
+jobs:
+  create_merge_pr:
+    name: Create PR to merge main into release branch
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
+    with:
+      base_branch: release/6.2
+    if: (github.event_name == 'schedule' && github.repository == 'swiftlang/swift-syntax') || (github.event_name != 'schedule')  # Ensure that we don't run this on a schedule in a fork


### PR DESCRIPTION
In the first period after branching the release branch, we want to include many changes from `main` also in the release branch. This workflow automatically creates a PR every Monday to merge main into the release branch.

Later in the release cycle we should stop this practice to avoid landing risky changes by disabling this workflow.

Similar to https://github.com/swiftlang/swift-format/pull/986