### PR TITLE
[CI] Enable Wasm SDK build

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,8 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Sources/SwiftLibraryPluginProvider/LibraryPluginProvider.swift
+++ b/Sources/SwiftLibraryPluginProvider/LibraryPluginProvider.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 #if compiler(>=6)
 public import SwiftSyntaxMacros
 @_spi(PluginMessage) public import SwiftCompilerPluginMessageHandling
@@ -221,3 +223,5 @@ extension UnsafeMutableBufferPointer {
   }
 }
 #endif
+
+#endif  // !os(WASI)


### PR DESCRIPTION
This helps us to prevent regressions like #2944.

(By the way, we can even [run tests](https://github.com/kkebo/swift-syntax/blob/wasm32-wasi-test/.github/workflows/swiftwasm.yml) on a Wasm runtime if we add more changes. However, I don't think it's a good time to do that since swiftlang/github-workflows does not support such a workflow yet.)