### PR TITLE
Use `Invoke-Program` for the Windows build command

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       # We require that releases of swift-syntax build without warnings
       linux_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
-      windows_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
+      windows_build_command: Invoke-Program swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
   create_tag:
     name: Create Tag
     runs-on: ubuntu-latest


### PR DESCRIPTION
Windows does not stop scripts when native commands exit with non-zero. Instead, their exit status has to be checked manually. This can be done through an `Invoke-Program` function that is added to the script running `windows_build_command`, which also previously prefixed the given command. This is changing in
https://github.com/swiftlang/github-workflows/pull/154 since it doesn't help with multi-line commands - update our modified `windows_build_command` to use `Invoke-Program` instead.