### PR TITLE
Add trailing comma support in cases missing from Swift 6.1

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -362,7 +362,7 @@ extension Parser {
     let additionalArgs = self.parseArgumentListElements(
       pattern: .none,
       flavor: .attributeArguments,
-      allowTrailingComma: false
+      allowTrailingComma: true
     )
     return [roleElement] + additionalArgs
   }
@@ -852,6 +852,11 @@ extension Parser {
           arena: self.arena
         )
       )
+
+      // If this was a trailing closure then there are no more elements
+      if self.at(.rightParen) {
+        break
+      }
     } while keepGoing != nil
     return RawBackDeployedAttributeArgumentsSyntax(
       unexpectedBeforeLabel,
@@ -883,6 +888,11 @@ extension Parser {
           arena: self.arena
         )
       )
+
+      // If this was a trailing closure then there are no more elements
+      if self.at(.rightParen) {
+        break
+      }
     } while keepGoing != nil
 
     return RawOriginallyDefinedInAttributeArgumentsSyntax(
@@ -1001,6 +1011,11 @@ extension Parser {
           arena: self.arena
         )
       )
+
+      // If this was a trailing closure then there are no more elements
+      if self.at(.rightParen) {
+        break
+      }
     } while keepGoing != nil
 
     return RawDocumentationAttributeArgumentListSyntax(elements: arguments, arena: self.arena)

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -47,6 +47,11 @@ extension Parser {
             arena: self.arena
           )
         )
+
+        // If this was a trailing closure, there are no more elements
+        if self.at(.rightParen) {
+          break
+        }
       } while keepGoing != nil
         && self.hasProgressed(&availabilityArgumentProgress)
     }

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -361,6 +361,11 @@ extension Parser {
             arena: self.arena
           )
         )
+
+        // If this was a trailing comma, there are no more elements
+        if at(prefix: ">") {
+          break
+        }
       } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
     let rangle = self.expectWithoutRecovery(prefix: ">", as: .rightAngle)

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -430,6 +430,11 @@ extension Parser {
             arena: self.arena
           )
         )
+
+        // If this was a trailing comma, we're done parsing the list
+        if self.at(prefix: ">") {
+          break
+        }
       } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
 

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -472,7 +472,25 @@ final class AttributeTests: ParserTestCase {
 
     assertParse(
       """
+      @backDeployed(
+        before: macOS 12.0,
+      )
+      struct Foo {}
+      """
+    )
+
+    assertParse(
+      """
       @backDeployed(before: macos 12.0, iOS 15.0)
+      struct Foo {}
+      """
+    )
+
+    assertParse(
+      """
+      @backDeployed(
+        before: macos 12.0, 
+        iOS 15.0,)
       struct Foo {}
       """
     )
@@ -533,6 +551,16 @@ final class AttributeTests: ParserTestCase {
     assertParse(
       """
       @_originallyDefinedIn(module: "ToasterKit", macOS 10.15)
+      struct Vehicle {}
+      """
+    )
+
+    assertParse(
+      """
+      @_originallyDefinedIn(
+        module: "ToasterKit",
+        macOS 10.15,
+      )
       struct Vehicle {}
       """
     )
@@ -845,6 +873,26 @@ final class AttributeTests: ParserTestCase {
         macro m()
         }
         """
+    )
+
+    assertParse(
+      """
+      @attached(
+        member,
+        names: named(deinit),
+      )
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @attached(
+        extension,
+        conformances: P1, P2,
+      )
+      macro AddAllConformances()
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3529,4 +3529,31 @@ final class DeclarationTests: ParserTestCase {
       ]
     )
   }
+
+  func testTrailingCommas() {
+    assertParse(
+      """
+      protocol Baaz<
+        Foo,
+        Bar,
+      > {
+        associatedtype Foo
+        associatedtype Bar
+      }
+      """
+    )
+
+    assertParse(
+      """
+      struct Foo<
+        T1,
+        T2,
+        T3,
+      >: Baaz<
+        T1,
+        T2,
+      > {}
+      """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -734,6 +734,44 @@ final class TypeTests: ParserTestCase {
       fixedSource: "func foo(test: nonisolated(nonsendinghello) () async -> Void)"
     )
   }
+
+  func testTrailingCommas() {
+    assertParse(
+      """
+      let foo: (
+        bar: String,
+        quux: String,
+      )
+      """
+    )
+
+    assertParse(
+      """
+      let closure: (
+        String,
+        String,
+      ) -> (
+        bar: String,
+        quux: String,
+      )
+      """
+    )
+
+    assertParse(
+      """
+      struct Foo<T1, T2, T3,> {}
+
+      typealias Bar<
+        T1,
+        T2,
+      > = Foo<
+        T1,
+        T2,
+        Bool,
+      >
+      """
+    )
+  }
 }
 
 final class InlineArrayTypeTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -400,17 +400,7 @@ final class AvailabilityQueryTests: ParserTestCase {
       """
       if #available(OSX 10.51,1️⃣) {
       }
-      """,
-      diagnostics: [
-        DiagnosticSpec(
-          message: "expected version restriction in availability argument",
-          fixIts: ["insert version restriction"]
-        )
-      ],
-      fixedSource: """
-        if #available(OSX 10.51, <#identifier#>) {
-        }
-        """
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -381,19 +381,9 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability23() {
     assertParse(
       """
-      if #unavailable(OSX 10.51,1️⃣) {
+      if #unavailable(OSX 10.51,) {
       }
-      """,
-      diagnostics: [
-        DiagnosticSpec(
-          message: "expected version restriction in availability argument",
-          fixIts: ["insert version restriction"]
-        )
-      ],
-      fixedSource: """
-        if #unavailable(OSX 10.51, <#identifier#>) {
-        }
-        """
+      """
     )
   }
 
@@ -609,6 +599,20 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '==' in 'if' statement")
       ]
+    )
+  }
+
+  func testTrailingComma() {
+    assertParse(
+      """
+      func fooDeprecated() {
+        if #available(
+          iOS 18.0,
+          macOS 14.0,
+          *,
+        ) {}
+      }
+      """
     )
   }
 }


### PR DESCRIPTION
In Swift 6.1, there are many cases where trailing commas [should be supported](https://forums.swift.org/t/accepted-with-modifications-se-0439-allow-trailing-comma-in-comma-separated-lists/73216) but currently are not:
 - https://github.com/swiftlang/swift/issues/81485
 - https://github.com/swiftlang/swift/issues/81474
 - https://github.com/swiftlang/swift/issues/81475

This includes cases like:

```swift
let foo: (
  bar: String,
  quux: String, // unexpectedly not supported in Swift 6.1
)

let closure: (
  String,
  String, // unexpectedly not supported in Swift 6.1
) -> (
  bar: String,
  quux: String, // unexpectedly not supported in Swift 6.1
)

let foo: Foo<
  String,
  Int,
  Boo, // unexpectedly not supported in Swift 6.1
>

typealias Bar<
  T1,
  T2
> = Foo<
  T1,
  T2,
  Bool, // unexpectedly not supported in Swift 6.1
>

protocol Baaz<
  T1,
  T2, // unexpectedly not supported in Swift 6.1
> {
  associatedtype T1
  associatedtype T2
}

@available(
    *,
    deprecated,
    renamed: "bar", // unexpectedly not supported in Swift 6.1
)
func foo() { }
```