### PR TITLE
[Tests] Cover @derivative module selector in ModuleSelectorTests

### DIFF
--- a/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
+++ b/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
@@ -179,8 +179,36 @@ final class ModuleSelectorTests: ParserTestCase {
       )
     )
 
-    // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
-    // @_derivative(of:)
+    assertParse(
+      """
+      @derivative(of: ModuleSelectorTestingKit::negate)
+      func negateDerivative() {}
+      """,
+      substructure: FunctionDeclSyntax(
+        attributes: [
+          .attribute(
+            AttributeSyntax(
+              attributeName: makeType(name: "derivative"),
+              leftParen: .leftParenToken(),
+              arguments: .derivativeRegistrationArguments(
+                DerivativeAttributeArgumentsSyntax(
+                  originalDeclName: makeDeclRef(
+                    moduleSelector: "ModuleSelectorTestingKit",
+                    baseName: "negate"
+                  )
+                )
+              ),
+              rightParen: .rightParenToken()
+            )
+          )
+        ],
+        name: .identifier("negateDerivative"),
+        signature: FunctionSignatureSyntax(
+          parameterClause: FunctionParameterClauseSyntax {}
+        ),
+        body: CodeBlockSyntax {}
+      )
+    )
 
     assertParse(
       """


### PR DESCRIPTION
## Summary

Adds a substructure assertion inside `testModuleSelectorCorrectCode` for the modern autodiff registration attribute with a module selector in its `of:` argument:

```swift
@derivative(of: ModuleSelectorTestingKit::negate)
func negateDerivative() {}
```

The attribute argument list flows through `parseQualifiedDeclarationName` → `parseDeclReferenceExpr`, so module selectors are already supported by the parser. The new test locks that behaviour in for the **simple decl-reference form**, complementing the existing test in `testModuleSelectorAttrs` (line 1754 in the pre-patch file) which covers the complex `member.access` form with a `wrt:` clause.

## Context

Addresses the pre-existing FIXME in `Tests/SwiftParserTest/translated/ModuleSelectorTests.swift`:

```swift
// FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
// @_derivative(of:)
```

Both attribute names in the FIXME use their **legacy underscore-prefixed spellings**. Neither is recognised by the current parser as the special-syntax attribute it refers to:

- `@_derivative` — the `.derivative` keyword text is `"derivative"` (no underscore) in `Sources/SwiftSyntax/generated/Keyword.swift`. `DeclarationAttributeWithSpecialSyntax` in `Sources/SwiftParser/Attributes.swift` matches on this keyword, so source `@_derivative` is not recognised as a derivative-registration attribute. The modern spelling is `@derivative`.
- `@_differentiable(jvp:vjp:)` — the `jvp:` / `vjp:` argument labels have been removed from `parseDifferentiableAttributeArguments`; the modern differentiable attribute uses `KindSpecifier`, `wrt:`, and `where` clauses instead.

The addressable intent of the FIXME — module-selector coverage for a derivative registration attribute inside `testModuleSelectorCorrectCode` — is satisfied here with the modern `@derivative` spelling.

The adjacent FIXME about `@convention(witness_method:)` is a **type-attribute** concern parsed by different code and is intentionally out of scope.

## Test plan

- [ ] `swift test --test-product SwiftParserTests` passes.
- [ ] `swift format -ipr .` produces no diff.
- The new test is inserted inside `testModuleSelectorCorrectCode()` alongside the existing `@_implements` and `@_dynamicReplacement` module-selector coverage. Same substructure pattern as neighbouring tests.
- No changes to parser code or public API.
- Not redundant with the existing `@derivative` test in `testModuleSelectorAttrs` (that test covers the complex `Swift::Foo.Swift::Bar.Swift::baz()` qualified form with `wrt: quux`; this test covers the simple `Module::name` decl-reference form).

## Files changed

- `Tests/SwiftParserTest/translated/ModuleSelectorTests.swift`: **+30 / -2** lines