### PR TITLE
Fix findManifestTargetCall to only search top-level targets array

### DIFF
--- a/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
+++ b/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
@@ -198,7 +198,19 @@ extension FunctionCallExprSyntax {
       return literalValue == targetName
     }
 
-    guard let targetCall = FunctionCallExprSyntax.findFirst(in: targetArray, matching: matchesTargetCall) else {
+    // Only check the top-level elements of the targets array. A recursive
+    // search would incorrectly match a target name that appears inside
+    // another target's `dependencies:` array — e.g. `.target(name: "Foo")`
+    // listed as a dependency has the same `name:` argument as the actual
+    // `.target(name: "Foo")` definition at the top level.
+    guard let targetCall = targetArray.elements.lazy.compactMap({ element -> FunctionCallExprSyntax? in
+      guard let call = element.expression.as(FunctionCallExprSyntax.self),
+        matchesTargetCall(call: call)
+      else {
+        return nil
+      }
+      return call
+    }).first else {
       throw ManifestEditError.cannotFindTarget(targetName: targetName)
     }
 

--- a/Tests/SwiftRefactorTest/ManifestEditTests.swift
+++ b/Tests/SwiftRefactorTest/ManifestEditTests.swift
@@ -642,6 +642,57 @@ final class ManifestEditTests: XCTestCase {
     )
   }
 
+  func testAddTargetDependencyWhenTargetIsAlsoDependency() throws {
+    // Regression test: when a target's name appears inside another target's
+    // dependencies array, the refactoring must modify the actual target
+    // definition, not the nested dependency reference.
+    // See https://github.com/swiftlang/swift-package-manager/issues/10122
+    try assertManifestRefactor(
+      """
+      // swift-tools-version: 5.5
+      let package = Package(
+        name: "packages",
+        targets: [
+          .target(
+            name: "Library",
+            dependencies: [
+              .target(name: "Helper"),
+            ]
+          ),
+          .target(
+            name: "Helper"
+          ),
+        ]
+      )
+      """,
+      expectedManifest: """
+      // swift-tools-version: 5.5
+      let package = Package(
+        name: "packages",
+        targets: [
+          .target(
+            name: "Library",
+            dependencies: [
+              .target(name: "Helper"),
+            ]
+          ),
+          .target(
+            name: "Helper",
+            dependencies: [
+              .target(name: "Support"),
+            ]
+          ),
+        ]
+      )
+      """,
+      provider: AddTargetDependency.self,
+      context: .init(
+        dependency: .target(name: "Support"),
+        targetName: "Helper"
+      )
+    )
+  }
+
   func testAddJava2SwiftPlugin() throws {
     try assertManifestRefactor(
       """


### PR DESCRIPTION
When `swift package add-target-dependency` is used on a target whose name also appears as a dependency of another target, the refactoring incorrectly modifies the dependency reference instead of the actual target definition — producing a malformed `Package.swift`.

**Root cause:** `findManifestTargetCall` used `FirstNodeFinder` which walks the entire syntax tree recursively. Because a target's name string (e.g. `.target(name: "TargetOne")`) can appear both as a top-level target definition *and* nested inside another target's `dependencies:` array, the recursive search finds the nested occurrence first and returns the wrong node.

**Fix:** Replace the recursive `findFirst` search with a linear scan over the top-level elements of the `targets:` array, so only target definitions are considered — not dependency references nested inside them.

A regression test is added that covers the exact scenario from the linked bug report.

Fixes swiftlang/swift-package-manager#10122