### PR TITLE
[SwiftParser] Update whitespace rule between attribute name and '('

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -51,12 +51,6 @@ extension TokenConsumer {
     case nil:
       break
     }
-    if self.at(.atSign) || self.at(.keyword(.inout)) {
-      var lookahead = self.lookahead()
-      if lookahead.canParseType() {
-        return true
-      }
-    }
     if self.at(.atSign) && self.peek(isAt: .stringQuote) {
       // Invalid Objective-C-style string literal
       return true

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -255,6 +255,10 @@ extension Parser {
       return self.parseStatementItem()
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl, allowRecovery: true) {
       return .decl(self.parseDeclaration())
+    } else if self.at(.atSign), peek(isAt: .identifier) {
+      // Force parsing '@<identifier>' as a declaration, as there's no valid
+      // expression or statement starting with an attribute.
+      return .decl(self.parseDeclaration())
     } else {
       return .init(expr: RawMissingExprSyntax(arena: self.arena))
     }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3643,12 +3643,33 @@ final class UsingDeclarationTests: ParserTestCase {
 
     assertParse(
       """
-      @MainActor
-      using
+      1️⃣@MainActor
+      using2️⃣
       """,
-      substructure: CodeBlockSyntax(
-        DeclReferenceExprSyntax(baseName: .identifier("using"))
-      )
+      substructure: CodeBlockItemSyntax(
+        item: CodeBlockItemSyntax.Item(
+          UsingDeclSyntax(
+            UnexpectedNodesSyntax([
+              Syntax(
+                AttributeSyntax(
+                  atSign: .atSignToken(),
+                  attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("MainActor")))
+                )
+              )
+            ]),
+            usingKeyword: .keyword(.using),
+            specifier: UsingDeclSyntax.Specifier(.identifier("", presence: .missing))
+          )
+        )
+      ),
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '@MainActor' before using"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in using", fixIts: ["insert identifier"]),
+      ],
+      fixedSource: """
+        @MainActor
+        using <#identifier#>
+        """
     )
 
     assertParse(


### PR DESCRIPTION
In Swift 6 and later, whitespace is no longer permitted between an attribute name and the opening parenthesis. Update the parser so that in Swift 6+, a '(' without preceding whitespace is always treated as the start of the argument list, while a '(' with preceding whitespace is considered the start of the argument list only when it is unambiguous.

This change makes the following closure be parsed correctly:

  ```swift
  { @MainActor (arg: Int) in ... }
  ```

rdar://147785544