### PR TITLE
[SwiftParser] Parse @abi attribute arguments even without feature flag

### DIFF
--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -1291,7 +1291,7 @@ extension Parser {
 
     case .isolated:
       return parseAttribute(argumentMode: .required) { parser in
-        return .argumentList(parser.parseIsolatedAttributeArguments())
+        return (nil, .argumentList(parser.parseIsolatedAttributeArguments()))
       }
     case .convention, ._opaqueReturnTypeOf, nil:  // Custom attribute
       return parseAttribute(argumentMode: .customAttribute) { parser in
@@ -1299,7 +1299,7 @@ extension Parser {
           pattern: .none,
           allowTrailingComma: true
         )
-        return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
+        return (nil, .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena)))
       }
 
     }

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -1283,6 +1283,49 @@ final class AttributeTests: ParserTestCase {
     )
   }
 
+  func testABIAttributeWithoutFeature() throws {
+    assertParse(
+      """
+      @abi(1️⃣func fn() -> Int2️⃣)
+      func fn1() -> Int { }
+      """,
+      substructure: FunctionDeclSyntax(
+        attributes: [
+          .attribute(
+            AttributeSyntax(
+              attributeName: TypeSyntax("abi"),
+              leftParen: .leftParenToken(),
+              [Syntax(try FunctionDeclSyntax("func fn() -> Int"))],
+              arguments: .argumentList([]),
+              rightParen: .rightParenToken()
+            )
+          )
+        ],
+        name: "fn1",
+        signature: FunctionSignatureSyntax(
+          parameterClause: FunctionParameterClauseSyntax {},
+          returnClause: ReturnClauseSyntax(type: TypeSyntax("Int"))
+        )
+      ) {},
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "unexpected code 'func fn() -> Int' in attribute"
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected argument for '@abi' attribute",
+          fixIts: ["insert attribute argument"]
+        ),
+      ],
+      fixedSource: """
+        @abi(func fn() -> Int)
+        func fn1() -> Int { }
+        """,
+      experimentalFeatures: []
+    )
+  }
+
   func testSpaceBetweenAtAndAttribute() {
     assertParse(
       "@1️⃣ custom func foo() {}",


### PR DESCRIPTION
When the parser see `@abi` attribute without the language feature enabled, not parsing the interior causes catastrophic breakage in the tree. To avoid that, parse the argument decl is parsed, but instead of generating `ABIAttributeArgumentsSyntax`, store it as a `UnexpectedNodesSyntax` after the left-paren.