### PR TITLE
.swift-format: Specify an exhaustive configuration

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,20 +1,20 @@
 {
-    "version": 1,
-    "lineLength": 120,
+    "indentConditionalCompilationBlocks": false,
     "indentation": {
         "spaces": 2
     },
     "lineBreakBeforeEachArgument": true,
-    "indentConditionalCompilationBlocks": false,
+    "lineLength": 120,
     "prioritizeKeepingFunctionOutputTogether": true,
     "rules": {
         "AlwaysUseLowerCamelCase": false,
         "AmbiguousTrailingClosureOverload": false,
         "NoBlockComments": false,
+        "NoVoidReturnOnFunctionSignature": true,
         "OrderedImports": true,
+        "ReturnVoidInsteadOfEmptyTuple": true,
         "UseLetInEveryBoundCaseVariable": false,
         "UseSynthesizedInitializer": false,
-        "ReturnVoidInsteadOfEmptyTuple": true,
-        "NoVoidReturnOnFunctionSignature": true,
-    }
+    },
+    "version": 1,
 }

--- a/.swift-format
+++ b/.swift-format
@@ -1,20 +1,78 @@
 {
+    "fileScopedDeclarationPrivacy": {
+        "accessLevel": "private"
+    },
     "indentConditionalCompilationBlocks": false,
+    "indentSwitchCaseLabels": false,
     "indentation": {
         "spaces": 2
     },
+    "lineBreakAroundMultilineExpressionChainComponents": false,
+    "lineBreakBeforeControlFlowKeywords": false,
     "lineBreakBeforeEachArgument": true,
+    "lineBreakBeforeEachGenericRequirement": false,
+    "lineBreakBetweenDeclarationAttributes": false,
     "lineLength": 120,
+    "maximumBlankLines": 1,
+    "multiElementCollectionTrailingCommas": true,
+    "noAssignmentInExpressions": {
+        "allowedFunctions": [
+            "XCTAssertNoThrow"
+        ]
+    },
     "prioritizeKeepingFunctionOutputTogether": true,
+    "reflowMultilineStringLiterals": {
+        "never": {
+
+        }
+    },
+    "respectsExistingLineBreaks": true,
     "rules": {
+        "AllPublicDeclarationsHaveDocumentation": false,
+        "AlwaysUseLiteralForEmptyCollectionInit": false,
         "AlwaysUseLowerCamelCase": false,
         "AmbiguousTrailingClosureOverload": false,
+        "AvoidRetroactiveConformances": true,
+        "BeginDocumentationCommentWithOneLineSummary": false,
+        "DoNotUseSemicolons": false,
+        "DontRepeatTypeInStaticProperties": true,
+        "FileScopedDeclarationPrivacy": true,
+        "FullyIndirectEnum": true,
+        "GroupNumericLiterals": true,
+        "IdentifiersMustBeASCII": true,
+        "NeverForceUnwrap": false,
+        "NeverUseForceTry": false,
+        "NeverUseImplicitlyUnwrappedOptionals": false,
+        "NoAccessLevelOnExtensionDeclaration": false,
+        "NoAssignmentInExpressions": true,
         "NoBlockComments": false,
+        "NoCasesWithOnlyFallthrough": true,
+        "NoEmptyLinesOpeningClosingBraces": false,
+        "NoEmptyTrailingClosureParentheses": true,
+        "NoLabelsInCasePatterns": true,
+        "NoLeadingUnderscores": false,
+        "NoParensAroundConditions": true,
+        "NoPlaygroundLiterals": true,
         "NoVoidReturnOnFunctionSignature": true,
+        "OmitExplicitReturns": false,
+        "OneCasePerLine": true,
+        "OneVariableDeclarationPerLine": true,
+        "OnlyOneTrailingClosureArgument": true,
         "OrderedImports": true,
+        "ReplaceForEachWithForLoop": true,
         "ReturnVoidInsteadOfEmptyTuple": true,
+        "TypeNamesShouldBeCapitalized": true,
+        "UseEarlyExits": false,
+        "UseExplicitNilCheckInConditions": true,
         "UseLetInEveryBoundCaseVariable": false,
+        "UseShorthandTypeNames": true,
+        "UseSingleLinePropertyGetter": true,
         "UseSynthesizedInitializer": false,
+        "UseTripleSlashForDocumentationComments": true,
+        "UseWhereClausesInForLoops": false,
+        "ValidateDocumentationComments": false
     },
+    "spacesAroundRangeFormationOperators": false,
+    "spacesBeforeEndOfLineComments": 2,
     "version": 1,
 }

--- a/CodeGeneration/Sources/SyntaxSupport/Child.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Child.swift
@@ -129,11 +129,11 @@ public class Child: NodeChoiceConvertible {
 
   public var syntaxNodeKind: SyntaxNodeKind {
     switch kind {
-    case .node(kind: let kind):
+    case .node(let kind):
       return kind
     case .nodeChoices:
       return .syntax
-    case .collection(kind: let kind, _, _, _, _):
+    case .collection(let kind, _, _, _, _):
       return kind
     case .token:
       return .token
@@ -284,7 +284,7 @@ public class Child: NodeChoiceConvertible {
       return choices.isEmpty
     case .node(let kind):
       return kind.isBase
-    case .collection(kind: let kind, _, _, _, _):
+    case .collection(let kind, _, _, _, _):
       return kind.isBase
     case .token:
       return false

--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -41,7 +41,7 @@ struct GrammarGenerator {
     case .nodeChoices(let choices, _):
       let choicesDescriptions = choices.map { grammar(for: $0) }
       return "(\(choicesDescriptions.joined(separator: " | ")))\(optionality)"
-    case .collection(kind: let kind, _, _, _, _):
+    case .collection(let kind, _, _, _, _):
       return "\(kind.doccLink)\(optionality)"
     case .token(let choices, _, _):
       if choices.count == 1 {

--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -284,7 +284,7 @@ public struct LayoutNode {
   /// This includes unexpected children
   public var children: [Child] {
     switch node.data {
-    case .layout(children: let children, childHistory: _, traits: _):
+    case .layout(let children, childHistory: _, traits: _):
       return children
     case .collection:
       preconditionFailure("NodeLayoutView must wrap a Node with data `.layout`")
@@ -299,7 +299,7 @@ public struct LayoutNode {
   /// The history of the layout node's children.
   public var childHistory: Child.History {
     switch node.data {
-    case .layout(children: _, childHistory: let childHistory, traits: _):
+    case .layout(children: _, let childHistory, traits: _):
       return childHistory
     case .collection:
       preconditionFailure("NodeLayoutView must wrap a Node with data `.layout`")
@@ -309,7 +309,7 @@ public struct LayoutNode {
   /// Traits that the node conforms to.
   public var traits: [String] {
     switch node.data {
-    case .layout(children: _, childHistory: _, traits: let traits):
+    case .layout(children: _, childHistory: _, let traits):
       return traits
     case .collection:
       preconditionFailure("NodeLayoutView must wrap a Node with data `.layout`")
@@ -361,7 +361,7 @@ public struct CollectionNode {
     switch node.data {
     case .layout:
       preconditionFailure("NodeLayoutView must wrap a Node with data `.collection`")
-    case .collection(choices: let choices):
+    case .collection(let choices):
       return choices
     }
   }
@@ -391,7 +391,7 @@ fileprivate extension Child {
       return [kind]
     case .nodeChoices(let choices, _):
       return choices.flatMap(\.kinds)
-    case .collection(kind: let kind, _, _, _, _):
+    case .collection(let kind, _, _, _, _):
       return [kind]
     case .token:
       return [.token]
@@ -399,7 +399,7 @@ fileprivate extension Child {
   }
 }
 
-fileprivate func interleaveUnexpectedChildren(_ children: [Child]) -> [Child] {
+private func interleaveUnexpectedChildren(_ children: [Child]) -> [Child] {
   let liftedChildren = children.lazy.map(Optional.some)
   let pairedChildren = zip([nil] + liftedChildren, liftedChildren + [nil])
 

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -29,11 +29,11 @@ extension Child {
   public var buildableType: SyntaxBuildableType {
     let buildableKind: SyntaxOrTokenNodeKind
     switch kind {
-    case .node(kind: let kind):
+    case .node(let kind):
       buildableKind = .node(kind: kind)
     case .nodeChoices:
       buildableKind = .node(kind: .syntax)
-    case .collection(kind: let kind, _, _, _, _):
+    case .collection(let kind, _, _, _, _):
       buildableKind = .node(kind: kind)
     case .token:
       buildableKind = .token(self.tokenKind!)

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -122,7 +122,7 @@ public struct SyntaxBuildableType: Hashable {
   /// without any question marks attached.
   public var syntaxBaseName: TypeSyntax {
     switch kind {
-    case .node(kind: let kind):
+    case .node(let kind):
       return kind.syntaxType
     case .token:
       return "TokenSyntax"
@@ -150,7 +150,7 @@ public struct SyntaxBuildableType: Hashable {
   /// that can be used to build the collection.
   public var resultBuilderType: TypeSyntax {
     switch kind {
-    case .node(kind: let kind):
+    case .node(let kind):
       return TypeSyntax("\(raw: kind.uppercasedFirstWordRawValue)Builder")
     case .token:
       preconditionFailure("Tokens cannot be constructed using result builders")

--- a/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
@@ -226,7 +226,7 @@ struct GenerateSwiftSyntax: AsyncParsableCommand {
 
 }
 
-fileprivate func generateFile(
+private func generateFile(
   contents: @autoclosure () -> String,
   destination: URL,
   verbose: Bool

--- a/CodeGeneration/Sources/generate-swift-syntax/InitSignature+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/InitSignature+Extensions.swift
@@ -191,7 +191,7 @@ extension InitSignature {
   }
 }
 
-fileprivate func convertFromSyntaxProtocolToSyntaxType(
+private func convertFromSyntaxProtocolToSyntaxType(
   child: Child
 ) -> ExprSyntax {
   let childName = child.identifier
@@ -350,7 +350,7 @@ extension InitParameterMapping {
   func makeArgumentExpr() -> LabeledExprSyntax {
     let argValue =
       switch argument {
-      case .decl(olderChild: let olderChild):
+      case .decl(let olderChild):
         ExprSyntax(DeclReferenceExprSyntax(baseName: olderChild.baseCallName))
 
       case .nestedInit(let initArgs):

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
@@ -209,7 +209,7 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
                         }
 
                         ExprSyntax("assertAnyHasNoError(kind, \(raw: index), \(verifiedChoices))")
-                      case .token(choices: let choices, requiresLeadingSpace: _, requiresTrailingSpace: _):
+                      case .token(let choices, requiresLeadingSpace: _, requiresTrailingSpace: _):
                         let choices = ArrayExprSyntax {
                           for choice in choices {
                             switch choice {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/TriviaPiecesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/TriviaPiecesFile.swift
@@ -268,7 +268,7 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! generateIsHelpers(for: "RawTriviaPiece")
 }
 
-fileprivate func generateIsHelpers(for pieceName: TokenSyntax) throws -> ExtensionDeclSyntax {
+private func generateIsHelpers(for pieceName: TokenSyntax) throws -> ExtensionDeclSyntax {
   func generateHelper(_ header: SyntaxNodeString, trait: TriviaTraits) throws -> VariableDeclSyntax {
     try VariableDeclSyntax(header) {
       try SwitchExprSyntax("switch self") {

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -13,7 +13,7 @@
 import SyntaxSupport
 import XCTest
 
-fileprivate func assertNoFailures(
+private func assertNoFailures(
   _ failures: [ValidationFailure],
   message: String,
   file: StaticString = #filePath,
@@ -34,7 +34,7 @@ fileprivate func assertNoFailures(
   XCTFail(message, file: file, line: line)
 }
 
-fileprivate func assertFailuresMatchXFails(
+private func assertFailuresMatchXFails(
   _ failures: [ValidationFailure],
   expectedFailures: [ValidationFailure],
   file: StaticString = #filePath,

--- a/Examples/Sources/MacroExamples/Implementation/ComplexMacros/OptionSetMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/ComplexMacros/OptionSetMacro.swift
@@ -195,7 +195,7 @@ extension OptionSetMacro: MemberMacro {
     // Find all of the case elements.
     let caseElements: [EnumCaseElementSyntax] = optionsEnum.memberBlock.members.flatMap { member in
       guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
-        return Array<EnumCaseElementSyntax>()
+        return [EnumCaseElementSyntax]()
       }
 
       return Array(caseDecl.elements)

--- a/Examples/Sources/MacroExamples/Implementation/Expression/URLMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Expression/URLMacro.swift
@@ -29,7 +29,7 @@ public enum URLMacro: ExpressionMacro {
       throw CustomError.message("#URL requires a static string literal")
     }
 
-    guard let _ = URL(string: literalSegment.content.text) else {
+    guard URL(string: literalSegment.content.text) != nil else {
       throw CustomError.message("malformed url: \(argument)")
     }
 

--- a/Examples/Sources/MacroExamples/Implementation/Member/MetaEnumMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Member/MetaEnumMacro.swift
@@ -95,7 +95,7 @@ extension EnumDeclSyntax {
   var caseElements: [EnumCaseElementSyntax] {
     memberBlock.members.flatMap { member in
       guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
-        return Array<EnumCaseElementSyntax>()
+        return [EnumCaseElementSyntax]()
       }
 
       return Array(caseDecl.elements)

--- a/Sources/SwiftBasicFormat/InferIndentation.swift
+++ b/Sources/SwiftBasicFormat/InferIndentation.swift
@@ -124,7 +124,7 @@ private class IndentationInferrer: SyntaxVisitor {
   }
 }
 
-fileprivate extension Array<Int> {
+fileprivate extension [Int] {
   var sum: Int {
     return self.reduce(0) { return $0 + $1 }
   }

--- a/Sources/SwiftIDEUtils/DeclNameLocation.swift
+++ b/Sources/SwiftIDEUtils/DeclNameLocation.swift
@@ -68,9 +68,9 @@ public struct DeclNameLocation: Equatable {
       case .labeled(let firstName, let secondName):
         let endPosition = secondName?.upperBound ?? firstName.upperBound
         return firstName.lowerBound..<endPosition
-      case .labeledCall(label: let label, colon: let colon):
+      case .labeledCall(let label, let colon):
         return label.lowerBound..<colon.upperBound
-      case .unlabeled(argumentPosition: let argumentPosition):
+      case .unlabeled(let argumentPosition):
         return argumentPosition..<argumentPosition
       }
     }
@@ -78,11 +78,11 @@ public struct DeclNameLocation: Equatable {
     /// Shift the ranges `utf8Offset` bytes to the right, ie. add `utf8Offset` to the upper and lower bound.
     func advanced(by utf8Offset: Int) -> DeclNameLocation.Argument {
       switch self {
-      case .labeled(firstName: let firstName, secondName: let secondName):
+      case .labeled(let firstName, let secondName):
         return .labeled(firstName: firstName.advanced(by: utf8Offset), secondName: secondName?.advanced(by: utf8Offset))
-      case .labeledCall(label: let label, colon: let colon):
+      case .labeledCall(let label, let colon):
         return .labeledCall(label: label.advanced(by: utf8Offset), colon: colon.advanced(by: utf8Offset))
-      case .unlabeled(argumentPosition: let argumentPosition):
+      case .unlabeled(let argumentPosition):
         return .unlabeled(argumentPosition: argumentPosition.advanced(by: utf8Offset))
       }
     }
@@ -122,7 +122,7 @@ public struct DeclNameLocation: Equatable {
       switch self {
       case .noArguments:
         return .noArguments
-      case .call(let arguments, firstTrailingClosureIndex: let firstTrailingClosureIndex):
+      case .call(let arguments, let firstTrailingClosureIndex):
         return .call(
           arguments.map { $0.advanced(by: utf8Offset) },
           firstTrailingClosureIndex: firstTrailingClosureIndex

--- a/Sources/SwiftIDEUtils/SyntaxClassifier.swift
+++ b/Sources/SwiftIDEUtils/SyntaxClassifier.swift
@@ -55,7 +55,7 @@ extension RawTriviaPiece {
   }
 }
 
-fileprivate struct TokenKindAndText {
+private struct TokenKindAndText {
   let kind: RawTokenKind
   let text: SyntaxText
 

--- a/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
+++ b/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
@@ -188,7 +188,7 @@ class ActiveSyntaxRewriter: SyntaxRewriter {
 
       // Find #ifs within the list.
       if let ifConfigDecl = elementAsIfConfig(element),
-        (!retainFeatureCheckIfConfigs || !ifConfigDecl.containsFeatureCheck)
+        !retainFeatureCheckIfConfigs || !ifConfigDecl.containsFeatureCheck
       {
         // Retrieve the active `#if` clause
         let activeClause = activeClauses.activeClause(for: ifConfigDecl, diagnostics: &diagnostics)
@@ -392,7 +392,7 @@ class ActiveSyntaxRewriter: SyntaxRewriter {
 }
 
 /// Helper class to find a feature or compiler check.
-fileprivate class FindFeatureCheckVisitor: SyntaxVisitor {
+private class FindFeatureCheckVisitor: SyntaxVisitor {
   var foundFeatureCheck = false
 
   override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
@@ -411,7 +411,7 @@ fileprivate class FindFeatureCheckVisitor: SyntaxVisitor {
   override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
     if let calleeDeclRef = node.calledExpression.as(DeclReferenceExprSyntax.self),
       let calleeName = calleeDeclRef.simpleIdentifier?.name,
-      (calleeName == "compiler" || calleeName == "_compiler_version")
+      calleeName == "compiler" || calleeName == "_compiler_version"
     {
       foundFeatureCheck = true
     }

--- a/Sources/SwiftIfConfig/ConfiguredRegions.swift
+++ b/Sources/SwiftIfConfig/ConfiguredRegions.swift
@@ -174,7 +174,7 @@ extension SyntaxProtocol {
 }
 
 /// Helper class that walks a syntax tree looking for configured regions.
-fileprivate class ConfiguredRegionVisitor<Configuration: BuildConfiguration>: SyntaxVisitor {
+private class ConfiguredRegionVisitor<Configuration: BuildConfiguration>: SyntaxVisitor {
   let configuration: Configuration
 
   /// The regions we've found so far.

--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -47,22 +47,22 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
     case .unknownExpression:
       return "invalid conditional compilation expression"
 
-    case .unhandledFunction(name: let name, syntax: _):
+    case .unhandledFunction(let name, syntax: _):
       return "build configuration cannot handle '\(name)'"
 
-    case .requiresUnlabeledArgument(name: let name, role: let role, syntax: _):
+    case .requiresUnlabeledArgument(let name, let role, syntax: _):
       return "'\(name)' requires a single unlabeled argument for the \(role)"
 
-    case .unsupportedVersionOperator(name: let name, operator: let op):
+    case .unsupportedVersionOperator(let name, operator: let op):
       return "'\(name)' version check does not support operator '\(op.trimmedDescription)'"
 
-    case .invalidVersionOperand(name: let name, syntax: let version):
+    case .invalidVersionOperand(let name, syntax: let version):
       return "'\(name)' version check has invalid version '\(version.trimmedDescription)'"
 
     case .emptyVersionComponent(syntax: _):
       return "found empty version component"
 
-    case .compilerVersionOutOfRange(value: let value, upperLimit: let upperLimit, syntax: _):
+    case .compilerVersionOutOfRange(let value, let upperLimit, syntax: _):
       return "compiler version component '\(value)' is not in the allowed range 0...\(upperLimit)"
 
     case .compilerVersionSecondComponentNotWildcard(syntax: _):
@@ -80,10 +80,10 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
     case .canImportTwoParameters(syntax: _):
       return "'canImport' can take only two parameters"
 
-    case .ignoredTrailingComponents(version: let version, syntax: _):
+    case .ignoredTrailingComponents(let version, syntax: _):
       return "trailing components of version '\(version.description)' are ignored"
 
-    case .integerLiteralCondition(syntax: let syntax, replacement: let replacement):
+    case .integerLiteralCondition(let syntax, let replacement):
       return "'\(syntax.trimmedDescription)' is not a valid conditional compilation expression, use '\(replacement)'"
 
     case .likelySimulatorPlatform:
@@ -121,26 +121,26 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
   var syntax: Syntax {
     switch self {
     case .unknownExpression(let syntax),
-      .unhandledFunction(name: _, syntax: let syntax),
-      .requiresUnlabeledArgument(name: _, role: _, syntax: let syntax),
-      .invalidVersionOperand(name: _, syntax: let syntax),
-      .emptyVersionComponent(syntax: let syntax),
-      .compilerVersionOutOfRange(value: _, upperLimit: _, syntax: let syntax),
-      .compilerVersionTooManyComponents(syntax: let syntax),
-      .compilerVersionSecondComponentNotWildcard(syntax: let syntax),
-      .canImportMissingModule(syntax: let syntax),
-      .canImportLabel(syntax: let syntax),
-      .canImportTwoParameters(syntax: let syntax),
-      .ignoredTrailingComponents(version: _, syntax: let syntax),
-      .integerLiteralCondition(syntax: let syntax, replacement: _),
-      .likelySimulatorPlatform(syntax: let syntax),
-      .likelyTargetOS(syntax: let syntax, replacement: _),
-      .endiannessDoesNotMatch(syntax: let syntax, argument: _),
-      .macabiIsMacCatalyst(syntax: let syntax),
-      .expectedModuleName(syntax: let syntax),
-      .badInfixOperator(syntax: let syntax),
-      .badPrefixOperator(syntax: let syntax),
-      .unexpectedDefined(syntax: let syntax, argument: _):
+      .unhandledFunction(name: _, let syntax),
+      .requiresUnlabeledArgument(name: _, role: _, let syntax),
+      .invalidVersionOperand(name: _, let syntax),
+      .emptyVersionComponent(let syntax),
+      .compilerVersionOutOfRange(value: _, upperLimit: _, let syntax),
+      .compilerVersionTooManyComponents(let syntax),
+      .compilerVersionSecondComponentNotWildcard(let syntax),
+      .canImportMissingModule(let syntax),
+      .canImportLabel(let syntax),
+      .canImportTwoParameters(let syntax),
+      .ignoredTrailingComponents(version: _, let syntax),
+      .integerLiteralCondition(let syntax, replacement: _),
+      .likelySimulatorPlatform(let syntax),
+      .likelyTargetOS(let syntax, replacement: _),
+      .endiannessDoesNotMatch(let syntax, argument: _),
+      .macabiIsMacCatalyst(let syntax),
+      .expectedModuleName(let syntax),
+      .badInfixOperator(let syntax),
+      .badPrefixOperator(let syntax),
+      .unexpectedDefined(let syntax, argument: _):
       return Syntax(syntax)
 
     case .unsupportedVersionOperator(name: _, operator: let op):

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -79,7 +79,7 @@ func evaluateIfConfig(
 
   // Integer literals aren't allowed, but we recognize them.
   if let intLiteral = condition.as(IntegerLiteralExprSyntax.self),
-    (intLiteral.literal.text == "0" || intLiteral.literal.text == "1")
+    intLiteral.literal.text == "0" || intLiteral.literal.text == "1"
   {
     let result = intLiteral.literal.text == "1"
 

--- a/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
+++ b/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
@@ -56,7 +56,7 @@ extension VersionTuple {
 
     /// Record a component after checking its value.
     func recordComponent(_ value: Int) throws {
-      let limit = components.isEmpty ? 9223371 : 999
+      let limit = components.isEmpty ? 9_223_371 : 999
       if value < 0 || value > limit {
         throw IfConfigDiagnostic.compilerVersionOutOfRange(value: value, upperLimit: limit, syntax: versionSyntax)
       }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -53,7 +53,7 @@ extension TokenConsumer {
     }
 
     // 'repeat' is the start of a pack expansion expression.
-    if (self.at(.keyword(.repeat))) {
+    if self.at(.keyword(.repeat)) {
       // FIXME: 'repeat' followed by '{' could still be a pack
       // expansion, but we need to do more lookahead to figure out
       // whether the '{' is the start of a closure expression or a
@@ -2551,7 +2551,7 @@ extension Parser.Lookahead {
     // Consume attributes.
     var lookahead = self.lookahead()
     var attributesProgress = LoopProgressCondition()
-    while let _ = lookahead.consume(if: .atSign), lookahead.hasProgressed(&attributesProgress) {
+    while lookahead.consume(if: .atSign) != nil, lookahead.hasProgressed(&attributesProgress) {
       guard lookahead.at(.identifier) else {
         break
       }

--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -208,7 +208,7 @@ struct IncrementalParseLookup {
 
 /// Functions as an iterator that walks the tree looking for nodes with a
 /// certain position.
-fileprivate struct SyntaxCursor {
+private struct SyntaxCursor {
   var node: Syntax
   var finished: Bool
   let viewMode = SyntaxTreeViewMode.sourceAccurate

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -176,7 +176,7 @@ extension Lexer.Cursor {
 
     mutating func perform(stateTransition: Lexer.StateTransition, stateAllocator: BumpPtrAllocator) {
       switch stateTransition {
-      case .push(newState: let newState):
+      case .push(let newState):
         if let topState {
           if let stateStack = stateStack {
             let newStateStack = stateAllocator.allocate(State.self, count: stateStack.count + 1)
@@ -197,7 +197,7 @@ extension Lexer.Cursor {
           ),
           stateAllocator: stateAllocator
         )
-      case .replace(newState: let newState):
+      case .replace(let newState):
         topState = newState
       case .pop:
         if let stateStack {
@@ -449,17 +449,17 @@ extension Lexer.Cursor {
       // In this state we lex a single token with the flag set, and then pop the state.
       result = lexNormal(sourceBufferStart: sourceBufferStart, preferRegexOverBinaryOperator: true)
       self.stateStack.perform(stateTransition: .pop, stateAllocator: stateAllocator)
-    case .afterRawStringDelimiter(delimiterLength: let delimiterLength):
+    case .afterRawStringDelimiter(let delimiterLength):
       result = lexAfterRawStringDelimiter(delimiterLength: delimiterLength)
-    case .inStringLiteral(kind: let stringLiteralKind, delimiterLength: let delimiterLength):
+    case .inStringLiteral(kind: let stringLiteralKind, let delimiterLength):
       result = lexInStringLiteral(stringLiteralKind: stringLiteralKind, delimiterLength: delimiterLength)
     case .afterStringLiteral(isRawString: _):
       result = lexAfterStringLiteral()
     case .afterClosingStringQuote:
       result = lexAfterClosingStringQuote()
-    case .inStringInterpolationStart(stringLiteralKind: let stringLiteralKind):
+    case .inStringInterpolationStart(let stringLiteralKind):
       result = lexInStringInterpolationStart(stringLiteralKind: stringLiteralKind)
-    case .inStringInterpolation(stringLiteralKind: let stringLiteralKind, parenCount: let parenCount):
+    case .inStringInterpolation(let stringLiteralKind, let parenCount):
       result = lexInStringInterpolation(
         stringLiteralKind: stringLiteralKind,
         parenCount: parenCount,
@@ -903,7 +903,7 @@ extension Lexer.Cursor {
 
     case "/":
       // A following comment counts as whitespace, so this token is not right bound.
-      if (self.is(offset: 1, at: "/", "*")) {
+      if self.is(offset: 1, at: "/", "*") {
         return false
       } else {
         return true
@@ -1800,7 +1800,7 @@ extension Lexer.Cursor {
       return .replace(newState: .afterClosingStringQuote)
     case .afterStringLiteral(isRawString: false):
       return .pop
-    case .afterRawStringDelimiter(delimiterLength: let delimiterLength):
+    case .afterRawStringDelimiter(let delimiterLength):
       return .replace(newState: .inStringLiteral(kind: kind, delimiterLength: delimiterLength))
     case .normal, .preferRegexOverBinaryOperator, .inStringInterpolation:
       return .push(newState: .inStringLiteral(kind: kind, delimiterLength: 0))
@@ -2161,14 +2161,14 @@ extension Lexer.Cursor {
       case ".":
         return (.period, error: nil)
       case "?":
-        if (leftBound) {
+        if leftBound {
           return (.postfixQuestionMark, error: nil)
         }
         return (.infixQuestionMark, error: nil)
       default:
         break
       }
-    } else if (operEnd.input.baseAddress! - operStart.input.baseAddress! == 2) {
+    } else if operEnd.input.baseAddress! - operStart.input.baseAddress! == 2 {
       switch (operStart.peek(), operStart.peek(at: 1)) {
       case ("-", ">"):  // ->
         return (.arrow, error: nil)

--- a/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
+++ b/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
@@ -17,7 +17,7 @@
 #endif
 
 /// A separate lexer specifically for regex literals.
-fileprivate struct RegexLiteralLexer {
+private struct RegexLiteralLexer {
   enum LexResult {
     /// Continue the lex, this is returned from `lexPatternCharacter` when
     /// it successfully lexed a character.

--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -74,7 +74,7 @@ extension Unicode.Scalar {
   }
 
   var isValidIdentifierStartCodePoint: Bool {
-    if (self.isASCII) {
+    if self.isASCII {
       return self.isAsciiIdentifierStart
     }
     guard self.isValidIdentifierContinuationCodePoint else {
@@ -84,8 +84,8 @@ extension Unicode.Scalar {
     // N1518: Recommendations for extended identifier characters for C and C++
     // Proposed Annex X.2: Ranges of characters disallowed initially
     let c = self.value
-    if ((c >= 0x0300 && c <= 0x036F) || (c >= 0x1DC0 && c <= 0x1DFF) || (c >= 0x20D0 && c <= 0x20FF)
-      || (c >= 0xFE20 && c <= 0xFE2F))
+    if (c >= 0x0300 && c <= 0x036F) || (c >= 0x1DC0 && c <= 0x1DFF) || (c >= 0x20D0 && c <= 0x20FF)
+      || (c >= 0xFE20 && c <= 0xFE2F)
     {
       return false
     }
@@ -183,7 +183,7 @@ extension Unicode.Scalar {
       return nil
     }
 
-    if (curByte < 0x80) {
+    if curByte < 0x80 {
       return Unicode.Scalar(curByte)
     }
 
@@ -216,7 +216,7 @@ extension Unicode.Scalar {
       }
       // If the high bit isn't set or the second bit isn't clear, then this is not
       // a continuation byte!
-      if (curByte < 0x80 || curByte >= 0xC0) {
+      if curByte < 0x80 || curByte >= 0xC0 {
         return nil
       }
 

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -212,7 +212,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    while let _ = self.consume(if: .atSign) {
+    while self.consume(if: .atSign) != nil {
       // Consume qualified names that may or may not involve generic arguments.
       repeat {
         self.consume(if: .identifier, .keyword(.rethrows))
@@ -402,7 +402,7 @@ extension Parser.Lookahead {
         case nil:
           self.consumeAnyToken()
         }
-      case .skipSinglePost(start: let start):
+      case .skipSinglePost(let start):
         switch start {
         case .leftParen:
           self.consume(if: .rightParen)

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -699,7 +699,7 @@ extension Parser {
         self.missingToken(.identifier)
       )
     } else if keywordRecovery,
-      (self.currentToken.isLexerClassifiedKeyword || self.at(.wildcard)),
+      self.currentToken.isLexerClassifiedKeyword || self.at(.wildcard),
       !self.atStartOfLine
     {
       let keyword = self.consumeAnyToken()

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -18,7 +18,7 @@
 
 // MARK: - Check multiline string literal indentation
 
-fileprivate class StringLiteralExpressionIndentationChecker {
+private class StringLiteralExpressionIndentationChecker {
   // MARK: Entry
 
   init(expectedIndentation: SyntaxText, arena: RawSyntaxArena) {

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -55,9 +55,9 @@ enum TokenPrecedence: Comparable {
   /// If the precedence is `weakBracketed` or `strongBracketed`, the closing delimiter of the bracketed group.
   var closingTokenKind: RawTokenKind? {
     switch self {
-    case .weakBracketed(closingDelimiter: let closingDelimiter):
+    case .weakBracketed(let closingDelimiter):
       return closingDelimiter
-    case .openingBrace(closingDelimiter: let closingDelimiter):
+    case .openingBrace(let closingDelimiter):
       return closingDelimiter
     case .openingPoundIf:
       return .poundEndif

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -20,7 +20,7 @@ import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
 #endif
 
-fileprivate let diagnosticDomain: String = "SwiftLexer"
+private let diagnosticDomain: String = "SwiftLexer"
 
 /// An error diagnostic whose ID is determined by the diagnostic's type.
 public protocol TokenError: DiagnosticMessage {

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -23,7 +23,7 @@ import SwiftDiagnostics
 // MARK: - Shared code
 
 /// Returns the bottommost node that is an ancestor of all nodes in `nodes`.
-fileprivate func findCommonAncestor(_ nodes: [Syntax]) -> Syntax? {
+private func findCommonAncestor(_ nodes: [Syntax]) -> Syntax? {
   return findCommonAncestorOrSelf(nodes.compactMap({ $0.parent }))
 }
 
@@ -35,7 +35,7 @@ class NoNewlinesFormat: BasicFormat {
   }
 }
 
-fileprivate enum NodesDescriptionPart {
+private enum NodesDescriptionPart {
   case tokensWithDefaultText([TokenSyntax])
   case tokenWithoutDefaultText(TokenSyntax)
   case node(Syntax)
@@ -232,7 +232,7 @@ fileprivate extension TokenKind {
 }
 
 /// Checks whether a node contains any tokens (missing or present)
-fileprivate class HasTokenChecker: SyntaxAnyVisitor {
+private class HasTokenChecker: SyntaxAnyVisitor {
   var hasToken: Bool = false
 
   override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -20,7 +20,7 @@ import SwiftDiagnostics
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 #endif
 
-fileprivate func getTokens(between first: TokenSyntax, and second: TokenSyntax) -> [TokenSyntax] {
+private func getTokens(between first: TokenSyntax, and second: TokenSyntax) -> [TokenSyntax] {
   var first = first
   if first.presence == .missing {
     let nextPresentToken = first.nextToken(viewMode: .sourceAccurate)

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -20,7 +20,7 @@ import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
 #endif
 
-fileprivate let diagnosticDomain: String = "SwiftParser"
+private let diagnosticDomain: String = "SwiftParser"
 
 /// An error diagnostic whose ID is determined by the diagnostic's type.
 public protocol ParserError: DiagnosticMessage {

--- a/Sources/SwiftRefactor/ExpandEditorPlaceholder.swift
+++ b/Sources/SwiftRefactor/ExpandEditorPlaceholder.swift
@@ -496,5 +496,5 @@ public func wrapInTypePlaceholder(_ str: String, type: String) -> String {
   return wrapInPlaceholder("T##" + str + "##" + type)
 }
 
-fileprivate let placeholderStart: String = "<#"
-fileprivate let placeholderEnd: String = "#>"
+private let placeholderStart: String = "<#"
+private let placeholderEnd: String = "#>"

--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -18,7 +18,7 @@ import SwiftSyntax
 
 /// Describes a "some" parameter that has been rewritten into a generic
 /// parameter.
-fileprivate struct RewrittenSome {
+private struct RewrittenSome {
   let original: SomeOrAnyTypeSyntax
   let genericParam: GenericParameterSyntax
   let genericParamRef: IdentifierTypeSyntax
@@ -37,7 +37,7 @@ fileprivate struct RewrittenSome {
 /// ```swift
 /// func someFunction<T1: Value>(_ input: T1) {}
 /// ```
-fileprivate class SomeParameterRewriter: SyntaxRewriter {
+private class SomeParameterRewriter: SyntaxRewriter {
   var rewrittenSomeParameters: [RewrittenSome] = []
 
   override func visit(_ node: SomeOrAnyTypeSyntax) -> TypeSyntax {

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -227,7 +227,7 @@ public struct RawSyntax: Sendable {
   }
 
   internal var payload: RawSyntaxData.Payload {
-    get { rawData.payload }
+    rawData.payload
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
@@ -271,7 +271,7 @@ struct RawSyntaxArenaRef: Hashable, @unchecked Sendable {
 
   /// Returns the ``RawSyntaxArena``
   private var value: RawSyntaxArena {
-    get { self._value.takeUnretainedValue() }
+    self._value.takeUnretainedValue()
   }
 
   /// Assuming that this references a `ParsingRawSyntaxArena`,

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -103,7 +103,7 @@ public struct SourceRange: Hashable, Codable, Sendable {
   }
 }
 
-fileprivate struct SourceLocationDirectiveArguments {
+private struct SourceLocationDirectiveArguments {
   enum Error: Swift.Error, CustomStringConvertible {
     case nonDecimalLineNumber(TokenSyntax)
     case stringInterpolationInFileName(SimpleStringLiteralExprSyntax)
@@ -685,7 +685,7 @@ private func computeLines(tree: Syntax) -> SourceLineTable {
 }
 
 /// Compute ``SourceLineTable`` from a ``SyntaxText``.
-fileprivate func computeLines(text: SyntaxText) -> SourceLineTable {
+private func computeLines(text: SyntaxText) -> SourceLineTable {
   var lineEnds: [AbsolutePosition] = []
   let endPos = text.forEachEndOfLine(position: .startOfFile) { pos in
     lineEnds.append(pos)

--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -37,9 +37,9 @@ import os
 /// Only set from `withStringInterpolationParsingErrorsSuppressed`, which is only intended for testing purposes that are
 /// single-threaded.
 #if swift(>=6)
-fileprivate nonisolated(unsafe) var suppressStringInterpolationParsingErrors = false
+private nonisolated(unsafe) var suppressStringInterpolationParsingErrors = false
 #else
-fileprivate var suppressStringInterpolationParsingErrors = false
+private var suppressStringInterpolationParsingErrors = false
 #endif
 
 /// Run the body, disabling any runtime warnings about syntax error in string

--- a/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
@@ -61,7 +61,7 @@ extension String {
 
 // MARK: SyntaxProtocol.stripp
 
-fileprivate class IndentationStripper: SyntaxRewriter {
+private class IndentationStripper: SyntaxRewriter {
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
     if token.leadingTrivia.contains(where: \.isNewline) || token.trailingTrivia.contains(where: \.isNewline) {
       return

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -103,7 +103,7 @@ extension MacroDefinition {
   }
 }
 
-fileprivate class ParameterReplacementVisitor: OnlyLiteralExprChecker {
+private class ParameterReplacementVisitor: OnlyLiteralExprChecker {
   let macro: MacroDeclSyntax
   var replacements: [MacroDefinition.Replacement] = []
   var genericReplacements: [MacroDefinition.GenericArgumentReplacement] = []

--- a/Sources/SwiftSyntaxMacros/MacroExpansionDiagnosticMessages.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionDiagnosticMessages.swift
@@ -16,7 +16,7 @@ public import SwiftDiagnostics
 import SwiftDiagnostics
 #endif
 
-fileprivate let diagnosticDomain: String = "SwiftSyntaxMacros"
+private let diagnosticDomain: String = "SwiftSyntaxMacros"
 
 /// An error during macro expansion that is described by its message.
 ///

--- a/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
@@ -633,7 +633,7 @@ fileprivate extension FixIt.Change {
         replacement: replacingChildData.newChild.description
       )
 
-    case .replaceText(range: let range, with: let newText, in: let syntax):
+    case .replaceText(let range, with: let newText, in: let syntax):
       let start = expansionContext.position(of: range.lowerBound, anchoredAt: syntax)
       let end = expansionContext.position(of: range.upperBound, anchoredAt: syntax)
       return SourceEdit(range: start..<end, replacement: newText)

--- a/Sources/_SwiftSyntaxTestSupport/LocationMarkers.swift
+++ b/Sources/_SwiftSyntaxTestSupport/LocationMarkers.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Finds all marked ranges in the given text, see `Marker`.
-fileprivate func findMarkedRanges(text: String) -> [Marker] {
+private func findMarkedRanges(text: String) -> [Marker] {
   var markers = [Marker]()
   while let marker = nextMarkedRange(text: text, from: markers.last?.range.upperBound ?? text.startIndex) {
     markers.append(marker)
@@ -29,7 +29,7 @@ extension Character {
   }
 }
 
-fileprivate func nextMarkedRange(text: String, from: String.Index) -> Marker? {
+private func nextMarkedRange(text: String, from: String.Index) -> Marker? {
   guard let start = text[from...].firstIndex(where: { $0.isMarkerEmoji }) else {
     return nil
   }
@@ -41,7 +41,7 @@ fileprivate func nextMarkedRange(text: String, from: String.Index) -> Marker? {
   return Marker(name: name, range: markerRange)
 }
 
-fileprivate struct Marker {
+private struct Marker {
   /// The name of the marker.
   let name: Substring
   /// The range of the marker.

--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -170,7 +170,7 @@ public enum SubtreeError: Error, CustomStringConvertible {
   }
 }
 
-fileprivate class SyntaxTypeFinder: SyntaxAnyVisitor {
+private class SyntaxTypeFinder: SyntaxAnyVisitor {
   private let offset: Int
   private let type: SyntaxProtocol.Type
   private var found: Syntax?

--- a/SwiftParserCLI/Sources/swift-parser-cli/BasicFormat.swift
+++ b/SwiftParserCLI/Sources/swift-parser-cli/BasicFormat.swift
@@ -23,7 +23,7 @@ struct BasicFormat: ParsableCommand, ParseCommand {
 
     var description: String {
       switch self {
-      case .unknownSyntaxNodeType(nodeType: let nodeType, parsableTypes: let parsableTypes):
+      case .unknownSyntaxNodeType(let nodeType, let parsableTypes):
         return """
           '\(nodeType)' is not a SwiftSyntax node type that conforms to SyntaxParsable. Possible options are:
           \(parsableTypes.map {" - \($0)" }.joined(separator: "\n"))

--- a/SwiftParserCLI/Sources/swift-parser-cli/Commands/Reduce.swift
+++ b/SwiftParserCLI/Sources/swift-parser-cli/Commands/Reduce.swift
@@ -17,7 +17,7 @@ import Foundation
 import WinSDK
 #endif
 
-fileprivate func withTemporaryFile<T>(contents: [UInt8], body: (URL) throws -> T) throws -> T {
+private func withTemporaryFile<T>(contents: [UInt8], body: (URL) throws -> T) throws -> T {
   var tempFileURL = FileManager.default.temporaryDirectory
   tempFileURL.appendPathComponent("swift-parser-cli-\(UUID().uuidString).swift")
   try Data(contents).write(to: tempFileURL)

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifySourceCode.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifySourceCode.swift
@@ -14,7 +14,7 @@ import ArgumentParser
 import Foundation
 import RegexBuilder
 
-fileprivate let modules: [String] = [
+private let modules: [String] = [
   "SwiftParser",
   "SwiftParserDiagnostics",
   "SwiftSyntax",

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Paths.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Paths.swift
@@ -114,7 +114,7 @@ enum Paths {
 
     var description: String {
       switch self {
-      case .notFound(executableName: let executableName):
+      case .notFound(let executableName):
         return "Executable \(executableName) not found in PATH"
       }
     }

--- a/Tests/PerformanceTest/InstructionsCountAssertion.swift
+++ b/Tests/PerformanceTest/InstructionsCountAssertion.swift
@@ -13,7 +13,7 @@
 import XCTest
 import _InstructionCounter
 
-fileprivate var baselineURL: URL {
+private var baselineURL: URL {
   if let baselineFile = ProcessInfo.processInfo.environment["BASELINE_FILE"] {
     return URL(fileURLWithPath: baselineFile)
   } else {

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 import XCTest
 import _SwiftSyntaxTestSupport
 
-fileprivate func assertFormatted<T: SyntaxProtocol>(
+private func assertFormatted<T: SyntaxProtocol>(
   tree: T,
   expected: String,
   using format: BasicFormat = BasicFormat(indentationWidth: .spaces(4)),
@@ -27,7 +27,7 @@ fileprivate func assertFormatted<T: SyntaxProtocol>(
   assertStringsEqualWithDiff(tree.formatted(using: format).description, expected, file: file, line: line)
 }
 
-fileprivate func assertFormatted(
+private func assertFormatted(
   source: String,
   expected: String,
   using format: BasicFormat = BasicFormat(indentationWidth: .spaces(4)),
@@ -43,7 +43,7 @@ fileprivate func assertFormatted(
   )
 }
 
-fileprivate func assertFormattingRoundTrips(
+private func assertFormattingRoundTrips(
   _ source: String,
   using format: BasicFormat = BasicFormat(indentationWidth: .spaces(4)),
   file: StaticString = #filePath,

--- a/Tests/SwiftBasicFormatTest/IndentTests.swift
+++ b/Tests/SwiftBasicFormatTest/IndentTests.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 import XCTest
 import _SwiftSyntaxTestSupport
 
-fileprivate func assertIndented(
+private func assertIndented(
   by indentation: Trivia = .tab,
   indentFirstLine: Bool = true,
   source: String,

--- a/Tests/SwiftBasicFormatTest/InferIndentationTests.swift
+++ b/Tests/SwiftBasicFormatTest/InferIndentationTests.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import XCTest
 
-fileprivate func assertIndentation(
+private func assertIndentation(
   of sourceFile: SourceFileSyntax,
   _ expected: Trivia?,
   file: StaticString = #filePath,

--- a/Tests/SwiftCompilerPluginTest/JSONTests.swift
+++ b/Tests/SwiftCompilerPluginTest/JSONTests.swift
@@ -254,29 +254,29 @@ final class JSONTests: XCTestCase {
 
 // MARK: - Test Types
 
-fileprivate struct EmptyStruct: Codable, Equatable {
+private struct EmptyStruct: Codable, Equatable {
   static func == (_ lhs: EmptyStruct, _ rhs: EmptyStruct) -> Bool {
     return true
   }
 }
 
-fileprivate class EmptyClass: Codable, Equatable {
+private class EmptyClass: Codable, Equatable {
   static func == (_ lhs: EmptyClass, _ rhs: EmptyClass) -> Bool {
     return true
   }
 }
 
-fileprivate enum Direction: Codable {
+private enum Direction: Codable {
   case right
   case left
 }
 
-fileprivate enum Animal: String, Codable {
+private enum Animal: String, Codable {
   case dog
   case cat
 }
 
-fileprivate enum Switch: Codable {
+private enum Switch: Codable {
   case off
   case on
 
@@ -297,14 +297,14 @@ fileprivate enum Switch: Codable {
   }
 }
 
-fileprivate enum Tree: Codable, Equatable {
-  indirect case int(Int)
-  indirect case string(String)
-  indirect case array([Self])
-  indirect case dictionary([String: Self])
+private indirect enum Tree: Codable, Equatable {
+  case int(Int)
+  case string(String)
+  case array([Self])
+  case dictionary([String: Self])
 }
 
-fileprivate struct ComplexStruct: Codable, Equatable {
+private struct ComplexStruct: Codable, Equatable {
   struct Diagnostic: Codable, Equatable {
     var message: String
     var animal: Animal

--- a/Tests/SwiftIDEUtilsTest/Assertions.swift
+++ b/Tests/SwiftIDEUtilsTest/Assertions.swift
@@ -32,7 +32,7 @@ func assertClassification(
 ) {
   let tree = Parser.parse(source: source)
 
-  var classifications: Array<SyntaxClassifiedRange>
+  var classifications: [SyntaxClassifiedRange]
   if let range {
     classifications = Array(tree.classifications(in: range))
   } else {

--- a/Tests/SwiftIfConfigTest/ActiveRegionTests.swift
+++ b/Tests/SwiftIfConfigTest/ActiveRegionTests.swift
@@ -125,7 +125,7 @@ public class ActiveRegionTests: XCTestCase {
 
 /// Assert that the various marked positions in the source code have the
 /// expected active states.
-fileprivate func assertActiveCode(
+private func assertActiveCode(
   _ markedSource: String,
   configuration: some BuildConfiguration = TestingBuildConfiguration(),
   states: [String: IfConfigRegionState],

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -592,7 +592,7 @@ public class EvaluateTests: XCTestCase {
 
 /// Assert the results of evaluating the condition within an `#if` against the
 /// given build configuration.
-fileprivate func assertIfConfig(
+private func assertIfConfig(
   _ condition: ExprSyntax,
   _ expectedState: IfConfigRegionState,
   configuration: some BuildConfiguration = TestingBuildConfiguration(),

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -399,7 +399,7 @@ extension VisitorTests {
 
 /// Assert that removing any inactive code according to the given build
 /// configuration returns the expected source and diagnostics.
-fileprivate func assertRemoveInactive(
+private func assertRemoveInactive(
   _ source: String,
   configuration: some BuildConfiguration,
   retainFeatureCheckIfConfigs: Bool = false,

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
-fileprivate func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Void) rethrows {
+private func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Void) rethrows {
   let lookaheadTracker = UnsafeMutablePointer<LookaheadTracker>.allocate(capacity: 1)
   defer {
     lookaheadTracker.deallocate()
@@ -37,7 +37,7 @@ fileprivate func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Vo
 /// values for trivia and text. While this is good for most cases, string
 /// literals can't contain invalid UTF-8. Thus, we need a different assert
 /// function working on byte arrays to test source code containing invalid UTF-8.
-fileprivate func assertRawBytesLexeme(
+private func assertRawBytesLexeme(
   _ lexeme: Lexer.Lexeme,
   kind: RawTokenKind,
   leadingTrivia: [UInt8] = [],

--- a/Tests/SwiftRefactorTest/CallToTrailingClosureTests.swift
+++ b/Tests/SwiftRefactorTest/CallToTrailingClosureTests.swift
@@ -249,7 +249,7 @@ final class CallToTrailingClosuresTest: XCTestCase {
   }
 }
 
-fileprivate func assertRefactorCall(
+private func assertRefactorCall(
   _ callExpr: ExprSyntax,
   startAtArgument: Int = 0,
   expected: ExprSyntax?,

--- a/Tests/SwiftRefactorTest/ConvertComputedPropertyToStoredTest.swift
+++ b/Tests/SwiftRefactorTest/ConvertComputedPropertyToStoredTest.swift
@@ -146,7 +146,7 @@ final class ConvertComputedPropertyToStoredTest: XCTestCase {
   }
 }
 
-fileprivate func assertRefactorConvert(
+private func assertRefactorConvert(
   _ callDecl: DeclSyntax,
   expected: DeclSyntax?,
   file: StaticString = #filePath,

--- a/Tests/SwiftRefactorTest/ConvertComputedPropertyToZeroParameterFunctionTests.swift
+++ b/Tests/SwiftRefactorTest/ConvertComputedPropertyToZeroParameterFunctionTests.swift
@@ -301,7 +301,7 @@ final class ConvertComputedPropertyToZeroParameterFunctionTests: XCTestCase {
   }
 }
 
-fileprivate func assertRefactorConvert(
+private func assertRefactorConvert(
   _ callDecl: DeclSyntax,
   expected: DeclSyntax?,
   file: StaticString = #filePath,

--- a/Tests/SwiftRefactorTest/ConvertStoredPropertyToComputedTest.swift
+++ b/Tests/SwiftRefactorTest/ConvertStoredPropertyToComputedTest.swift
@@ -172,7 +172,7 @@ final class ConvertStoredPropertyToComputedTest: XCTestCase {
   }
 }
 
-fileprivate func assertRefactorConvert(
+private func assertRefactorConvert(
   _ callDecl: DeclSyntax,
   expected: DeclSyntax?,
   file: StaticString = #filePath,

--- a/Tests/SwiftRefactorTest/ConvertZeroParameterFunctionToComputedPropertyTests.swift
+++ b/Tests/SwiftRefactorTest/ConvertZeroParameterFunctionToComputedPropertyTests.swift
@@ -140,7 +140,7 @@ final class ConvertZeroParameterFunctionToComputedPropertyTests: XCTestCase {
   }
 }
 
-fileprivate func assertRefactorConvert(
+private func assertRefactorConvert(
   _ callDecl: DeclSyntax,
   expected: DeclSyntax?,
   file: StaticString = #filePath,

--- a/Tests/SwiftRefactorTest/ExpandEditorPlaceholderTests.swift
+++ b/Tests/SwiftRefactorTest/ExpandEditorPlaceholderTests.swift
@@ -18,16 +18,16 @@ import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 
-fileprivate let closurePlaceholder = wrapInPlaceholder("T##closure##() -> Void")
-fileprivate let closureWithArgPlaceholder = wrapInPlaceholder(
+private let closurePlaceholder = wrapInPlaceholder("T##closure##() -> Void")
+private let closureWithArgPlaceholder = wrapInPlaceholder(
   "T##(Int) -> String##(Int) -> String##(_ someInt: Int) -> String"
 )
-fileprivate let closureCombinedTypeDisplayPlaceholder = wrapInPlaceholder(
+private let closureCombinedTypeDisplayPlaceholder = wrapInPlaceholder(
   "T##(Int) -> String"
 )
-fileprivate let voidPlaceholder = wrapInPlaceholder("T##code##Void")
-fileprivate let intPlaceholder = wrapInPlaceholder("T##Int##Int")
-fileprivate let stringPlaceholder = wrapInPlaceholder("T##String##String")
+private let voidPlaceholder = wrapInPlaceholder("T##code##Void")
+private let intPlaceholder = wrapInPlaceholder("T##Int##Int")
+private let stringPlaceholder = wrapInPlaceholder("T##String##String")
 
 final class ExpandEditorPlaceholderTests: XCTestCase {
   func testSimple() throws {
@@ -505,7 +505,7 @@ final class ExpandEditorPlaceholderTests: XCTestCase {
   }
 }
 
-fileprivate func assertRefactorPlaceholder(
+private func assertRefactorPlaceholder(
   _ placeholder: String,
   wrap: Bool = true,
   expected: String,
@@ -532,7 +532,7 @@ fileprivate func assertRefactorPlaceholder(
   )
 }
 
-fileprivate func assertRefactorPlaceholderCall(
+private func assertRefactorPlaceholderCall(
   _ expr: String,
   placeholder: Int = 0,
   expected: String,
@@ -556,7 +556,7 @@ fileprivate func assertRefactorPlaceholderCall(
   )
 }
 
-fileprivate func assertRefactorPlaceholderToken(
+private func assertRefactorPlaceholderToken(
   _ expr: String,
   placeholder: Int = 0,
   expected: String,
@@ -580,7 +580,7 @@ fileprivate func assertRefactorPlaceholderToken(
   )
 }
 
-fileprivate func assertExpandEditorPlaceholdersToClosures(
+private func assertExpandEditorPlaceholdersToClosures(
   _ call: some CallLikeSyntax,
   expected: String,
   format: ExpandEditorPlaceholdersToLiteralClosures.Context.Format = .trailing(indentationWidth: nil),
@@ -597,7 +597,7 @@ fileprivate func assertExpandEditorPlaceholdersToClosures(
   )
 }
 
-fileprivate func assertExpandEditorPlaceholdersToClosures(
+private func assertExpandEditorPlaceholdersToClosures(
   _ expr: String,
   expected: String,
   format: ExpandEditorPlaceholdersToLiteralClosures.Context.Format = .trailing(indentationWidth: nil),
@@ -615,7 +615,7 @@ fileprivate func assertExpandEditorPlaceholdersToClosures(
   )
 }
 
-fileprivate func assertExpandEditorPlaceholdersToClosures(
+private func assertExpandEditorPlaceholdersToClosures(
   decl: String,
   expected: String,
   format: ExpandEditorPlaceholdersToLiteralClosures.Context.Format = .trailing(indentationWidth: nil),
@@ -639,7 +639,7 @@ fileprivate extension ExpandEditorPlaceholdersToLiteralClosures.Context.Format {
   }
 }
 
-fileprivate class CustomClosureFormat: BasicFormat {
+private class CustomClosureFormat: BasicFormat {
   override func requiresNewline(between _: TokenSyntax?, and _: TokenSyntax?) -> Bool {
     return false
   }

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -214,8 +214,8 @@ final class StringInterpolationTests: XCTestCase {
   }
 
   func testInterpolationLiteralOptional() {
-    let some: Optional<Int> = 42
-    let none: Optional<Int> = nil
+    let some: Int? = 42
+    let none: Int? = nil
 
     let a: ExprSyntax = "print(\(literal: some))"
     assertStringsEqualWithDiff(a.description, #"print(42)"#)

--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -25,7 +25,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-fileprivate struct ConstantOneGetter: AccessorMacro {
+private struct ConstantOneGetter: AccessorMacro {
   static func expansion(
     of node: AttributeSyntax,
     providingAccessorsOf declaration: some DeclSyntaxProtocol,

--- a/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 import XCTest
 import _SwiftSyntaxTestSupport
 
-fileprivate func assertSyntaxRemovingTestAttributes(
+private func assertSyntaxRemovingTestAttributes(
   _ originalSource: String,
   reduction expectedReducedSource: String,
   file: StaticString = #filePath,

--- a/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
@@ -25,7 +25,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-fileprivate struct DeclsFromStringsMacro: DeclarationMacro {
+private struct DeclsFromStringsMacro: DeclarationMacro {
   static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext

--- a/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
@@ -25,7 +25,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-fileprivate struct DeclsFromStringsMacro: DeclarationMacro {
+private struct DeclsFromStringsMacro: DeclarationMacro {
   static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
@@ -24,7 +24,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-fileprivate struct StringifyMacro: ExpressionMacro {
+private struct StringifyMacro: ExpressionMacro {
   static func expansion(
     of macro: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
@@ -253,7 +253,7 @@ final class ExtensionMacroTests: XCTestCase {
   }
 }
 
-fileprivate struct SendableExtensionMacro: ExtensionMacro {
+private struct SendableExtensionMacro: ExtensionMacro {
   static func expansion(
     of node: AttributeSyntax,
     attachedTo: some DeclGroupSyntax,

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
@@ -25,7 +25,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-fileprivate struct WrapAllProperties: MemberAttributeMacro {
+private struct WrapAllProperties: MemberAttributeMacro {
   static func expansion(
     of node: AttributeSyntax,
     attachedTo decl: some DeclGroupSyntax,

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
@@ -25,7 +25,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-fileprivate struct NoOpMemberMacro: MemberMacro {
+private struct NoOpMemberMacro: MemberMacro {
   static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -13,7 +13,7 @@
 @_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
-fileprivate func cannedStructDecl(arena: ParsingRawSyntaxArena) -> RawStructDeclSyntax {
+private func cannedStructDecl(arena: ParsingRawSyntaxArena) -> RawStructDeclSyntax {
   let structKW = RawTokenSyntax(
     kind: .keyword,
     text: arena.intern("struct"),

--- a/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
+++ b/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
@@ -15,7 +15,7 @@ import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 
-fileprivate func assertPresumedSourceLocation(
+private func assertPresumedSourceLocation(
   _ source: SourceFileSyntax,
   inspectionItemFilter: (CodeBlockItemSyntax.Item) -> (some SyntaxProtocol)? = { $0.as(VariableDeclSyntax.self) },
   presumedFile: String,

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 import XCTest
 import _SwiftSyntaxTestSupport
 
-fileprivate func intElement(_ int: Int) -> ArrayElementSyntax {
+private func intElement(_ int: Int) -> ArrayElementSyntax {
   let literal = TokenSyntax.integerLiteral("\(int)")
   return ArrayElementSyntax(
     expression: IntegerLiteralExprSyntax(literal: literal),
@@ -22,7 +22,7 @@ fileprivate func intElement(_ int: Int) -> ArrayElementSyntax {
   )
 }
 
-fileprivate func assertSyntaxCollectionManipulation(
+private func assertSyntaxCollectionManipulation(
   initialElements: [Int],
   transformation: (_ array: inout ArrayExprSyntax) -> Void,
   expectedElements: [Int],

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 import XCTest
 
-fileprivate func cannedStructDecl() -> StructDeclSyntax {
+private func cannedStructDecl() -> StructDeclSyntax {
   let structKW = TokenSyntax.keyword(.struct, trailingTrivia: .space)
   let fooID = TokenSyntax.identifier("Foo", trailingTrivia: .space)
   let rBrace = TokenSyntax.rightBraceToken(leadingTrivia: .newline)

--- a/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 import XCTest
 
-fileprivate func cannedVarDecl() -> VariableDeclSyntax {
+private func cannedVarDecl() -> VariableDeclSyntax {
   let identifierPattern = IdentifierPatternSyntax(
     identifier: .identifier("a")
   )


### PR DESCRIPTION
Not specifying a rule disables checking for that rule rather than assumes the default value, which was not the expected effect.

This applies the default configuration, keeping current settings and disabling 2 default-enabled rules: `DoNotUseSemicolons` and `NoAccessLevelOnExtensionDeclaration`.