### PR TITLE
[SwiftParser] Ignore '(' on newline after attribute name

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -203,12 +203,12 @@ extension Parser {
     case .customAttribute:
       shouldParseArgument = self.withLookahead { $0.atAttributeOrSpecifierArgument() }
     case .optional:
-      shouldParseArgument = self.at(.leftParen)
+      shouldParseArgument = self.at(TokenSpec(.leftParen, allowAtStartOfLine: false))
     case .noArgument:
       shouldParseArgument = false
     }
     if shouldParseArgument {
-      var (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
+      var (unexpectedBeforeLeftParen, leftParen) = self.expect(TokenSpec(.leftParen, allowAtStartOfLine: false))
       if unexpectedBeforeLeftParen == nil
         && (attributeName.raw.trailingTriviaByteLength > 0 || leftParen.leadingTriviaByteLength > 0)
       {

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -213,7 +213,7 @@ extension Parser {
   /// Parse a line control directive.
   mutating func parsePoundSourceLocationDirective() -> RawPoundSourceLocationSyntax {
     let line = self.consumeAnyToken()
-    let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
+    let (unexpectedBeforeLParen, lparen) = self.expect(TokenSpec(.leftParen, allowAtStartOfLine: false))
     let arguments: RawPoundSourceLocationArgumentsSyntax?
     if !self.at(.rightParen) {
       let (unexpectedBeforeFile, file) = self.expect(.keyword(.file))

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -213,6 +213,21 @@ final class AttributeTests: ParserTestCase {
     )
   }
 
+  func testObjCAttributeNewlineParen() {
+    assertParse(
+      """
+      @objc
+      1️⃣(foo) func foo()
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "unexpected code '(foo)' in function"
+        )
+      ]
+    )
+  }
+
   func testRethrowsAttribute() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/AvailabilityTests.swift
+++ b/Tests/SwiftParserTest/AvailabilityTests.swift
@@ -204,4 +204,33 @@ final class AvailabilityTests: ParserTestCase {
       ]
     )
   }
+
+  func testAvailableNewlineParen() {
+    assertParse(
+      """
+      @available1️⃣
+      2️⃣(*, unavailable) func foo() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected '()' in attribute",
+          fixIts: ["insert '()'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected argument for '@available' attribute",
+          fixIts: ["insert attribute argument"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "unexpected code '(*, unavailable)' in function"
+        ),
+      ],
+      fixedSource: """
+        @available()
+        (*, unavailable) func foo() {}
+        """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/DirectiveTests.swift
+++ b/Tests/SwiftParserTest/DirectiveTests.swift
@@ -358,7 +358,7 @@ final class DirectiveTests: ParserTestCase {
     )
   }
 
-  func testIfConfigRRR() {
+  func testIfConfigAfterAttribute() {
     assertParse(
       """
       @frozen1️⃣
@@ -433,6 +433,28 @@ final class DirectiveTests: ParserTestCase {
         #if true
         func foo() {}
         #endif
+        """
+    )
+  }
+
+  func testSourcelocationDirectiveNewlineParen() {
+    assertParse(
+      """
+      #sourceLocation1️⃣
+      (file: "other.swift", line: 1)
+      var someName: Int
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected '(', arguments, and ')' in '#sourceLocation' directive",
+          fixIts: ["insert '(', arguments, and ')'"]
+        )
+      ],
+      fixedSource: """
+        #sourceLocation(file: "", line: <#integer literal#>)
+        (file: "other.swift", line: 1)
+        var someName: Int
         """
     )
   }


### PR DESCRIPTION
Some builtin attributes mistakingly accepted '(' on newline, while custom attribute didn't. For consistency, ignore '(' on next line.