### PR TITLE
Allow peer macros on variables with multiple bindings in assertMacroExpansion

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -246,10 +246,6 @@ private func expandPeerMacroMember(
   in context: some MacroExpansionContext,
   indentationWidth: Trivia
 ) throws -> MemberBlockItemListSyntax? {
-  if let variable = attachedTo.as(VariableDeclSyntax.self), variable.bindings.count > 1 {
-    throw MacroApplicationError.peerMacroOnVariableWithMultipleBindings
-  }
-
   guard
     let expanded = expandAttachedMacro(
       definition: definition,
@@ -278,10 +274,6 @@ private func expandPeerMacroCodeItem(
   in context: some MacroExpansionContext,
   indentationWidth: Trivia
 ) throws -> CodeBlockItemListSyntax? {
-  if let variable = attachedTo.as(VariableDeclSyntax.self), variable.bindings.count > 1 {
-    throw MacroApplicationError.peerMacroOnVariableWithMultipleBindings
-  }
-
   guard
     let expanded = expandAttachedMacro(
       definition: definition,
@@ -622,7 +614,6 @@ let diagnosticDomain: String = "SwiftSyntaxMacroExpansion"
 
 private enum MacroApplicationError: DiagnosticMessage, Error {
   case accessorMacroOnVariableWithMultipleBindings
-  case peerMacroOnVariableWithMultipleBindings
   case malformedAccessor
 
   var diagnosticID: MessageID {
@@ -635,8 +626,6 @@ private enum MacroApplicationError: DiagnosticMessage, Error {
     switch self {
     case .accessorMacroOnVariableWithMultipleBindings:
       return "accessor macro can only be applied to a single variable"
-    case .peerMacroOnVariableWithMultipleBindings:
-      return "peer macro can only be applied to a single variable"
     case .malformedAccessor:
       return """
         macro returned a malformed accessor. Accessors should start with an introducer like 'get' or 'set'.

--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -171,10 +171,9 @@ final class PeerMacroTests: XCTestCase {
       """,
       expandedSource: """
         let a = 17, b = 12
+
+        var baz: Int = 0
         """,
-      diagnostics: [
-        DiagnosticSpec(message: "peer macro can only be applied to a single variable", line: 1, column: 1)
-      ],
       macros: ["Test": TestMacro.self]
     )
 
@@ -188,11 +187,37 @@ final class PeerMacroTests: XCTestCase {
       expandedSource: """
         struct Foo {
           let a = 17, b = 12
+
+          var baz: Int = 0
         }
         """,
-      diagnostics: [
-        DiagnosticSpec(message: "peer macro can only be applied to a single variable", line: 2, column: 3)
-      ],
+      macros: ["Test": TestMacro.self]
+    )
+  }
+
+  func testPeerMacroReturningNoPeersOnVariableWithMultipleBindings() {
+    struct TestMacro: PeerMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      struct Foo {
+        @Test
+        var a: Int, b: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          var a: Int, b: Int
+        }
+        """,
       macros: ["Test": TestMacro.self]
     )
   }


### PR DESCRIPTION
`assertMacroExpansion` rejects a peer macro attached to a variable declaration with more than one binding, such as `var a: Int, b: Int`, raising "peer macro can only be applied to a single variable" before the macro is ever invoked. Reported in #3320.

This restriction dates back to #2154, when the rationale was that the compiler effectively disallowed this: it invoked the peer macro once per binding with the same syntax node, which generated the same peers twice and produced a redeclaration error. That is no longer the situation. The compiler now invokes a peer macro on such declarations and only diagnoses a problem if the macro itself emits conflicting declarations. A peer macro that returns no peers (the case in #3320), or that returns peers with unique names, compiles cleanly.

I verified this against the Swift 6.3 toolchain by building a peer macro and applying it to `var a: Int = 1, b: Int = 2`:

- Returning `[]` compiles and runs with no diagnostics.
- Returning a declaration with a `context.makeUniqueName` based name compiles cleanly.
- Returning a fixed-name declaration fails only with "invalid redeclaration", and the note shows the macro was expanded on each property, confirming the macro is invoked rather than rejected outright.

So the guard made `assertMacroExpansion` emit a false-positive diagnostic for code the compiler accepts, which makes it an unreliable oracle when testing peer macros on multi-binding variables.

The fix removes the binding-count guard from both `expandPeerMacroMember` and `expandPeerMacroCodeItem`, so the peer macro runs on the whole declaration and its peers are emitted, matching the compiler. The now-unused `peerMacroOnVariableWithMultipleBindings` error case is dropped. The accessor-macro restriction is intentionally left untouched, since the compiler genuinely does not allow accessor macros on multi-binding variables.

The existing `testPeerMacroOnVariableWithMultipleBindings` is updated to assert that the peer is now emitted, and a new `testPeerMacroReturningNoPeersOnVariableWithMultipleBindings` covers the exact scenario from #3320. Both fail against the current code with the spurious diagnostic and pass after the change. The full SwiftSyntaxMacroExpansion test target (135 tests) passes.