### PR TITLE
[SwiftRefactor] PackageManifest: Make a couple of properties external…

### DIFF
--- a/Sources/SwiftRefactor/PackageManifest/AddPackageTarget.swift
+++ b/Sources/SwiftRefactor/PackageManifest/AddPackageTarget.swift
@@ -295,18 +295,6 @@ public struct AddPackageTarget: ManifestEditRefactoringProvider {
   }
 }
 
-fileprivate extension PackageTarget.Dependency {
-  /// Retrieve the name of the dependency
-  var name: String {
-    switch self {
-    case .target(let name),
-      .byName(let name),
-      .product(let name, package: _):
-      return name
-    }
-  }
-}
-
 /// The array of auxiliary files that can be added by a package editing
 /// operation.
 private typealias AuxiliaryFiles = [(String, SourceFileSyntax)]
@@ -344,18 +332,6 @@ fileprivate extension PackageDependency {
       )
     )
   }
-}
-
-fileprivate extension PackageTarget {
-  var sanitizedName: String {
-    name
-      .mangledToC99ExtendedIdentifier()
-      .localizedFirstWordCapitalized()
-  }
-}
-
-fileprivate extension String {
-  func localizedFirstWordCapitalized() -> String { prefix(1).uppercased() + dropFirst() }
 }
 
 extension SourceFileSyntax {

--- a/Sources/SwiftRefactor/PackageManifest/PackageTarget.swift
+++ b/Sources/SwiftRefactor/PackageManifest/PackageTarget.swift
@@ -18,6 +18,12 @@ import SwiftSyntax
 public struct PackageTarget {
   public let name: String
 
+  public var sanitizedName: String {
+    name
+      .mangledToC99ExtendedIdentifier()
+      .localizedFirstWordCapitalized()
+  }
+
   /// The type of target.
   public let type: TargetKind
 
@@ -51,6 +57,16 @@ public struct PackageTarget {
     case byName(name: String)
     case target(name: String)
     case product(name: String, package: String?)
+
+    /// Retrieve the name of the dependency
+    public var name: String {
+      switch self {
+      case .byName(let name),
+        .target(let name),
+        .product(let name, package: _):
+        return name
+      }
+    }
   }
 
   public init(
@@ -140,4 +156,8 @@ extension PackageTarget.PluginUsage: ManifestSyntaxRepresentable {
       return ".plugin(name: \(literal: name), package: \(literal: package))"
     }
   }
+}
+
+fileprivate extension String {
+  func localizedFirstWordCapitalized() -> String { prefix(1).uppercased() + dropFirst() }
 }


### PR DESCRIPTION
…ly accessible

In it's current state `AddPackageTarget` does multiple things:

1. Updates the manifest to introduce new targets and dependencies.

2. Generates one or more auxiliary files depending on the type of target being added (i.e. a primary file for the target and sometimes a macro specific defintions file).

We'd like to scope the refactoring action down to manifest updates only.

The callers are going to be resposble for #2 from the list. In order to do that `PackageTarget.sanitizedName` and `PackageTarget.Dependency.name` have to be externally accessible (under `@_spi(PackageRefactor)` still) to form the content of the file.