### PR TITLE
Fix a crash if we had a dollar identifier as the second parameter label in a closure not followed by a colon

### DIFF
--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -944,13 +944,13 @@ extension Parser.Lookahead {
       // by a type annotation.
       if self.startsParameterName(isClosure: false, allowMisplacedSpecifierRecovery: false) {
         self.consumeAnyToken()
+        // If we have a secondary argument label, consume it.
         if self.atArgumentLabel() {
           self.consumeAnyToken()
-          guard self.at(.colon) else {
-            return false
-          }
         }
-        self.eat(.colon)
+        guard self.consume(if: .colon) != nil else {
+          return false
+        }
 
         // Parse a type.
         guard self.canParseType() else {

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2145,6 +2145,26 @@ final class ExpressionTests: ParserTestCase {
       """
     )
   }
+
+  func testSecondaryArgumentLabelDollarIdentifierInClosure() {
+    assertParse(
+      """
+      ℹ️{ a1️⃣: (a $
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected '}' to end closure",
+          notes: [NoteSpec(message: "to match this opening '{'")],
+          fixIts: ["insert '}'"]
+        ),
+        DiagnosticSpec(message: "extraneous code ': (a $' at top level"),
+      ],
+      fixedSource: """
+        { a
+        }: (a $
+        """
+    )
+  }
 }
 
 final class MemberExprTests: ParserTestCase {


### PR DESCRIPTION
There was a mismatch between the call to `eat` and `at`. Switch the pair to a `consume(if:)` to avoid the issue.

Fixes swiftlang/swift-syntax#3103