### PR TITLE
Make `@abi` non-experimental

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -122,8 +122,7 @@ public let ATTRIBUTE_NODES: [Node] = [
           Child(
             name: "abiArguments",
             // Special arguments for declaration syntax. e.g. @abi(func abiName() -> Int)
-            kind: .node(kind: .abiAttributeArguments),
-            experimentalFeature: .abiAttribute
+            kind: .node(kind: .abiAttributeArguments)
           ),
         ]),
         documentation: """
@@ -256,7 +255,6 @@ public let ATTRIBUTE_NODES: [Node] = [
   Node(
     kind: .abiAttributeArguments,
     base: .syntax,
-    experimentalFeature: .abiAttribute,
     nameForDiagnostics: "ABI-providing declaration",
     documentation: "The arguments of the '@abi' attribute",
     children: [

--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -19,7 +19,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case nonescapableTypes
   case trailingComma
   case coroutineAccessors
-  case abiAttribute
   case keypathWithMethodMembers
   case oldOwnershipOperatorSpellings
   case inlineArrayTypeSugar
@@ -39,8 +38,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "TrailingComma"
     case .coroutineAccessors:
       return "CoroutineAccessors"
-    case .abiAttribute:
-      return "ABIAttribute"
     case .keypathWithMethodMembers:
       return "KeypathWithMethodMembers"
     case .oldOwnershipOperatorSpellings:
@@ -65,8 +62,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "trailing commas"
     case .coroutineAccessors:
       return "coroutine accessors"
-    case .abiAttribute:
-      return "@abi attribute"
     case .keypathWithMethodMembers:
       return "keypaths with method members"
     case .oldOwnershipOperatorSpellings:

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -357,7 +357,7 @@ public enum Keyword: CaseIterable {
     case ._version:
       return KeywordSpec("_version")
     case .abi:
-      return KeywordSpec("abi", experimentalFeature: .abiAttribute)
+      return KeywordSpec("abi")
     case .accesses:
       return KeywordSpec("accesses")
     case .actor:

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -43,17 +43,14 @@ extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of coroutine accessors.
   public static let coroutineAccessors = Self (rawValue: 1 << 5)
 
-  /// Whether to enable the parsing of @abi attribute.
-  public static let abiAttribute = Self (rawValue: 1 << 6)
-
   /// Whether to enable the parsing of keypaths with method members.
-  public static let keypathWithMethodMembers = Self (rawValue: 1 << 7)
+  public static let keypathWithMethodMembers = Self (rawValue: 1 << 6)
 
   /// Whether to enable the parsing of `_move` and `_borrow` as ownership operators.
-  public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 8)
+  public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 7)
 
   /// Whether to enable the parsing of sugar type for InlineArray.
-  public static let inlineArrayTypeSugar = Self (rawValue: 1 << 9)
+  public static let inlineArrayTypeSugar = Self (rawValue: 1 << 8)
 
   /// Creates a new value representing the experimental feature with the
   /// given name, or returns nil if the name is not recognized.
@@ -71,8 +68,6 @@ extension Parser.ExperimentalFeatures {
       self = .trailingComma
     case "CoroutineAccessors":
       self = .coroutineAccessors
-    case "ABIAttribute":
-      self = .abiAttribute
     case "KeypathWithMethodMembers":
       self = .keypathWithMethodMembers
     case "OldOwnershipOperatorSpellings":

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -303,6 +303,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 
 ### Attributes
 
+- <doc:SwiftSyntax/ABIAttributeArgumentsSyntax>
 - <doc:SwiftSyntax/AttributeListSyntax>
 - <doc:SwiftSyntax/AttributeSyntax>
 - <doc:SwiftSyntax/BackDeployedAttributeArgumentsSyntax>

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -54,7 +54,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case _underlyingVersion
   case _UnknownLayout
   case _version
-  @_spi(ExperimentalLanguageFeatures)
   case abi
   case accesses
   case actor

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -57,12 +57,10 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
-  @_spi(ExperimentalLanguageFeatures)
   override open func visit(_ node: ABIAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  @_spi(ExperimentalLanguageFeatures)
   override open func visitPost(_ node: ABIAttributeArgumentsSyntax) {
     visitAnyPost(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -16,7 +16,6 @@
 /// Enum to exhaustively switch over all different syntax nodes.
 public enum SyntaxEnum: Sendable {
   case token(TokenSyntax)
-  @_spi(ExperimentalLanguageFeatures)
   case abiAttributeArguments(ABIAttributeArgumentsSyntax)
   @_spi(Compiler)
   case accessorBlockFile(AccessorBlockFileSyntax)

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -16,7 +16,6 @@
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
 public enum SyntaxKind: Sendable {
   case token
-  @_spi(ExperimentalLanguageFeatures)
   case abiAttributeArguments
   @_spi(Compiler)
   case accessorBlockFile

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -99,10 +99,9 @@ open class SyntaxRewriter {
     return token
   }
 
-  /// Visit a `ABIAttributeArgumentsSyntax`.
+  /// Visit a ``ABIAttributeArgumentsSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  @_spi(ExperimentalLanguageFeatures)
   open func visit(_ node: ABIAttributeArgumentsSyntax) -> ABIAttributeArgumentsSyntax {
     return ABIAttributeArgumentsSyntax(unsafeCasting: visitChildren(node._syntaxNode))
   }

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -35,17 +35,15 @@ open class SyntaxVisitor {
     dispatchVisit(Syntax(node))
   }
 
-  /// Visiting `ABIAttributeArgumentsSyntax` specifically.
+  /// Visiting ``ABIAttributeArgumentsSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  @_spi(ExperimentalLanguageFeatures)
   open func visit(_ node: ABIAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
-  /// The function called after visiting `ABIAttributeArgumentsSyntax` and its descendants.
+  /// The function called after visiting ``ABIAttributeArgumentsSyntax`` and its descendants.
   ///   - node: the node we just finished visiting.
-  @_spi(ExperimentalLanguageFeatures)
   open func visitPost(_ node: ABIAttributeArgumentsSyntax) {
   }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesAB.swift
@@ -13,7 +13,6 @@
 // Do not edit directly!
 // swift-format-ignore-file
 
-@_spi(ExperimentalLanguageFeatures)
 @_spi(RawSyntax)
 public struct RawABIAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public enum Provider: RawSyntaxNodeProtocol {
@@ -1615,8 +1614,6 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     case dynamicReplacementArguments(RawDynamicReplacementAttributeArgumentsSyntax)
     case effectsArguments(RawEffectsAttributeArgumentListSyntax)
     case documentationArguments(RawDocumentationAttributeArgumentListSyntax)
-    /// - Note: Requires experimental feature `abiAttribute`.
-    @_spi(ExperimentalLanguageFeatures)
     case abiArguments(RawABIAttributeArgumentsSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -17,8 +17,6 @@
 
 /// The arguments of the '@abi' attribute
 ///
-/// - Note: Requires experimental feature `abiAttribute`.
-///
 /// ### Children
 /// 
 ///  - `provider`: (``AssociatedTypeDeclSyntax`` | ``DeinitializerDeclSyntax`` | ``EnumCaseDeclSyntax`` | ``FunctionDeclSyntax`` | ``InitializerDeclSyntax`` | ``MissingDeclSyntax`` | ``SubscriptDeclSyntax`` | ``TypeAliasDeclSyntax`` | ``VariableDeclSyntax``)
@@ -26,7 +24,6 @@
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-@_spi(ExperimentalLanguageFeatures)
 public struct ABIAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Provider: SyntaxChildChoices, SyntaxHashable {
     case associatedType(AssociatedTypeDeclSyntax)
@@ -2600,6 +2597,10 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExp
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `initializer`: ``TypeInitializerClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -3097,7 +3098,7 @@ public struct AttributeClauseFileSyntax: SyntaxProtocol, SyntaxHashable, _LeafSy
 ///  - `atSign`: `@`
 ///  - `attributeName`: ``TypeSyntax``
 ///  - `leftParen`: `(`?
-///  - `arguments`: (``LabeledExprListSyntax`` | ``AvailabilityArgumentListSyntax`` | ``SpecializeAttributeArgumentListSyntax`` | ``ObjCSelectorPieceListSyntax`` | ``ImplementsAttributeArgumentsSyntax`` | ``DifferentiableAttributeArgumentsSyntax`` | ``DerivativeAttributeArgumentsSyntax`` | ``BackDeployedAttributeArgumentsSyntax`` | ``OriginallyDefinedInAttributeArgumentsSyntax`` | ``DynamicReplacementAttributeArgumentsSyntax`` | ``EffectsAttributeArgumentListSyntax`` | ``DocumentationAttributeArgumentListSyntax`` | `ABIAttributeArgumentsSyntax`)?
+///  - `arguments`: (``LabeledExprListSyntax`` | ``AvailabilityArgumentListSyntax`` | ``SpecializeAttributeArgumentListSyntax`` | ``ObjCSelectorPieceListSyntax`` | ``ImplementsAttributeArgumentsSyntax`` | ``DifferentiableAttributeArgumentsSyntax`` | ``DerivativeAttributeArgumentsSyntax`` | ``BackDeployedAttributeArgumentsSyntax`` | ``OriginallyDefinedInAttributeArgumentsSyntax`` | ``DynamicReplacementAttributeArgumentsSyntax`` | ``EffectsAttributeArgumentListSyntax`` | ``DocumentationAttributeArgumentListSyntax`` | ``ABIAttributeArgumentsSyntax``)?
 ///  - `rightParen`: `)`?
 ///
 /// ### Contained in
@@ -3118,8 +3119,6 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
     case dynamicReplacementArguments(DynamicReplacementAttributeArgumentsSyntax)
     case effectsArguments(EffectsAttributeArgumentListSyntax)
     case documentationArguments(DocumentationAttributeArgumentListSyntax)
-    /// - Note: Requires experimental feature `abiAttribute`.
-    @_spi(ExperimentalLanguageFeatures)
     case abiArguments(ABIAttributeArgumentsSyntax)
 
     public var _syntaxNode: Syntax {
@@ -3201,8 +3200,6 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
       self = .documentationArguments(node)
     }
 
-    /// - Note: Requires experimental feature `abiAttribute`.
-    @_spi(ExperimentalLanguageFeatures)
     public init(_ node: ABIAttributeArgumentsSyntax) {
       self = .abiArguments(node)
     }
@@ -3521,30 +3518,24 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
       return self.as(DocumentationAttributeArgumentListSyntax.self)!
     }
 
-    /// Checks if the current syntax node can be cast to `ABIAttributeArgumentsSyntax`.
+    /// Checks if the current syntax node can be cast to ``ABIAttributeArgumentsSyntax``.
     ///
     /// - Returns: `true` if the node can be cast, `false` otherwise.
-    /// - Note: Requires experimental feature `abiAttribute`.
-    @_spi(ExperimentalLanguageFeatures)
     public func `is`(_ syntaxType: ABIAttributeArgumentsSyntax.Type) -> Bool {
       return self.as(syntaxType) != nil
     }
 
-    /// Attempts to cast the current syntax node to `ABIAttributeArgumentsSyntax`.
+    /// Attempts to cast the current syntax node to ``ABIAttributeArgumentsSyntax``.
     ///
-    /// - Returns: An instance of `ABIAttributeArgumentsSyntax`, or `nil` if the cast fails.
-    /// - Note: Requires experimental feature `abiAttribute`.
-    @_spi(ExperimentalLanguageFeatures)
+    /// - Returns: An instance of ``ABIAttributeArgumentsSyntax``, or `nil` if the cast fails.
     public func `as`(_ syntaxType: ABIAttributeArgumentsSyntax.Type) -> ABIAttributeArgumentsSyntax? {
       return ABIAttributeArgumentsSyntax.init(self)
     }
 
-    /// Force-casts the current syntax node to `ABIAttributeArgumentsSyntax`.
+    /// Force-casts the current syntax node to ``ABIAttributeArgumentsSyntax``.
     ///
-    /// - Returns: An instance of `ABIAttributeArgumentsSyntax`.
+    /// - Returns: An instance of ``ABIAttributeArgumentsSyntax``.
     /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
-    /// - Note: Requires experimental feature `abiAttribute`.
-    @_spi(ExperimentalLanguageFeatures)
     public func cast(_ syntaxType: ABIAttributeArgumentsSyntax.Type) -> ABIAttributeArgumentsSyntax {
       return self.as(ABIAttributeArgumentsSyntax.self)!
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -893,6 +893,10 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 ///  - `deinitKeyword`: `deinit`
 ///  - `effectSpecifiers`: ``DeinitializerEffectSpecifiersSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -312,6 +312,10 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `caseKeyword`: `case`
 ///  - `elements`: ``EnumCaseElementListSyntax``
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -3312,6 +3316,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafE
 ///  - `signature`: ``FunctionSignatureSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -4022,6 +4022,10 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 ///  - `signature`: ``FunctionSignatureSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -4536,6 +4536,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeS
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `placeholder`: `<identifier>`
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -3108,6 +3108,10 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
 ///  - `returnClause`: ``ReturnClauseSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `accessorBlock`: ``AccessorBlockSyntax``?
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -1851,6 +1851,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSynt
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
 ///  - `initializer`: ``TypeInitializerClauseSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 
@@ -3219,6 +3223,10 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, 
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `bindingSpecifier`: (`let` | `var` | `inout` | `_mutating` | `_borrowing` | `_consuming`)
 ///  - `bindings`: ``PatternBindingListSyntax``
+///
+/// ### Contained in
+/// 
+///  - ``ABIAttributeArgumentsSyntax``.``ABIAttributeArgumentsSyntax/provider``
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -960,23 +960,20 @@ final class AttributeTests: ParserTestCase {
           parameterClause: FunctionParameterClauseSyntax {},
           returnClause: ReturnClauseSyntax(type: TypeSyntax("Int"))
         )
-      ) {},
-      experimentalFeatures: [.abiAttribute]
+      ) {}
     )
 
     assertParse(
       """
       @abi(associatedtype AssocTy)
       associatedtype AssocTy
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(deinit)
       deinit {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
@@ -984,50 +981,43 @@ final class AttributeTests: ParserTestCase {
         @abi(case someCase)
         case someCase
       }
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(func fn())
       func fn()
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(init())
       init() {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(subscript(i: Int) -> Element)
       subscript(i: Int) -> Element {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(typealias Typealias = @escaping () -> Void)
       typealias Typealias = () -> Void
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(let c1, c2)
       let c1, c2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(var v1, v2)
       var v1, v2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
 
     assertParse(
@@ -1042,8 +1032,7 @@ final class AttributeTests: ParserTestCase {
       ),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "editor placeholder in source file")
-      ],
-      experimentalFeatures: [.abiAttribute]
+      ]
     )
 
     assertParse(
@@ -1067,8 +1056,7 @@ final class AttributeTests: ParserTestCase {
       ),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "import is not permitted as ABI-providing declaration")
-      ],
-      experimentalFeatures: [.abiAttribute]
+      ]
     )
 
     //
@@ -1079,15 +1067,13 @@ final class AttributeTests: ParserTestCase {
       """
       @abi(associatedtype AssocTy = T)
       associatedtype AssocTy
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(deinit {})
       deinit {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
@@ -1095,50 +1081,43 @@ final class AttributeTests: ParserTestCase {
         @abi(case someCase = 42)
         case someCase
       }
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(func fn() {})
       func fn()
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(init() {})
       init() {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(subscript(i: Int) -> Element { get {} set {} })
       subscript(i: Int) -> Element {}
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(let c1 = 1, c2 = 2)
       let c1, c2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(var v1 = 1, v2 = 2)
       var v1, v2
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
     assertParse(
       """
       @abi(var v3 { get {} set {} })
       var v3
-      """,
-      experimentalFeatures: [.abiAttribute]
+      """
     )
 
     //
@@ -1160,8 +1139,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(var <#pattern#>)
         var v1
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1184,8 +1162,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(var v2)
         var v2
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1203,8 +1180,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(<#declaration#>)
         func fn2() {}
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1221,8 +1197,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(<#declaration#>)
         func fn3() {}
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
     assertParse(
       """
@@ -1244,8 +1219,7 @@ final class AttributeTests: ParserTestCase {
       fixedSource: """
         @abi(<#declaration#>) func fn4_abi())
         func fn4() {}
-        """,
-      experimentalFeatures: [.abiAttribute]
+        """
     )
 
     // `#if` is banned inside an `@abi` attribute.
@@ -1278,51 +1252,7 @@ final class AttributeTests: ParserTestCase {
           func _fn<E: Error>() throws(E)
         )
         func fn<E: Error>() throws(E) {}
-        """,
-      experimentalFeatures: [.abiAttribute]
-    )
-  }
-
-  func testABIAttributeWithoutFeature() throws {
-    assertParse(
-      """
-      @abi(1️⃣func fn() -> Int2️⃣)
-      func fn1() -> Int { }
-      """,
-      substructure: FunctionDeclSyntax(
-        attributes: [
-          .attribute(
-            AttributeSyntax(
-              attributeName: TypeSyntax("abi"),
-              leftParen: .leftParenToken(),
-              [Syntax(try FunctionDeclSyntax("func fn() -> Int"))],
-              arguments: .argumentList([]),
-              rightParen: .rightParenToken()
-            )
-          )
-        ],
-        name: "fn1",
-        signature: FunctionSignatureSyntax(
-          parameterClause: FunctionParameterClauseSyntax {},
-          returnClause: ReturnClauseSyntax(type: TypeSyntax("Int"))
-        )
-      ) {},
-      diagnostics: [
-        DiagnosticSpec(
-          locationMarker: "1️⃣",
-          message: "unexpected code 'func fn() -> Int' in attribute"
-        ),
-        DiagnosticSpec(
-          locationMarker: "2️⃣",
-          message: "expected argument for '@abi' attribute",
-          fixIts: ["insert attribute argument"]
-        ),
-      ],
-      fixedSource: """
-        @abi(func fn() -> Int)
-        func fn1() -> Int { }
-        """,
-      experimentalFeatures: []
+        """
     )
   }
 


### PR DESCRIPTION
Removes the experimental status of the syntax nodes for `@abi`, including a temporary hack used to make `@abi` parse correctly in macro expansion tests.

This will need to land at the same time as matching compiler changes in swiftlang/swift#81115.