### PR TITLE
Add Source Location Support to makeUniqueName for Robust Macro-Generated Identifiers

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -281,6 +281,11 @@ class PluginMacroExpansionContext {
 extension PluginMacroExpansionContext: MacroExpansionContext {
   /// Generate a unique name for use in the macro.
   public func makeUniqueName(_ providedName: String) -> TokenSyntax {
+    return makeUniqueName(providedName, sourceLocation: nil)
+  }
+
+  /// Generate a unique name for use in the macro, incorporating source location information.
+  public func makeUniqueName(_ providedName: String, sourceLocation: AbstractSourceLocation?) -> TokenSyntax {
     // If provided with an empty name, substitute in something.
     let name = providedName.isEmpty ? "__local" : providedName
 
@@ -296,6 +301,14 @@ extension PluginMacroExpansionContext: MacroExpansionContext {
 
     // Mangle the operator for unique macro names.
     resultString += "fMu"
+
+    // If we have source location information, incorporate it into the unique name
+    if let sourceLocation = sourceLocation {
+      // Create a hash from the source location to make it more unique
+      let locationString = "\(sourceLocation.file)_\(sourceLocation.line)_\(sourceLocation.column)"
+      let locationHash = locationString.hashValue
+      resultString += "_\(abs(locationHash) % 10000)"
+    }
 
     // Mangle the index.
     if uniqueIndex > 0 {

--- a/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
@@ -146,6 +146,11 @@ extension String {
 extension BasicMacroExpansionContext: MacroExpansionContext {
   /// Generate a unique name for use in the macro.
   public func makeUniqueName(_ providedName: String) -> TokenSyntax {
+    return makeUniqueName(providedName, sourceLocation: nil)
+  }
+
+  /// Generate a unique name for use in the macro, incorporating source location information.
+  public func makeUniqueName(_ providedName: String, sourceLocation: AbstractSourceLocation?) -> TokenSyntax {
     // If provided with an empty name, substitute in something.
     let name = providedName.isEmpty ? "__local" : providedName
 
@@ -161,6 +166,14 @@ extension BasicMacroExpansionContext: MacroExpansionContext {
 
     // Mangle the operator for unique macro names.
     resultString += "fMu"
+
+    // If we have source location information, incorporate it into the unique name
+    if let sourceLocation = sourceLocation {
+      // Create a hash from the source location to make it more unique
+      let locationString = "\(sourceLocation.file)_\(sourceLocation.line)_\(sourceLocation.column)"
+      let locationHash = locationString.hashValue
+      resultString += "_\(abs(locationHash) % 10000)"
+    }
 
     // Mangle the index.
     if uniqueIndex > 0 {

--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -33,6 +33,18 @@ public protocol MacroExpansionContext: AnyObject {
   ///   conflict with any other name in a well-formed program.
   func makeUniqueName(_ name: String) -> TokenSyntax
 
+  /// Generate a unique name for use in the macro, incorporating source location information.
+  ///
+  /// - Parameters:
+  ///   - name: The name to use as a basis for the uniquely-generated name,
+  ///     which will appear in the unique name that's produced here.
+  ///   - sourceLocation: Optional source location information to incorporate
+  ///     into the unique name generation for better uniqueness.
+  ///
+  /// - Returns: an identifier token containing a unique name that will not
+  ///   conflict with any other name in a well-formed program.
+  func makeUniqueName(_ name: String, sourceLocation: AbstractSourceLocation?) -> TokenSyntax
+
   /// Produce a diagnostic while expanding the macro.
   func diagnose(_ diagnostic: Diagnostic)
 
@@ -86,6 +98,12 @@ extension MacroExpansionContext {
     of node: some SyntaxProtocol
   ) -> AbstractSourceLocation? {
     return location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID)
+  }
+
+  /// Default implementation of makeUniqueName with source location that
+  /// falls back to the original method for backward compatibility.
+  public func makeUniqueName(_ name: String, sourceLocation: AbstractSourceLocation?) -> TokenSyntax {
+    return makeUniqueName(name)
   }
 
   #if compiler(>=6.0)


### PR DESCRIPTION
This PR improves the uniqueness of macro-generated identifiers by extending the `makeUniqueName` API to accept optional source location information. When provided, the source location (file, line, column) is incorporated into the generated name, ensuring that functions or declarations with the same name at different locations produce unique identifiers.

#### Motivation
Previously, macros such as `@Test` could generate duplicate symbols if two functions had the same name, leading to compiler crashes or invalid redeclarations. This change generalizes the solution by making unique name generation robust for all macros, not just `@Test`.

#### Changes
- Added an overloaded `makeUniqueName(_:sourceLocation:)` method to the `MacroExpansionContext` protocol.
- Updated `BasicMacroExpansionContext` and `PluginMacroExpansionContext` to implement the new method.
- Incorporated a hash of the source location (file, line, column) into the generated name when available.
- Maintained backward compatibility with the original API.

#### Impact
- Macro authors can now generate unique names that are robust to duplicate declarations at different source locations.
- No breaking changes for existing macro code.

Resolves swiftlang/swift#82631