### PR TITLE
[ParserDiagnostics] Remove unncessary protocol requirements

### DIFF
--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -24,7 +24,6 @@ private let diagnosticDomain: String = "SwiftLexer"
 
 /// An error diagnostic whose ID is determined by the diagnostic's type.
 public protocol TokenError: DiagnosticMessage {
-  var diagnosticID: MessageID { get }
 }
 
 extension TokenError {
@@ -43,7 +42,6 @@ extension TokenError {
 
 /// A warning diagnostic whose ID is determined by the diagnostic's type.
 public protocol TokenWarning: DiagnosticMessage {
-  var diagnosticID: MessageID { get }
 }
 
 extension TokenWarning {

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -24,7 +24,6 @@ private let diagnosticDomain: String = "SwiftParser"
 
 /// An error diagnostic whose ID is determined by the diagnostic's type.
 public protocol ParserError: DiagnosticMessage {
-  var diagnosticID: MessageID { get }
 }
 
 extension ParserError {
@@ -42,7 +41,6 @@ extension ParserError {
 }
 
 public protocol ParserNote: NoteMessage {
-  var noteID: MessageID { get }
 }
 
 extension ParserNote {
@@ -61,7 +59,6 @@ extension ParserNote {
 }
 
 public protocol ParserFixIt: FixItMessage {
-  var fixItID: MessageID { get }
 }
 
 extension ParserFixIt {


### PR DESCRIPTION
These requirements are already declared by the parent protocols.

This workarounds an docc issue in 6.3 toolchain where it emits spurious errors on these requirements.