### PR TITLE
Trigger PR testing when PR opened by GitHub Actions is marked as ready for review

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: Pull request
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,15 +11,20 @@ concurrency:
 jobs:
   tests:
     name: Test
+    # PRs created by GitHub Actions don't kick off further actions (https://github.com/peter-evans/create-pull-request/blob/d57e551ebc1a16dee0b8c9ea6d24dba7627a6e35/docs/concepts-guidelines.md#triggering-further-workflow-runs).
+    # As a workaround, we mark automerge PRs that are created by GitHub actions as draft and trigger the GitHub actions by marking the PR as ready for review. But we don't want to re-trigger testing this when a normal user's PR is marked as ready for review.
+    if: (github.event.action != 'ready_for_review') || (github.event.action == 'ready_for_review' && github.event.pull_request.user.login == 'github-actions[bot]')
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
   soundness:
     name: Soundness
+    if: (github.event.action != 'ready_for_review') || (github.event.action == 'ready_for_review' && github.event.pull_request.user.login == 'github-actions[bot]')
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       api_breakage_check_enabled: false  # https://github.com/swiftlang/swift-syntax/issues/3010
       docs_check_additional_arguments: "--disable-parameters-and-returns-validation"
   verify_source_code:
     name: Validate generated code
+    if: (github.event.action != 'ready_for_review') || (github.event.action == 'ready_for_review' && github.event.pull_request.user.login == 'github-actions[bot]')
     runs-on: ubuntu-latest
     container:
       image: swift:latest
@@ -32,6 +37,7 @@ jobs:
         run: "./swift-syntax-dev-utils verify-source-code --toolchain /usr"
   test_using_swift_syntax_dev_utils_linux:
     name: Run tests using swift-syntax-dev-utils (Linux)
+    if: (github.event.action != 'ready_for_review') || (github.event.action == 'ready_for_review' && github.event.pull_request.user.login == 'github-actions[bot]')
     runs-on: ubuntu-latest
     container:
       image: swift:latest
@@ -44,6 +50,7 @@ jobs:
         run: "./swift-syntax-dev-utils test --enable-rawsyntax-validation --enable-test-fuzzing --toolchain /usr"
   test_using_swift_syntax_dev_utils_windows:
     name: Run tests using swift-syntax-dev-utils (Windows)
+    if: (github.event.action != 'ready_for_review') || (github.event.action == 'ready_for_review' && github.event.pull_request.user.login == 'github-actions[bot]')
     runs-on: windows-2022
     steps:
       - name: Pull Docker image


### PR DESCRIPTION
PRs created by GitHub Actions don't kick off further actions (https://github.com/peter-evans/create-pull-request/blob/d57e551ebc1a16dee0b8c9ea6d24dba7627a6e35/docs/concepts-guidelines.md#triggering-further-workflow-runs). As a workaround, we mark automerge PRs that are created by GitHub actions as draft and trigger the GitHub actions by marking the PR as ready for review. But we don't want to re-trigger testing this when a normal user's PR is marked as ready for review.