### PR TITLE
Test new @_expose(!Cxx) attribute syntax

### DIFF
--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -581,6 +581,12 @@ final class AttributeTests: ParserTestCase {
 
     assertParse(
       """
+      @_expose(!Cxx) func foo() {}
+      """
+    )
+
+    assertParse(
+      """
       @_expose(Cxx, "baz") func foo() {}
       """
     )


### PR DESCRIPTION
Seems to work out of the box