### PR TITLE
[SwiftRefactor] EditRefactoringProvider: Make `textRefactor` and `ref…

### DIFF
--- a/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
@@ -40,7 +40,7 @@ final class SourceEditorCommand: NSObject, XCSourceEditorCommand {
       }
 
       override func visitAny(_ node: Syntax) -> Syntax? {
-        func withOpenedRefactoringProvider<T: SyntaxRefactoringProvider>(_ providerType: T.Type) -> Syntax? {
+        func withOpenedRefactoringProvider<T: SyntaxRefactoringProvider>(_ providerType: T.Type) throws -> Syntax? {
           guard
             let input = node.as(providerType.Input.self),
             providerType.Context.self == Void.self
@@ -48,10 +48,10 @@ final class SourceEditorCommand: NSObject, XCSourceEditorCommand {
             return nil
           }
           let context = unsafeBitCast(Void(), to: providerType.Context.self)
-          return providerType.refactor(syntax: input, in: context).map { Syntax($0) }
+          return try Syntax(providerType.refactor(syntax: input, in: context))
         }
 
-        return _openExistential(self.provider, do: withOpenedRefactoringProvider)
+        return try? _openExistential(self.provider, do: withOpenedRefactoringProvider)
       }
     }
 

--- a/Sources/SwiftRefactor/AddSeparatorsToIntegerLiteral.swift
+++ b/Sources/SwiftRefactor/AddSeparatorsToIntegerLiteral.swift
@@ -37,11 +37,12 @@ import SwiftSyntax
 /// 0b1_010
 /// ```
 public struct AddSeparatorsToIntegerLiteral: SyntaxRefactoringProvider {
-  public static func refactor(syntax lit: IntegerLiteralExprSyntax, in context: Void) -> IntegerLiteralExprSyntax? {
+  public static func refactor(
+    syntax lit: IntegerLiteralExprSyntax,
+    in context: Void
+  ) throws -> IntegerLiteralExprSyntax {
     if lit.literal.text.contains("_") {
-      guard let strippedLiteral = RemoveSeparatorsFromIntegerLiteral.refactor(syntax: lit) else {
-        return nil
-      }
+      let strippedLiteral = try RemoveSeparatorsFromIntegerLiteral.refactor(syntax: lit)
       return self.addSeparators(to: strippedLiteral)
     } else {
       return self.addSeparators(to: lit)

--- a/Sources/SwiftRefactor/CallToTrailingClosures.swift
+++ b/Sources/SwiftRefactor/CallToTrailingClosures.swift
@@ -55,39 +55,43 @@ public struct CallToTrailingClosures: SyntaxRefactoringProvider {
 
   /// Apply the refactoring to a given syntax node. If either a
   /// non-function-like syntax node is passed, or the refactoring fails,
-  /// `nil` is returned.
-  // TODO: Rather than returning nil, we should consider throwing errors with
-  // appropriate messages instead.
+  /// an error is thrown.
   public static func refactor(
     syntax: Syntax,
     in context: Context = Context()
-  ) -> Syntax? {
-    guard let call = syntax.asProtocol(CallLikeSyntax.self) else { return nil }
-    return Syntax(fromProtocol: _refactor(syntax: call, in: context))
+  ) throws -> Syntax {
+    guard let call = syntax.asProtocol(CallLikeSyntax.self) else {
+      throw RefactoringNotApplicableError("not a call")
+    }
+    return try Syntax(fromProtocol: _refactor(syntax: call, in: context))
   }
 
   @available(*, deprecated, message: "Pass a Syntax argument instead of FunctionCallExprSyntax")
   public static func refactor(
     syntax call: FunctionCallExprSyntax,
     in context: Context = Context()
-  ) -> FunctionCallExprSyntax? {
-    _refactor(syntax: call, in: context)
+  ) throws -> FunctionCallExprSyntax {
+    try _refactor(syntax: call, in: context)
   }
 
   internal static func _refactor<C: CallLikeSyntax>(
     syntax call: C,
     in context: Context = Context()
-  ) -> C? {
-    let converted = call.convertToTrailingClosures(from: context.startAtArgument)
-    return converted?.formatted().as(C.self)
+  ) throws -> C {
+    let converted = try call.convertToTrailingClosures(from: context.startAtArgument)
+
+    guard let formatted = converted.formatted().as(C.self) else {
+      throw RefactoringNotApplicableError("format error")
+    }
+
+    return formatted
   }
 }
 
 extension CallLikeSyntax {
-  fileprivate func convertToTrailingClosures(from startAtArgument: Int) -> Self? {
+  fileprivate func convertToTrailingClosures(from startAtArgument: Int) throws -> Self {
     guard trailingClosure == nil, additionalTrailingClosures.isEmpty, leftParen != nil, rightParen != nil else {
-      // Already have trailing closures
-      return nil
+      throw RefactoringNotApplicableError("call already uses trailing closures")
     }
 
     var closures = [(original: LabeledExprSyntax, closure: ClosureExprSyntax)]()
@@ -106,7 +110,7 @@ extension CallLikeSyntax {
     }
 
     guard !closures.isEmpty else {
-      return nil
+      throw RefactoringNotApplicableError("no arguments to convert to closures")
     }
 
     // First trailing closure won't have label/colon. Transfer their trivia.

--- a/Sources/SwiftRefactor/ConvertComputedPropertyToZeroParameterFunction.swift
+++ b/Sources/SwiftRefactor/ConvertComputedPropertyToZeroParameterFunction.swift
@@ -17,17 +17,17 @@ import SwiftSyntax
 #endif
 
 public struct ConvertComputedPropertyToZeroParameterFunction: SyntaxRefactoringProvider {
-  public static func refactor(syntax: VariableDeclSyntax, in context: Void) -> FunctionDeclSyntax? {
+  public static func refactor(syntax: VariableDeclSyntax, in context: Void) throws -> FunctionDeclSyntax {
     guard syntax.bindings.count == 1,
       let binding = syntax.bindings.first,
       let identifierPattern = binding.pattern.as(IdentifierPatternSyntax.self)
-    else { return nil }
+    else { throw RefactoringNotApplicableError("unsupported variable declaration") }
 
     var statements: CodeBlockItemListSyntax
 
     guard let typeAnnotation = binding.typeAnnotation,
       var accessorBlock = binding.accessorBlock
-    else { return nil }
+    else { throw RefactoringNotApplicableError("no type annotation or stored") }
 
     var effectSpecifiers: AccessorEffectSpecifiersSyntax?
 
@@ -35,7 +35,7 @@ public struct ConvertComputedPropertyToZeroParameterFunction: SyntaxRefactoringP
     case .accessors(let accessors):
       guard accessors.count == 1, let accessor = accessors.first,
         accessor.accessorSpecifier.tokenKind == .keyword(.get), let codeBlock = accessor.body
-      else { return nil }
+      else { throw RefactoringNotApplicableError("not a getter-only declaration") }
       effectSpecifiers = accessor.effectSpecifiers
       statements = codeBlock.statements
       let accessorSpecifier = accessor.accessorSpecifier

--- a/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
+++ b/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
@@ -17,10 +17,10 @@ import SwiftSyntax
 #endif
 
 public struct ConvertZeroParameterFunctionToComputedProperty: SyntaxRefactoringProvider {
-  public static func refactor(syntax: FunctionDeclSyntax, in context: ()) -> VariableDeclSyntax? {
+  public static func refactor(syntax: FunctionDeclSyntax, in context: ()) throws -> VariableDeclSyntax {
     guard syntax.signature.parameterClause.parameters.isEmpty,
       let body = syntax.body
-    else { return nil }
+    else { throw RefactoringNotApplicableError("not a zero parameter function") }
 
     let variableName = PatternSyntax(
       IdentifierPatternSyntax(

--- a/Sources/SwiftRefactor/ExpandEditorPlaceholder.swift
+++ b/Sources/SwiftRefactor/ExpandEditorPlaceholder.swift
@@ -275,13 +275,19 @@ public struct ExpandEditorPlaceholdersToLiteralClosures: SyntaxRefactoringProvid
   public static func refactor(
     syntax: Syntax,
     in context: Context = Context()
-  ) -> Syntax? {
-    guard let call = syntax.asProtocol(CallLikeSyntax.self) else { return nil }
-    let expanded = Self.expandClosurePlaceholders(
-      in: call,
-      ifIncluded: nil,
-      context: context
-    )
+  ) throws -> Syntax {
+    guard let call = syntax.asProtocol(CallLikeSyntax.self) else {
+      throw RefactoringNotApplicableError("not a call")
+    }
+    guard
+      let expanded = Self.expandClosurePlaceholders(
+        in: call,
+        ifIncluded: nil,
+        context: context
+      )
+    else {
+      throw RefactoringNotApplicableError("could not expand closure placeholders")
+    }
     return Syntax(fromProtocol: expanded)
   }
 
@@ -325,7 +331,7 @@ public struct ExpandEditorPlaceholdersToLiteralClosures: SyntaxRefactoringProvid
       let callToTrailingContext = CallToTrailingClosures.Context(
         startAtArgument: call.arguments.count - expanded.numClosures
       )
-      return CallToTrailingClosures._refactor(syntax: expanded.expr, in: callToTrailingContext)
+      return try? CallToTrailingClosures._refactor(syntax: expanded.expr, in: callToTrailingContext)
     }
   }
 }

--- a/Sources/SwiftRefactor/FormatRawStringLiteral.swift
+++ b/Sources/SwiftRefactor/FormatRawStringLiteral.swift
@@ -35,7 +35,7 @@ import SwiftSyntax
 /// "Hello World"
 /// ```
 public struct FormatRawStringLiteral: SyntaxRefactoringProvider {
-  public static func refactor(syntax lit: StringLiteralExprSyntax, in context: Void) -> StringLiteralExprSyntax? {
+  public static func refactor(syntax lit: StringLiteralExprSyntax, in context: Void) -> StringLiteralExprSyntax {
     var maximumHashes = 0
     for segment in lit.segments {
       switch segment {

--- a/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
+++ b/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
@@ -39,7 +39,7 @@ import SwiftSyntax
 ///   // ...
 /// }
 public struct MigrateToNewIfLetSyntax: SyntaxRefactoringProvider {
-  public static func refactor(syntax node: IfExprSyntax, in context: ()) -> IfExprSyntax? {
+  public static func refactor(syntax node: IfExprSyntax, in context: ()) -> IfExprSyntax {
     // Visit all conditions in the node.
     let newConditions = node.conditions.enumerated().map { (index, condition) -> ConditionElementListSyntax.Element in
       var conditionCopy = condition

--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -179,7 +179,7 @@ public struct OpaqueParameterToGeneric: SyntaxRefactoringProvider {
   public static func refactor(
     syntax decl: DeclSyntax,
     in context: Void
-  ) -> DeclSyntax? {
+  ) throws -> DeclSyntax {
     // Function declaration.
     if let funcSyntax = decl.as(FunctionDeclSyntax.self) {
       guard
@@ -188,7 +188,7 @@ public struct OpaqueParameterToGeneric: SyntaxRefactoringProvider {
           augmenting: funcSyntax.genericParameterClause
         )
       else {
-        return nil
+        throw RefactoringNotApplicableError("found no parameters to rewrite")
       }
 
       return DeclSyntax(
@@ -206,7 +206,7 @@ public struct OpaqueParameterToGeneric: SyntaxRefactoringProvider {
           augmenting: initSyntax.genericParameterClause
         )
       else {
-        return nil
+        throw RefactoringNotApplicableError("found no parameters to rewrite")
       }
 
       return DeclSyntax(
@@ -224,7 +224,7 @@ public struct OpaqueParameterToGeneric: SyntaxRefactoringProvider {
           augmenting: subscriptSyntax.genericParameterClause
         )
       else {
-        return nil
+        throw RefactoringNotApplicableError("found no parameters to rewrite")
       }
 
       return DeclSyntax(
@@ -234,6 +234,6 @@ public struct OpaqueParameterToGeneric: SyntaxRefactoringProvider {
       )
     }
 
-    return nil
+    throw RefactoringNotApplicableError("unsupported declaration")
   }
 }

--- a/Sources/SwiftRefactor/RemoveSeparatorsFromIntegerLiteral.swift
+++ b/Sources/SwiftRefactor/RemoveSeparatorsFromIntegerLiteral.swift
@@ -31,10 +31,8 @@ import SwiftSyntax
 /// 0xFFFFFFFFF
 /// ```
 public struct RemoveSeparatorsFromIntegerLiteral: SyntaxRefactoringProvider {
-  public static func refactor(syntax lit: IntegerLiteralExprSyntax, in context: Void) -> IntegerLiteralExprSyntax? {
-    guard lit.literal.text.contains("_") else {
-      return lit
-    }
+  public static func refactor(syntax lit: IntegerLiteralExprSyntax, in context: Void) -> IntegerLiteralExprSyntax {
+    guard lit.literal.text.contains("_") else { return lit }
     let formattedText = lit.literal.text.filter({ $0 != "_" })
     return lit.with(\.literal, lit.literal.with(\.tokenKind, .integerLiteral(formattedText)))
   }

--- a/Tests/SwiftRefactorTest/RefactorTestUtils.swift
+++ b/Tests/SwiftRefactorTest/RefactorTestUtils.swift
@@ -25,7 +25,7 @@ func assertRefactor<R: EditRefactoringProvider>(
   file: StaticString = #filePath,
   line: UInt = #line
 ) throws {
-  let edits = R.textRefactor(syntax: input, in: context)
+  let edits = try R.textRefactor(syntax: input, in: context)
   guard !edits.isEmpty else {
     if !expected.isEmpty {
       XCTFail(
@@ -83,12 +83,12 @@ func assertRefactor<R: SyntaxRefactoringProvider>(
   file: StaticString = #filePath,
   line: UInt = #line
 ) throws {
-  let refactored = R.refactor(syntax: input, in: context)
+  let refactored = try? R.refactor(syntax: input, in: context)
   guard let refactored = refactored else {
     if expected != nil {
       XCTFail(
         """
-        Refactoring produced nil result, expected:
+        Refactoring failed, expected:
         \(expected?.description ?? "")
         """,
         file: file,


### PR DESCRIPTION
…actor` requirements throwing

The result of both has been made non-optional as well. The idea here is to be able to produce a description for every failure instead of `nil` result, this is something that package model refactoring actions already do.

The only error we currently have is "not applicable" but that's just a start.