### PR TITLE
[6.2][SwiftParser] Parse operator function with value generics

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1215,8 +1215,11 @@ extension Parser {
     let unexpectedAfterIdentifier: RawUnexpectedNodesSyntax?
     let identifier: RawTokenSyntax
     if self.at(anyIn: Operator.self) != nil || self.at(.exclamationMark, .prefixAmpersand) {
+      // If the name is an operator token that ends in '<' followed by an identifier or 'let',
+      // leave the '<' so it's parsed as a generic parameter clause. This allows things like
+      // 'func ==<T>(x:T, y:T) {}'.
       var name = self.currentToken.tokenText
-      if !currentToken.isEditorPlaceholder && name.hasSuffix("<") && self.peek(isAt: .identifier) {
+      if !currentToken.isEditorPlaceholder && name.hasSuffix("<") && self.peek(isAt: .identifier, .keyword(.let)) {
         name = SyntaxText(rebasing: name.dropLast())
       }
       unexpectedBeforeIdentifier = nil

--- a/Tests/SwiftParserTest/ValueGenericsTests.swift
+++ b/Tests/SwiftParserTest/ValueGenericsTests.swift
@@ -287,4 +287,12 @@ final class ValueGenericsTests: ParserTestCase {
       fixedSource: "func foo() -> (<#type#>-1) X"
     )
   }
+
+  func testOperatorFunc() {
+    assertParse(
+      """
+      func *<let X: Int, let Y: Int>(l: A<X>, r: A<Y>) -> Int { l.int * r.int }
+      """
+    )
+  }
 }


### PR DESCRIPTION
Cherry-pick #3070 into `release/6.2`

* **Explanation**:  Operator function parsing has a heuristics to determine if `<` a part of the operator name or the generic parameter clause. Previously if `<` was followed by an identifier it considered `<` was a start of the generic parameter clause. However, since value generics was introduced, generic parameter clause can start with `< let` which was not handled.
* **Scope**: Parse
* **Risk**: Low, the change is trivial.
* **Testing**: Added an regression test case
* **Issue**: rdar://149556573
* **Reviewer**: Ben Barham (@bnbarham)
