### PR TITLE
[SwiftParser] Improve attribute parsing and recovering

### DIFF
--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -221,11 +221,8 @@ extension Parser.Lookahead {
         _ = self.consumeGenericArguments()
       } while self.consume(if: .period) != nil
 
-      if self.consume(if: .leftParen) != nil {
-        while !self.at(.endOfFile, .rightParen, .poundEndif) {
-          self.skipSingle()
-        }
-        self.consume(if: .rightParen)
+      if self.atAttributeOrSpecifierArgument() {
+        self.skipSingle()
       }
     }
     return true

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -267,9 +267,9 @@ enum ContextualDeclKeyword: TokenSpecSet {
   }
 }
 
-/// A `DeclarationKeyword` that is not a `ValueBindingPatternSyntax.BindingSpecifierOptions`.
+/// A `DeclarationKeyword` that is not a `VariableDeclSyntax.BindingSpecifierOptions`.
 ///
-/// `ValueBindingPatternSyntax.BindingSpecifierOptions` are injected into
+/// `VariableDeclSyntax.BindingSpecifierOptions` are injected into
 /// `DeclarationKeyword` via an `EitherTokenSpecSet`.
 enum PureDeclarationKeyword: TokenSpecSet {
   case actor
@@ -344,7 +344,7 @@ enum PureDeclarationKeyword: TokenSpecSet {
 
 typealias DeclarationKeyword = EitherTokenSpecSet<
   PureDeclarationKeyword,
-  ValueBindingPatternSyntax.BindingSpecifierOptions
+  VariableDeclSyntax.BindingSpecifierOptions
 >
 
 enum DeclarationModifier: TokenSpecSet {

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -251,10 +251,10 @@ extension Parser {
       return self.parseStatementItem()
     } else if self.atStartOfExpression() {
       return .expr(self.parseExpression(flavor: .basic, pattern: .none))
-    } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl, allowRecovery: true) {
-      return .decl(self.parseDeclaration())
     } else if self.atStartOfStatement(allowRecovery: true, preferExpr: false) {
       return self.parseStatementItem()
+    } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl, allowRecovery: true) {
+      return .decl(self.parseDeclaration())
     } else {
       return .init(expr: RawMissingExprSyntax(arena: self.arena))
     }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -1308,17 +1308,21 @@ extension Parser {
       return .attribute(self.parseDifferentiableAttribute())
 
     case .isolated:
-      return parseAttribute(argumentMode: .required) { parser in
-        return (nil, .argumentList(parser.parseIsolatedAttributeArguments()))
-      }
+      return .attribute(
+        parseAttribute(argumentMode: .required) { parser in
+          return (nil, .argumentList(parser.parseIsolatedAttributeArguments()))
+        }
+      )
     case .convention, ._opaqueReturnTypeOf, nil:  // Custom attribute
-      return parseAttribute(argumentMode: .customAttribute) { parser in
-        let arguments = parser.parseArgumentListElements(
-          pattern: .none,
-          allowTrailingComma: true
-        )
-        return (nil, .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena)))
-      }
+      return .attribute(
+        parseAttribute(argumentMode: .customAttribute) { parser in
+          let arguments = parser.parseArgumentListElements(
+            pattern: .none,
+            allowTrailingComma: true
+          )
+          return (nil, .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena)))
+        }
+      )
 
     }
   }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -482,21 +482,36 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       otherNode.lastToken(viewMode: .sourceAccurate)?.tokenKind == .poundEndif
     {
       let diagnoseOn = parent.parent ?? parent
-      addDiagnostic(
-        diagnoseOn,
-        IfConfigDeclNotAllowedInContext(context: diagnoseOn),
-        highlights: [Syntax(node), Syntax(otherNode)],
-        fixIts: [
-          FixIt(
-            message: RemoveNodesFixIt([Syntax(node), Syntax(otherNode)]),
-            changes: [
-              .makeMissing([Syntax(node)], transferTrivia: false),
-              .makeMissing([Syntax(otherNode)], transferTrivia: false),
-            ]
-          )
-        ],
-        handledNodes: [node.id, otherNode.id]
-      )
+      if node == otherNode {
+        addDiagnostic(
+          diagnoseOn,
+          IfConfigDeclNotAllowedInContext(context: diagnoseOn),
+          highlights: [Syntax(node)],
+          fixIts: [
+            FixIt(
+              message: RemoveNodesFixIt([Syntax(node)]),
+              changes: .makeMissing([Syntax(node)], transferTrivia: false)
+            )
+          ],
+          handledNodes: [node.id]
+        )
+      } else {
+        addDiagnostic(
+          diagnoseOn,
+          IfConfigDeclNotAllowedInContext(context: diagnoseOn),
+          highlights: [Syntax(node), Syntax(otherNode)],
+          fixIts: [
+            FixIt(
+              message: RemoveNodesFixIt([Syntax(node), Syntax(otherNode)]),
+              changes: [
+                .makeMissing([Syntax(node)], transferTrivia: false),
+                .makeMissing([Syntax(otherNode)], transferTrivia: false),
+              ]
+            )
+          ],
+          handledNodes: [node.id, otherNode.id]
+        )
+      }
     } else {
       addDiagnostic(node, UnexpectedNodesError(unexpectedNodes: node), highlights: [Syntax(node)])
     }

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -1400,4 +1400,17 @@ final class AttributeTests: ParserTestCase {
       """
     )
   }
+
+  func testAttributeParsable() {
+    let source = """
+      #if true
+      @discardableResult
+      #endif
+      """
+    var parser = Parser(source)
+    let attr = AttributeSyntax.parse(from: &parser)
+
+    XCTAssertTrue(attr.description == source)
+    XCTAssertTrue(attr.tokens(viewMode: .fixedUp).allSatisfy({ $0.presence == .missing }))
+  }
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -567,11 +567,15 @@ final class DeclarationTests: ParserTestCase {
 
     assertParse(
       """
-      1️⃣private(
+      private(1️⃣
       """,
       diagnostics: [
-        DiagnosticSpec(message: "extraneous code 'private(' at top level")
-      ]
+        DiagnosticSpec(message: "expected 'set)' to end modifier", fixIts: ["insert 'set)'"]),
+        DiagnosticSpec(message: "expected declaration after 'private' modifier", fixIts: ["insert declaration"]),
+      ],
+      fixedSource: """
+        private(set) <#declaration#>
+        """
     )
 
     assertParse(

--- a/Tests/SwiftParserTest/DirectiveTests.swift
+++ b/Tests/SwiftParserTest/DirectiveTests.swift
@@ -357,4 +357,83 @@ final class DirectiveTests: ParserTestCase {
       ]
     )
   }
+
+  func testIfConfigRRR() {
+    assertParse(
+      """
+      @frozen1️⃣
+
+      #if true
+      func foo() {}
+      #endif
+      """,
+      substructure: CodeBlockItemListSyntax([
+        CodeBlockItemSyntax(
+          item: .init(
+            MissingDeclSyntax(
+              attributes: [
+                .attribute(
+                  AttributeSyntax(
+                    atSign: .atSignToken(),
+                    attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("frozen")))
+                  )
+                )
+              ],
+              modifiers: [],
+              placeholder: .identifier("<#declaration#>", presence: .missing)
+            )
+          )
+        ),
+        CodeBlockItemSyntax(
+          item: .init(
+            IfConfigDeclSyntax(
+              clauses: IfConfigClauseListSyntax([
+                IfConfigClauseSyntax(
+                  poundKeyword: .poundIfToken(),
+                  condition: ExprSyntax(BooleanLiteralExprSyntax(literal: .keyword(.true))),
+                  elements: .statements(
+                    CodeBlockItemListSyntax([
+                      CodeBlockItemSyntax(
+                        item: CodeBlockItemSyntax.Item(
+                          FunctionDeclSyntax(
+                            attributes: [],
+                            modifiers: [],
+                            funcKeyword: .keyword(.func),
+                            name: .identifier("foo"),
+                            signature: FunctionSignatureSyntax(
+                              parameterClause: FunctionParameterClauseSyntax(
+                                leftParen: .leftParenToken(),
+                                parameters: FunctionParameterListSyntax([]),
+                                rightParen: .rightParenToken()
+                              )
+                            ),
+                            body: CodeBlockSyntax(
+                              leftBrace: .leftBraceToken(),
+                              statements: CodeBlockItemListSyntax([]),
+                              rightBrace: .rightBraceToken()
+                            )
+                          )
+                        )
+                      )
+                    ])
+                  )
+                )
+              ]),
+              poundEndif: .poundEndifToken()
+            )
+          )
+        ),
+      ]),
+      diagnostics: [
+        DiagnosticSpec(message: "expected declaration after attribute", fixIts: ["insert declaration"])
+      ],
+      fixedSource: """
+        @frozen <#declaration#>
+
+        #if true
+        func foo() {}
+        #endif
+        """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -703,7 +703,7 @@ final class StatementTests: ParserTestCase {
   func testRecoveryInFrontOfAccessorIntroducer() {
     assertParse(
       """
-      subscript1️⃣(2️⃣{3️⃣@self _modify
+      subscript1️⃣(2️⃣{@attr _modify3️⃣
       """,
       diagnostics: [
         DiagnosticSpec(
@@ -723,14 +723,10 @@ final class StatementTests: ParserTestCase {
           notes: [NoteSpec(locationMarker: "2️⃣", message: "to match this opening '{'")],
           fixIts: ["insert '}'"]
         ),
-        DiagnosticSpec(
-          locationMarker: "3️⃣",
-          message: "extraneous code '@self _modify' at top level"
-        ),
       ],
       fixedSource: """
-        subscript() -> <#type#> {
-        }@self _modify
+        subscript() -> <#type#> {@attr _modify
+        }
         """
     )
   }


### PR DESCRIPTION
Attributes followed by non-attribute `#if` were not `atStartOfDeclaration()` nor `parseStatementItem()`, so the rest of the code including the attribute were parsed as "unexpected code".

* Improve attibute list checking in `atStartOfDeclaration()` and parse attributes without decl introducer as `MissingDeclSyntax`
* Make sure `#if` contains only attributes before parsing them as an attribute list element
* Remove `#if` parsing from `parseAttribute()`, and introduce `parseAttributeListElement()` for attribute list element parsing including `#if`. This prevents a crash when  `#if` is passed to `AttributeSyntax.parse(from:)`

https://github.com/swiftlang/swift-syntax/issues/3134