### PR TITLE
[6.2] Add a `SendableMetatype` conformance to `Macro`

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/Macro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/Macro.swift
@@ -10,9 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6.2)
+/// Describes a macro.
+public protocol Macro: SendableMetatype {
+  /// How the resulting expansion should be formatted, `.auto` by default.
+  /// Use `.disabled` for the expansion to be used as is.
+  static var formatMode: FormatMode { get }
+}
+#else
 /// Describes a macro.
 public protocol Macro {
   /// How the resulting expansion should be formatted, `.auto` by default.
   /// Use `.disabled` for the expansion to be used as is.
   static var formatMode: FormatMode { get }
 }
+#endif


### PR DESCRIPTION
- **Explanation**: Adds `SendableMetatype` conformance to `Macro`, as its metatype is used in the associated value of various `Error`-conforming enums. This is blocking the release of new swift-syntax pre-release tags (https://github.com/swiftlang/swift-syntax/actions/runs/15217482806).
- **Scope**: Macros
- **Original PRs**: https://github.com/swiftlang/swift-syntax/pull/3084
- **Risk**: Low, main risk is for older Swift's, but given how small the protocol is I ended up going with the route of separate definitions for older versions.
- **Testing**: Builds 🥳 
- **Reviewers**: @ahoppen 