### PR TITLE
Add a `SendableMetatype` conformance to `Macro`

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/Macro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/Macro.swift
@@ -10,9 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6.2)
+/// Describes a macro.
+public protocol Macro: SendableMetatype {
+  /// How the resulting expansion should be formatted, `.auto` by default.
+  /// Use `.disabled` for the expansion to be used as is.
+  static var formatMode: FormatMode { get }
+}
+#else
 /// Describes a macro.
 public protocol Macro {
   /// How the resulting expansion should be formatted, `.auto` by default.
   /// Use `.disabled` for the expansion to be used as is.
   static var formatMode: FormatMode { get }
 }
+#endif


### PR DESCRIPTION
`Macro.Type` is used in various `Error`s and since SE-0470, needs to conform to `SendableMetatype`.