### PR TITLE
Fix support for trailing commas in tuples with generic arguments

### DIFF
--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -1025,7 +1025,8 @@ extension Parser.Lookahead {
       }
 
       self.consumeIfContextualPunctuator("...")
-    } while self.consume(if: .comma) != nil && self.hasProgressed(&loopProgress)
+      
+    } while self.consume(if: .comma) != nil && !self.at(.rightParen) && self.hasProgressed(&loopProgress)
     return self.consume(if: .rightParen) != nil
   }
 

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2225,6 +2225,49 @@ final class ExpressionTests: ParserTestCase {
       let _ = ((Int, Bool, String,) -> Void).self
       """
     )
+    
+    assertParse(
+      """
+      let _ = Array<(
+        bar: String,
+        baaz: String,
+      )>()
+      """,
+      substructure: FunctionCallExprSyntax(
+        calledExpression: GenericSpecializationExprSyntax(
+          expression: DeclReferenceExprSyntax(baseName: .identifier("Array")),
+          genericArgumentClause: GenericArgumentClauseSyntax(
+            leftAngle: .leftAngleToken(),
+            arguments: GenericArgumentListSyntax([
+              GenericArgumentSyntax(
+                argument: .type(TypeSyntax(TupleTypeSyntax(
+                  leftParen: .leftParenToken(),
+                  elements: TupleTypeElementListSyntax([
+                    TupleTypeElementSyntax(
+                      firstName: .identifier("bar"),
+                      colon: .colonToken(),
+                      type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String"))),
+                      trailingComma: .commaToken()
+                    ),
+                    TupleTypeElementSyntax(
+                      firstName: .identifier("baaz"),
+                      colon: .colonToken(),
+                      type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String"))),
+                      trailingComma: .commaToken()
+                    )
+                  ]),
+                  rightParen: .rightParenToken()
+                )))
+              )
+            ]),
+            rightAngle: .rightAngleToken()
+          )
+        ),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([]),
+        rightParen: .rightParenToken()
+      )
+    )
   }
 
   func testSecondaryArgumentLabelDollarIdentifierInClosure() {


### PR DESCRIPTION
This PR fixes support for trailing commas in tuples within generic arguments.

This currently fails to compile in Swift 6.2 due to being parsed incorrectly. The type lookahead returns `false` so it confuses the `<` for a less-than operator.

```swift
// error: cannot convert value of type 'Bool' to expected argument type '()'
let _ = Array<[(
  bar: String,
  baaz: String,
)]>()
```