### PR TITLE
[SwiftParser] Intern source text per parsed token

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -47,26 +47,29 @@ class ParsedSyntaxRegistry {
     swiftVersion: Parser.SwiftVersion,
     experimentalFeatures: Parser.ExperimentalFeatures
   ) -> Syntax {
-    var parser = Parser(
-      source,
+    // The parse runs entirely within `withParser`, so lex directly over the
+    // source without copying it into a parser-owned buffer.
+    return Parser.withParser(
+      source: source,
       swiftVersion: swiftVersion,
       experimentalFeatures: experimentalFeatures
-    )
-    switch kind {
-    case .declaration:
-      return Syntax(DeclSyntax.parse(from: &parser))
-    case .statement:
-      return Syntax(StmtSyntax.parse(from: &parser))
-    case .expression:
-      return Syntax(ExprSyntax.parse(from: &parser))
-    case .type:
-      return Syntax(TypeSyntax.parse(from: &parser))
-    case .pattern:
-      return Syntax(PatternSyntax.parse(from: &parser))
-    case .attribute:
-      return Syntax(AttributeSyntax.parse(from: &parser))
-    case .accessor:
-      return Syntax(AccessorDeclSyntax.parse(from: &parser))
+    ) { parser in
+      switch kind {
+      case .declaration:
+        return Syntax(DeclSyntax.parse(from: &parser))
+      case .statement:
+        return Syntax(StmtSyntax.parse(from: &parser))
+      case .expression:
+        return Syntax(ExprSyntax.parse(from: &parser))
+      case .type:
+        return Syntax(TypeSyntax.parse(from: &parser))
+      case .pattern:
+        return Syntax(PatternSyntax.parse(from: &parser))
+      case .attribute:
+        return Syntax(AttributeSyntax.parse(from: &parser))
+      case .accessor:
+        return Syntax(AccessorDeclSyntax.parse(from: &parser))
+      }
     }
   }
 

--- a/Sources/SwiftIDEUtils/NameMatcher.swift
+++ b/Sources/SwiftIDEUtils/NameMatcher.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
-import SwiftParser
+@_spi(RawSyntax) import SwiftParser
 public import SwiftSyntax
 #else
-import SwiftParser
+@_spi(RawSyntax) import SwiftParser
 import SwiftSyntax
 #endif
 
@@ -227,8 +227,9 @@ public class NameMatcher: SyntaxAnyVisitor {
       let triviaRangeEndOffsetInToken = triviaRange.upperBound.utf8Offset - token.position.utf8Offset
       let commentTree = token.syntaxTextBytes[positionOffsetInToken..<triviaRangeEndOffsetInToken]
         .withUnsafeBufferPointer { (buffer) -> ExprSyntax in
-          var parser = Parser(buffer)
-          return ExprSyntax.parse(from: &parser)
+          // The parse runs entirely within this scope, so lex directly over
+          // `buffer` without copying it.
+          Parser.withParser(source: buffer) { ExprSyntax.parse(from: &$0) }
         }
       // Run a new `NameMatcher`. Since the input of that name matcher is the text after the position to resolve, we
       // want to resolve the position at offset 0.

--- a/Sources/SwiftParser/ParseSourceFile.swift
+++ b/Sources/SwiftParser/ParseSourceFile.swift
@@ -22,8 +22,13 @@ extension Parser {
   public static func parse(
     source: String
   ) -> SourceFileSyntax {
-    var parser = Parser(source)
-    return SourceFileSyntax.parse(from: &parser)
+    return withParser(
+      source: source,
+      maximumNestingLevel: nil,
+      parseTransition: nil,
+      swiftVersion: nil,
+      experimentalFeatures: []
+    ) { SourceFileSyntax.parse(from: &$0) }
   }
 
   /// A compiler interface that allows the enabling of experimental features.
@@ -33,8 +38,13 @@ extension Parser {
     swiftVersion: SwiftVersion? = nil,
     experimentalFeatures: ExperimentalFeatures
   ) -> SourceFileSyntax {
-    var parser = Parser(source, swiftVersion: swiftVersion, experimentalFeatures: experimentalFeatures)
-    return SourceFileSyntax.parse(from: &parser)
+    return withParser(
+      source: source,
+      maximumNestingLevel: nil,
+      parseTransition: nil,
+      swiftVersion: swiftVersion,
+      experimentalFeatures: experimentalFeatures
+    ) { SourceFileSyntax.parse(from: &$0) }
   }
 
   /// Parse the source code in the given buffer as Swift source file. See
@@ -44,8 +54,13 @@ extension Parser {
     maximumNestingLevel: Int? = nil,
     swiftVersion: SwiftVersion? = nil
   ) -> SourceFileSyntax {
-    var parser = Parser(source, maximumNestingLevel: maximumNestingLevel, swiftVersion: swiftVersion)
-    return SourceFileSyntax.parse(from: &parser)
+    return withParser(
+      source: source,
+      maximumNestingLevel: maximumNestingLevel,
+      parseTransition: nil,
+      swiftVersion: swiftVersion,
+      experimentalFeatures: []
+    ) { SourceFileSyntax.parse(from: &$0) }
   }
 
   /// Parse the source code in the given string as Swift source file with support
@@ -120,8 +135,13 @@ extension Parser {
     source: String,
     parseTransition: IncrementalParseTransition?
   ) -> IncrementalParseResult {
-    var parser = Parser(source, parseTransition: parseTransition)
-    return IncrementalParseResult(tree: SourceFileSyntax.parse(from: &parser), lookaheadRanges: parser.lookaheadRanges)
+    return withParser(
+      source: source,
+      maximumNestingLevel: nil,
+      parseTransition: parseTransition,
+      swiftVersion: nil,
+      experimentalFeatures: []
+    ) { IncrementalParseResult(tree: SourceFileSyntax.parse(from: &$0), lookaheadRanges: $0.lookaheadRanges) }
   }
 
   /// Parse the source code in the given buffer as Swift source file with support
@@ -133,8 +153,13 @@ extension Parser {
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition?
   ) -> IncrementalParseResult {
-    var parser = Parser(source, maximumNestingLevel: maximumNestingLevel, parseTransition: parseTransition)
-    return IncrementalParseResult(tree: SourceFileSyntax.parse(from: &parser), lookaheadRanges: parser.lookaheadRanges)
+    return withParser(
+      source: source,
+      maximumNestingLevel: maximumNestingLevel,
+      parseTransition: parseTransition,
+      swiftVersion: nil,
+      experimentalFeatures: []
+    ) { IncrementalParseResult(tree: SourceFileSyntax.parse(from: &$0), lookaheadRanges: $0.lookaheadRanges) }
   }
 }
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -119,7 +119,13 @@ public struct Parser {
   public internal(set) var lookaheadRanges = LookaheadRanges()
 
   /// Parser should own a ``LookaheadTracker`` so that we can share one `furthestOffset` in a parse.
-  let lookaheadTrackerOwner: LookaheadTrackerOwner
+  private let lookaheadTrackerOwner: LookaheadTrackerOwner
+
+  /// Owns the source buffer for the lifetime of this parser when the parser
+  /// created its own arena. The source is not copied into the arena, so it is
+  /// freed when this `Parser` is destroyed. `nil` when the source lives
+  /// elsewhere (a caller-provided arena that already owns the buffer).
+  private let sourceBufferOwner: ParserSourceBufferOwner?
 
   /// The Swift version as which this source file should be parsed.
   let swiftVersion: SwiftVersion
@@ -199,10 +205,11 @@ public struct Parser {
   /// The delegated initializer for the parser.
   ///
   /// - Parameters
-  ///   - input: An input buffer containing Swift source text. If a non-`nil`
-  ///            arena is provided, the buffer must be present in it. Otherwise
-  ///            the buffer is copied into a new arena and can thus be freed
-  ///            after the initializer has been called.
+  ///   - input: An input buffer containing Swift source text. When
+  ///            `copySource` is `true` it is copied into a parser-owned buffer
+  ///            and can be freed after the initializer returns. When `false` the
+  ///            caller must keep `input` valid for the entire parse (see
+  ///            `withParser`).
   ///   - maximumNestingLevel: To avoid overflowing the stack, the parser will
   ///                          stop if a nesting level greater than this value
   ///                          is reached. The nesting level is increased
@@ -211,10 +218,12 @@ public struct Parser {
   ///                          if this is `nil`.
   ///   - parseTransition: The previously recorded state for an incremental
   ///                      parse, or `nil`.
-  ///   - arena: Arena the parsing syntax are made into. If it's `nil`, a new
-  ///            arena is created automatically, and `input` copied into the
-  ///            arena. If non-`nil`, `input` must be within its registered
-  ///            source buffer or allocator.
+  ///   - arena: Arena the parsed syntax is made into. If `nil`, a new arena is
+  ///            created automatically.
+  ///   - copySource: Whether to copy `input` into a parser-owned buffer. Pass
+  ///                 `false` only when the caller guarantees `input` remains
+  ///                 valid for the resulting `Parser`'s lifetime (the buffer is
+  ///                 only read while lexing, which happens during that lifetime).
   ///  - swiftVersion: The version of Swift using which the file should be parsed.
   ///                  Defaults to the latest version.
   ///  - experimentalFeatures: The experimental features enabled for the parser.
@@ -223,16 +232,28 @@ public struct Parser {
     maximumNestingLevel: Int?,
     parseTransition: IncrementalParseTransition?,
     arena: ParsingRawSyntaxArena?,
+    copySource: Bool,
     swiftVersion: SwiftVersion?,
     experimentalFeatures: ExperimentalFeatures
   ) {
+    self.arena = arena ?? ParsingRawSyntaxArena(parseTriviaFunction: TriviaParser.parseTrivia)
+
     var input = input
-    if let arena {
-      self.arena = arena
-      precondition(arena.contains(text: SyntaxText(baseAddress: input.baseAddress, count: input.count)))
+    if copySource {
+      // Copy the source into a parser-owned buffer so the caller may free their
+      // buffer once this initializer returns. The buffer is freed when this
+      // `Parser` is destroyed (i.e. when the parse call returns); each token's
+      // text is interned into the arena at node-creation time, so the resulting
+      // tree does not reference this buffer.
+      let owner = ParserSourceBufferOwner(copying: input)
+      self.sourceBufferOwner = owner
+      input = owner.buffer
     } else {
-      self.arena = ParsingRawSyntaxArena(parseTriviaFunction: TriviaParser.parseTrivia)
-      input = self.arena.internSourceBuffer(input)
+      // No-copy: lex directly over the caller-provided buffer. The caller
+      // guarantees it stays valid for the entire parse (see `withParser`). Each
+      // token's text is interned into the arena, so the tree is self-contained
+      // and does not reference the buffer after parsing.
+      self.sourceBufferOwner = nil
     }
 
     self.maximumNestingLevel = maximumNestingLevel ?? Self.defaultMaximumNestingLevel
@@ -269,6 +290,10 @@ public struct Parser {
         maximumNestingLevel: maximumNestingLevel,
         parseTransition: parseTransition,
         arena: nil,
+        // The String's UTF-8 storage is only valid inside `withUTF8`, but the
+        // parse happens after this initializer returns, so the source must be
+        // copied into a parser-owned buffer.
+        copySource: true,
         swiftVersion: swiftVersion,
         experimentalFeatures: experimentalFeatures
       )
@@ -295,10 +320,9 @@ public struct Parser {
   /// Initializes a ``Parser`` from the given input buffer.
   ///
   /// - Parameters
-  ///   - input: An input buffer containing Swift source text. If a non-`nil`
-  ///            arena is provided, the buffer must be present in it. Otherwise
-  ///            the buffer is copied into a new arena and can thus be freed
-  ///            after the initializer has been called.
+  ///   - input: An input buffer containing Swift source text. It is copied into
+  ///            a parser-owned buffer, so it can be freed after the initializer
+  ///            has been called.
   ///   - maximumNestingLevel: To avoid overflowing the stack, the parser will
   ///                          stop if a nesting level greater than this value
   ///                          is reached. The nesting level is increased
@@ -313,12 +337,14 @@ public struct Parser {
     parseTransition: IncrementalParseTransition? = nil,
     swiftVersion: SwiftVersion? = nil
   ) {
-    // Chain to the private buffer initializer.
+    // Chain to the private buffer initializer. Copy the source so the caller may
+    // free `input` after this initializer returns.
     self.init(
       buffer: input,
       maximumNestingLevel: maximumNestingLevel,
       parseTransition: parseTransition,
       arena: nil,
+      copySource: true,
       swiftVersion: swiftVersion,
       experimentalFeatures: []
     )
@@ -355,15 +381,114 @@ public struct Parser {
     swiftVersion: SwiftVersion? = nil,
     experimentalFeatures: ExperimentalFeatures
   ) {
-    // Chain to the private buffer initializer.
+    // Chain to the private buffer initializer. Copy the source so the caller may
+    // free `input` after this initializer returns, and so the resulting tree
+    // does not depend on `input` (its tokens are interned into `arena`).
     self.init(
       buffer: input,
       maximumNestingLevel: maximumNestingLevel,
       parseTransition: parseTransition,
       arena: arena,
+      copySource: true,
       swiftVersion: swiftVersion,
       experimentalFeatures: experimentalFeatures
     )
+  }
+
+  /// Runs `body` with a `Parser` that lexes directly over `input` without
+  /// copying it into a parser-owned buffer.
+  ///
+  /// This is the no-copy fast path used by the static `parse` entry points and
+  /// by string-interpolation literal construction: the entire parse runs inside
+  /// this scope, where `input` is guaranteed valid, and each token's text is
+  /// interned into the arena so the resulting tree is self-contained once `body`
+  /// returns.
+  ///
+  /// - Important: `input` must remain valid for the entire duration of `body`.
+  ///   It is *not* referenced after `body` returns.
+  /// - Important: The `Parser` passed to `body` must not escape the closure. It
+  ///   lexes directly over `input`, so it is only valid within this scope.
+  @_spi(RawSyntax)
+  public static func withParser<T>(
+    source input: UnsafeBufferPointer<UInt8>,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil,
+    body: (inout Parser) -> T
+  ) -> T {
+    return withParser(
+      source: input,
+      maximumNestingLevel: maximumNestingLevel,
+      parseTransition: parseTransition,
+      swiftVersion: nil,
+      experimentalFeatures: [],
+      body: body
+    )
+  }
+
+  /// Runs `body` with a `Parser` that lexes directly over `input` without
+  /// copying it into a parser-owned buffer, with a given Swift version and set
+  /// of experimental language features.
+  ///
+  /// This is the no-copy fast path: the entire parse runs inside this scope,
+  /// where `input` is guaranteed valid, and each token's text is interned into
+  /// the arena so the resulting tree is self-contained once `body` returns.
+  ///
+  /// - Important: `input` must remain valid for the entire duration of `body`.
+  ///   It is *not* referenced after `body` returns.
+  /// - Important: The `Parser` passed to `body` must not escape the closure. It
+  ///   lexes directly over `input`, so it is only valid within this scope.
+  @_spi(RawSyntax)
+  @_spi(ExperimentalLanguageFeatures)
+  public static func withParser<T>(
+    source input: UnsafeBufferPointer<UInt8>,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil,
+    swiftVersion: SwiftVersion?,
+    experimentalFeatures: ExperimentalFeatures,
+    body: (inout Parser) -> T
+  ) -> T {
+    var parser = Parser(
+      buffer: input,
+      maximumNestingLevel: maximumNestingLevel,
+      parseTransition: parseTransition,
+      arena: nil,
+      copySource: false,
+      swiftVersion: swiftVersion,
+      experimentalFeatures: experimentalFeatures
+    )
+    return body(&parser)
+  }
+
+  /// Runs `body` with a no-copy `Parser` over the UTF-8 of `input`, with a given
+  /// Swift version and set of experimental language features.
+  ///
+  /// The entire parse runs inside `String.withUTF8`, where the contiguous UTF-8
+  /// storage is valid, so no copy of the source is needed.
+  ///
+  /// - Important: The `Parser` passed to `body` must not escape the closure. It
+  ///   lexes directly over `input`, so it is only valid within this scope.
+  @_spi(RawSyntax)
+  @_spi(ExperimentalLanguageFeatures)
+  public static func withParser<T>(
+    source input: String,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil,
+    swiftVersion: SwiftVersion?,
+    experimentalFeatures: ExperimentalFeatures,
+    body: (inout Parser) -> T
+  ) -> T {
+    var input = input
+    input.makeContiguousUTF8()
+    return input.withUTF8 { buffer in
+      withParser(
+        source: buffer,
+        maximumNestingLevel: maximumNestingLevel,
+        parseTransition: parseTransition,
+        swiftVersion: swiftVersion,
+        experimentalFeatures: experimentalFeatures,
+        body: body
+      )
+    }
   }
 
   mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText? = nil) -> RawTokenSyntax {
@@ -920,7 +1045,7 @@ public struct LookaheadTracker {
 /// Owns a ``LookaheadTracker``.
 ///
 /// Once the `LookeaheadTrackerOwner` is deinitialized, the ``LookaheadTracker`` is also destroyed.
-class LookaheadTrackerOwner {
+private final class LookaheadTrackerOwner {
   var lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>
 
   init() {
@@ -930,6 +1055,25 @@ class LookaheadTrackerOwner {
 
   deinit {
     self.lookaheadTracker.deallocate()
+  }
+}
+
+/// Owns a copy of the source buffer for the lifetime of a `Parser`.
+///
+/// The parser lexes over this buffer and interns each token's text into the
+/// arena at node-creation time, so once parsing finishes the resulting tree no
+/// longer references the source.
+private final class ParserSourceBufferOwner {
+  let buffer: UnsafeBufferPointer<UInt8>
+
+  init(copying input: UnsafeBufferPointer<UInt8>) {
+    let allocated = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: input.count)
+    _ = allocated.initialize(from: input)
+    self.buffer = UnsafeBufferPointer(start: allocated.baseAddress, count: input.count)
+  }
+
+  deinit {
+    self.buffer.deallocate()
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -577,10 +577,10 @@ extension RawSyntax {
     tokenDiagnostic: TokenDiagnostic?,
     arena: __shared ParsingRawSyntaxArena
   ) -> RawSyntax {
-    assert(
-      arena.contains(text: wholeText),
-      "token text must be managed by the arena"
-    )
+    // Intern the token's whole text into the arena's node allocator so the tree
+    // does not depend on the source buffer outliving the parse. `textRange` is
+    // 0-based within `wholeText`, so it is unaffected by the copy.
+    let wholeText = arena.internParsedTokenText(wholeText)
     let payload = RawSyntaxData.ParsedToken(
       tokenKind: kind,
       wholeText: wholeText,
@@ -619,6 +619,14 @@ extension RawSyntax {
     tokenDiagnostic: TokenDiagnostic?,
     arena: __shared RawSyntaxArena
   ) -> RawSyntax {
+    // A materialized token's `text` must outlive the tree. Callers may pass text
+    // that is already arena-managed, a static default (`kind.defaultText`), or -
+    // during parsing - a slice of the `Parser`-owned source buffer, which does
+    // *not* outlive the parse. Intern dynamic text so the token is always
+    // self-contained. `intern` is a no-op for already-arena-managed (and empty)
+    // text, and we skip static defaults to avoid copying constants into every
+    // token.
+    let text = kind.defaultText?.baseAddress == text.baseAddress ? text : arena.intern(text)
     let payload = RawSyntaxData.MaterializedToken(
       tokenKind: kind,
       tokenText: text,

--- a/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
@@ -184,53 +184,28 @@ public class RawSyntaxArena {
 public class ParsingRawSyntaxArena: RawSyntaxArena {
   public typealias ParseTriviaFunction = (_ source: SyntaxText, _ position: TriviaPosition) -> [RawTriviaPiece]
 
-  /// Source file buffer the Syntax tree represents.
-  private var sourceBuffer: UnsafeBufferPointer<UInt8>
-
   /// Function to parse trivia.
   ///
   /// - Important: Must never be changed to a mutable value. See `RawSyntaxArenaRef.parseTrivia`.
   private let parseTriviaFunction: ParseTriviaFunction
 
   public init(parseTriviaFunction: @escaping ParseTriviaFunction) {
-    self.sourceBuffer = .init(start: nil, count: 0)
     self.parseTriviaFunction = parseTriviaFunction
     super.init(slabSize: 4096)
   }
 
-  /// Copies a source buffer in to the memory this arena manages, and returns
-  /// the interned buffer.
+  /// Intern a parsed token's whole text into the arena's node allocator so the
+  /// resulting node does not depend on the source buffer.
   ///
-  /// The interned buffer is guaranteed to be null-terminated.
-  /// `contains(address _:)` is faster if the address is inside the memory
-  /// range this function returned.
-  public func internSourceBuffer(_ buffer: UnsafeBufferPointer<UInt8>) -> UnsafeBufferPointer<UInt8> {
-    let allocated = allocator.allocate(
-      UInt8.self,
-      count: buffer.count + /* for NULL */ 1
-    )
-    precondition(sourceBuffer.baseAddress == nil, "SourceBuffer should only be set once.")
-    _ = allocated.initialize(from: buffer)
-
-    // NULL terminate.
-    allocated.baseAddress!.advanced(by: buffer.count).initialize(to: 0)
-
-    sourceBuffer = UnsafeBufferPointer(start: allocated.baseAddress!, count: buffer.count)
-    return sourceBuffer
-  }
-
-  public override func contains(text: SyntaxText) -> Bool {
-    if let addr = text.baseAddress, self.sourceBufferContains(addr) {
-      return true
+  /// Unlike `intern(_:)`, this skips the `contains` check: lexer-produced text
+  /// is never already managed by the arena, so a copy is always needed.
+  func internParsedTokenText(_ text: SyntaxText) -> SyntaxText {
+    if text.isEmpty {
+      return text
     }
-    return super.contains(text: text)
-  }
-
-  /// Checks if the given memory address is inside the memory range returned
-  /// from `internSourceBuffer(_:)` method.
-  func sourceBufferContains(_ address: UnsafePointer<UInt8>) -> Bool {
-    guard let sourceStart = sourceBuffer.baseAddress else { return false }
-    return sourceStart <= address && address < sourceStart.advanced(by: sourceBuffer.count)
+    let allocated = allocateTextBuffer(count: text.count)
+    _ = allocated.initialize(from: text)
+    return SyntaxText(baseAddress: allocated.baseAddress, count: allocated.count)
   }
 
   /// Parse `source` into a list of ``RawTriviaPiece`` using `parseTriviaFunction`.

--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -12,7 +12,7 @@
 
 #if compiler(>=6)
 internal import SwiftDiagnostics
-public import SwiftParser
+@_spi(RawSyntax) public import SwiftParser
 internal import SwiftParserDiagnostics
 internal import SwiftSyntax
 // Don't introduce a dependency on OSLog when building SwiftSyntax using CMake
@@ -23,7 +23,7 @@ private import os
 
 #else
 import SwiftDiagnostics
-import SwiftParser
+@_spi(RawSyntax) import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax
 
@@ -89,9 +89,7 @@ extension SyntaxParseable {
   ///              be logged using OSLog on Darwin platforms.
   public init(stringInterpolation: SyntaxStringInterpolation) {
     self = stringInterpolation.sourceText.withUnsafeBufferPointer { buffer in
-      var parser = Parser(buffer)
-      let result = Self.parse(from: &parser)
-      return result
+      Parser.withParser(source: buffer) { Self.parse(from: &$0) }
     }
     if self.hasError {
       self.logStringInterpolationParsingError()

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -30,6 +30,42 @@ class EntryTests: ParserTestCase {
     XCTAssertEqual(tree.description, source)
   }
 
+  /// The parser lexes directly over the source buffer, which is not
+  /// null-terminated, so EOF-adjacent lexing must never read past the buffer's
+  /// end. These inputs exercise the code paths most likely to over-read at EOF;
+  /// each must round-trip exactly.
+  ///
+  /// Each case is copied into an exactly-sized allocation so that, under
+  /// AddressSanitizer, any read past the last byte is caught (an `Array`'s or
+  /// `String`'s storage may have trailing slack that would mask such a read).
+  func testParseBufferEOFEdgeCases() throws {
+    func assertRoundTrips(_ bytes: [UInt8], file: StaticString = #filePath, line: UInt = #line) {
+      let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: bytes.count)
+      defer { buffer.deallocate() }
+      _ = buffer.initialize(from: bytes)
+      let tree = Parser.parse(source: UnsafeBufferPointer(buffer))
+      XCTAssertEqual(
+        tree.syntaxTextBytes,
+        bytes,
+        "parsed tree did not round-trip for input \(bytes)",
+        file: file,
+        line: line
+      )
+    }
+
+    assertRoundTrips(Array("".utf8))  // empty input
+    assertRoundTrips(Array("x".utf8))  // single character
+    assertRoundTrips(Array("let a = b +".utf8))  // trailing operator, no newline
+    assertRoundTrips(Array("a /".utf8))  // slash at EOF (comment lookahead)
+    assertRoundTrips(Array("/* unterminated".utf8))  // unterminated block comment at EOF
+    assertRoundTrips(Array("\"unterminated".utf8))  // unterminated string at EOF
+    assertRoundTrips(Array("1.".utf8))  // number needing lookahead at EOF
+    assertRoundTrips(Array("foo".utf8) + [0xE2, 0x80])  // truncated 3-byte UTF-8 at EOF
+    assertRoundTrips(Array("bar".utf8) + [0xF0])  // lone UTF-8 lead byte at EOF
+    assertRoundTrips(Array("#if X".utf8))  // directive at EOF
+    assertRoundTrips(Array("a".utf8) + [0x00] + Array("b".utf8))  // embedded NUL
+  }
+
   func testSyntaxParse() throws {
     assertParse(
       "func test() {}",


### PR DESCRIPTION
Previously, parsing interned the whole source buffer into the `RawSyntaxArena` and pointed each token's `wholeText` into that copy, so the arena kept a copy of the entire source for the tree's lifetime. This compounds under incremental reparsing: each reparse copies the full post-edit source into a new arena, and because reused subtrees keep their origin arenas alive, the retained arenas accumulate roughly one full source copy per generation.

This PR interns each parsed token's text into the node allocator individually, so an arena retains only the text of the tokens that are actually parsed, rather than a copy of the whole source. 

- `ParsingRawSyntaxArena` no longer interns the source buffer; `RawSyntax.parsedToken` copies each token's `wholeText` into the arena's node allocator via a new `internParsedTokenText`.
- `materializedToken` interns any dynamic (non-known-static, non-empty) text as well, so tokens produced by string-literal post-processing (which re-slice existing token text) remain self-contained.
- The common parse entry points now lex directly over the caller's buffer via a new no-copy `Parser.withParser` scope. The `Parser(_:)` public initializers, whose parse happens after the initializer returns, keep a `Parser`-owned copy of the source that is freed when the `Parser` is destroyed.
- The source buffer is no longer null-terminated. All lexer reads are already bounds-checked against the buffer length and the start-of-file sentinel is injected rather than read from the buffer, so the trailing NUL was unnecessary.

### Performance

Measured on a 41.5 KB source file (400 small functions), release build, comparing this change against the previous whole-source-in-arena behavior. Memory is the resident byte count of the latest tree and all arenas it transitively retains.

- **Initial parse: no regression.** Resident memory is unchanged (2792 KB in both — per-token text copies sum to about the same bytes as the single whole-source copy, since tokens tile the source), and parse time is neutral (~2.67 ms baseline vs ~2.71 ms, within noise).
- **Incremental reparsing: ~83% less memory growth.** Applying 30 random single-character edits while retaining every intermediate tree (the editor-style transition chain), per-edit resident growth drops from **50.0 KB/edit to 8.7 KB/edit**, and total growth over the 30 edits from **1500 KB to 261 KB**.
- The number of retained arenas is unchanged (31 after 30 edits in both); the saving comes entirely from each reparse arena no longer carrying a full copy of the post-edit source.
