### PR TITLE
Make SwiftSyntaxCShims compatible with C++

### DIFF
--- a/Sources/_SwiftSyntaxCShims/include/Atomics.h
+++ b/Sources/_SwiftSyntaxCShims/include/Atomics.h
@@ -16,6 +16,10 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
   _Atomic(bool) value;
 } AtomicBool;
@@ -49,5 +53,9 @@ static inline const void *_Nullable swiftsyntax_atomic_pointer_get(const AtomicP
 static inline void swiftsyntax_atomic_pointer_set(AtomicPointer *_Nonnull atomic, const void *_Nullable newValue) {
   atomic->value = newValue;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // SWIFTSYNTAX_ATOMICBOOL_H

--- a/Sources/_SwiftSyntaxCShims/include/PlatformMutex.h
+++ b/Sources/_SwiftSyntaxCShims/include/PlatformMutex.h
@@ -15,6 +15,10 @@
 
 #include "_bridging.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct PlatformMutex {
   void *opaque;
 } PlatformMutex;
@@ -30,5 +34,9 @@ void swiftsyntax_platform_mutex_unlock(PlatformMutex m);
 
 SWIFT_NAME_S("PlatformMutex.destroy(self:)")
 void swiftsyntax_platform_mutex_destroy(PlatformMutex m);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // SWIFTSYNTAX_PLATFORMMUTEX_H

--- a/Sources/_SwiftSyntaxCShims/include/swiftsyntax_errno.h
+++ b/Sources/_SwiftSyntaxCShims/include/swiftsyntax_errno.h
@@ -17,9 +17,17 @@
 
 #include <errno.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SWIFT_NAME_S("getter:swift_syntax_errno()")
 static inline int swiftsyntax_errno(void) {
   return errno;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // SWIFTSYNTAX_ERRNO_H

--- a/Sources/_SwiftSyntaxCShims/include/swiftsyntax_stdio.h
+++ b/Sources/_SwiftSyntaxCShims/include/swiftsyntax_stdio.h
@@ -17,6 +17,10 @@
 
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 SWIFT_NAME_S("getter:swift_syntax_stdout()")
 static inline FILE *swiftsyntax_stdout(void) {
   return stdout;
@@ -31,5 +35,9 @@ SWIFT_NAME_S("getter:swift_syntax_stderr()")
 static inline FILE *swiftsyntax_stderr(void) {
   return stderr;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // SWIFTSYNTAX_STDIO_H


### PR DESCRIPTION
This fixes a build failure in some external projects that depend on SwiftSyntax and enable C++ interop:

```
Undefined symbols for architecture arm64:
  "swiftsyntax_platform_mutex_lock(PlatformMutex)", referenced from:
      SwiftSyntax.SyntaxDataArena.layout(for: SwiftSyntax.ArenaAllocatedPointer<SwiftSyntax.SyntaxData>) -> SwiftSyntax.ArenaAllocatedBufferPointer<SwiftSyntax.ArenaAllocatedPointer<SwiftSyntax.SyntaxData>?> in Syntax.swift.o
```

rdar://161624532