### PR TITLE
[SwiftParser] Make ExperimentalFeatures public and reduce overloads

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
@@ -94,7 +94,7 @@ struct GenerateSwiftSyntax: AsyncParsableCommand {
 
     var fileSpecs: [GeneratedFileSpec] = [
       // SwiftParser
-      GeneratedFileSpec(swiftParserGeneratedDir + ["ExperimentalFeatures.swift"], experimentalFeaturesFile),
+      GeneratedFileSpec(swiftParserGeneratedDir + ["LanguageFeatures.swift"], languageFeaturesFile),
       GeneratedFileSpec(swiftParserGeneratedDir + ["IsLexerClassified.swift"], isLexerClassifiedFile),
       GeneratedFileSpec(swiftParserGeneratedDir + ["LayoutNodes+Parsable.swift"], layoutNodesParsableFile),
       GeneratedFileSpec(swiftParserGeneratedDir + ["Parser+TokenSpecSet.swift"], parserTokenSpecSetFile),

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ExperimentalFeaturesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ExperimentalFeaturesFile.swift
@@ -19,7 +19,10 @@ let experimentalFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) 
   DeclSyntax(
     """
     extension Parser {
-      @_spi(ExperimentalLanguageFeatures)
+      /// The type is public so it can appear in the (non-SPI) parser API, but
+      /// the individual features are `@_spi(ExperimentalLanguageFeatures)` since
+      /// they are unstable. Clients that don't enable experimental features only
+      /// ever use the empty set.
       public struct ExperimentalFeatures: OptionSet, Hashable, Sendable {
         public let rawValue: UInt
         public init(rawValue: UInt) {
@@ -35,6 +38,7 @@ let experimentalFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) 
       DeclSyntax(
         """
         /// Whether to enable the parsing of \(raw: feature.documentationDescription).
+        @_spi(ExperimentalLanguageFeatures)
         public static let \(feature.token) = Self(rawValue: 1 << \(raw: i))
         """
       )
@@ -44,6 +48,7 @@ let experimentalFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) 
       """
       /// Creates a new value representing the experimental feature with the
       /// given name, or returns nil if the name is not recognized.
+      @_spi(ExperimentalLanguageFeatures)
       public init?(name: String)
       """
     ) {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LanguageFeaturesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LanguageFeaturesFile.swift
@@ -15,7 +15,7 @@ import SwiftSyntaxBuilder
 import SyntaxSupport
 import Utils
 
-let experimentalFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
+let languageFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   DeclSyntax(
     """
     extension Parser {
@@ -23,7 +23,7 @@ let experimentalFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) 
       /// the individual features are `@_spi(ExperimentalLanguageFeatures)` since
       /// they are unstable. Clients that don't enable experimental features only
       /// ever use the empty set.
-      public struct ExperimentalFeatures: OptionSet, Hashable, Sendable {
+      public struct LanguageFeatures: OptionSet, Hashable, Sendable {
         public let rawValue: UInt
         public init(rawValue: UInt) {
           self.rawValue = rawValue
@@ -33,7 +33,7 @@ let experimentalFeaturesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) 
     """
   )
 
-  try! ExtensionDeclSyntax("extension Parser.ExperimentalFeatures") {
+  try! ExtensionDeclSyntax("extension Parser.LanguageFeatures") {
     for (i, feature) in ExperimentalFeature.allCases.enumerated() {
       DeclSyntax(
         """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ParserTokenSpecSetFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ParserTokenSpecSetFile.swift
@@ -21,7 +21,7 @@ func tokenCaseMatch(
 ) -> SwitchCaseSyntax {
   var whereClause = ""
   if let feature = experimentalFeature {
-    whereClause += "where experimentalFeatures.contains(.\(feature.token))"
+    whereClause += "where languageFeatures.contains(.\(feature.token))"
   }
   return "case TokenSpec(.\(enumCaseCallName))\(raw: whereClause): self = .\(enumCaseCallName)"
 }
@@ -54,7 +54,7 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
 
             try InitializerDeclSyntax(
-              "init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures)"
+              "init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures)"
             ) {
               try SwitchExprSyntax("switch PrepareForKeywordMatch(lexeme)") {
                 for choice in choices {

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -41,7 +41,7 @@ extension PluginProviderMessageHandler {
     _ lexicalContext: [PluginMessage.Syntax]?,
     sourceManager: SourceManager,
     swiftVersion: Parser.SwiftVersion?,
-    experimentalFeatures: Parser.ExperimentalFeatures?,
+    languageFeatures: Parser.LanguageFeatures?,
     operatorTable: OperatorTable,
     fallbackSyntax: some SyntaxProtocol
   ) -> [Syntax] {
@@ -55,7 +55,7 @@ extension PluginProviderMessageHandler {
       sourceManager.add(
         $0,
         swiftVersion: swiftVersion,
-        experimentalFeatures: experimentalFeatures,
+        languageFeatures: languageFeatures,
         foldingWith: operatorTable
       )
     }
@@ -72,11 +72,11 @@ extension PluginProviderMessageHandler {
   ) -> PluginToHostMessage {
     let sourceManager = SourceManager(syntaxRegistry: syntaxRegistry)
     let swiftVersion = staticBuildConfiguration?.parserSwiftVersion
-    let experimentalFeatures = staticBuildConfiguration?.experimentalFeatures
+    let languageFeatures = staticBuildConfiguration?.parserLanguageFeatures
     let syntax = sourceManager.add(
       expandingSyntax,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures,
+      languageFeatures: languageFeatures,
       foldingWith: .standardOperators
     )
 
@@ -86,7 +86,7 @@ extension PluginProviderMessageHandler {
         lexicalContext,
         sourceManager: sourceManager,
         swiftVersion: swiftVersion,
-        experimentalFeatures: experimentalFeatures,
+        languageFeatures: languageFeatures,
         operatorTable: .standardOperators,
         fallbackSyntax: syntax
       ),
@@ -147,13 +147,13 @@ extension PluginProviderMessageHandler {
   ) -> PluginToHostMessage {
     let sourceManager = SourceManager(syntaxRegistry: syntaxRegistry)
     let swiftVersion = staticBuildConfiguration?.parserSwiftVersion
-    let experimentalFeatures = staticBuildConfiguration?.experimentalFeatures
+    let languageFeatures = staticBuildConfiguration?.parserLanguageFeatures
 
     func addToSourceManager(_ syntax: PluginMessage.Syntax, foldOperators: Bool) -> Syntax {
       sourceManager.add(
         syntax,
         swiftVersion: swiftVersion,
-        experimentalFeatures: experimentalFeatures,
+        languageFeatures: languageFeatures,
         foldingWith: foldOperators ? .standardOperators : nil
       )
     }
@@ -178,7 +178,7 @@ extension PluginProviderMessageHandler {
         lexicalContext,
         sourceManager: sourceManager,
         swiftVersion: swiftVersion,
-        experimentalFeatures: experimentalFeatures,
+        languageFeatures: languageFeatures,
         operatorTable: .standardOperators,
         fallbackSyntax: declarationNode
       ),

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -32,7 +32,7 @@ class ParsedSyntaxRegistry {
     let source: String
     let kind: PluginMessage.Syntax.Kind
     let swiftVersion: Parser.SwiftVersion
-    let experimentalFeatures: Parser.ExperimentalFeatures
+    let languageFeatures: Parser.LanguageFeatures
   }
 
   private var storage: LRUCache<Key, Syntax>
@@ -45,14 +45,14 @@ class ParsedSyntaxRegistry {
     source: String,
     kind: PluginMessage.Syntax.Kind,
     swiftVersion: Parser.SwiftVersion,
-    experimentalFeatures: Parser.ExperimentalFeatures
+    languageFeatures: Parser.LanguageFeatures
   ) -> Syntax {
     // The parse runs entirely within `withParser`, so lex directly over the
     // source without copying it into a parser-owned buffer.
     return Parser.withParser(
       source: source,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     ) { parser in
       switch kind {
       case .declaration:
@@ -77,15 +77,15 @@ class ParsedSyntaxRegistry {
     source: String,
     kind: PluginMessage.Syntax.Kind,
     swiftVersion: Parser.SwiftVersion?,
-    experimentalFeatures: Parser.ExperimentalFeatures?
+    languageFeatures: Parser.LanguageFeatures?
   ) -> Syntax {
     let swiftVersion = swiftVersion ?? Parser.defaultSwiftVersion
-    let experimentalFeatures = experimentalFeatures ?? Parser.ExperimentalFeatures()
+    let languageFeatures = languageFeatures ?? Parser.LanguageFeatures()
     let key = Key(
       source: source,
       kind: kind,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
     if let cached = storage[key] {
       return cached
@@ -95,7 +95,7 @@ class ParsedSyntaxRegistry {
       source: source,
       kind: kind,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
     storage[key] = node
     return node
@@ -160,14 +160,14 @@ class SourceManager {
   func add(
     _ syntaxInfo: PluginMessage.Syntax,
     swiftVersion: Parser.SwiftVersion?,
-    experimentalFeatures: Parser.ExperimentalFeatures?,
+    languageFeatures: Parser.LanguageFeatures?,
     foldingWith operatorTable: OperatorTable?
   ) -> Syntax {
     var node = syntaxRegistry.get(
       source: syntaxInfo.source,
       kind: syntaxInfo.kind,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
     if let operatorTable {
       node = operatorTable.foldAll(node, errorHandler: { _ in /*ignore*/ })

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -14,14 +14,14 @@
 internal import SwiftDiagnostics
 internal import SwiftIfConfig
 internal import SwiftOperators
-@_spi(ExperimentalLanguageFeatures) internal import SwiftParser
+@_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) internal import SwiftParser
 internal import SwiftSyntax
 internal import SwiftSyntaxMacros
 #else
 import SwiftDiagnostics
 import SwiftIfConfig
 import SwiftOperators
-@_spi(ExperimentalLanguageFeatures) import SwiftParser
+@_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxMacros
 #endif

--- a/Sources/SwiftIfConfig/StaticBuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/StaticBuildConfiguration.swift
@@ -450,10 +450,10 @@ extension StaticBuildConfiguration {
   /// Determine the set of experimental features that are enabled by this
   /// static build configuration.
   @_spi(ExperimentalLanguageFeatures)
-  public var experimentalFeatures: Parser.ExperimentalFeatures {
-    var result: Parser.ExperimentalFeatures = []
+  public var parserLanguageFeatures: Parser.LanguageFeatures {
+    var result: Parser.LanguageFeatures = []
     for feature in features {
-      if let experimentalFeature = Parser.ExperimentalFeatures(name: feature) {
+      if let experimentalFeature = Parser.LanguageFeatures(name: feature) {
         result.insert(experimentalFeature)
       }
     }

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -90,7 +90,7 @@ extension Parser {
     case Sendable
     case transpose
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._backDeploy): self = ._backDeploy
       case TokenSpec(._documentation): self = ._documentation
@@ -1053,7 +1053,7 @@ extension Parser {
             }
           }
 
-          init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+          init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
             switch PrepareForKeywordMatch(lexeme) {
             case TokenSpec(.private): self = .private
             case TokenSpec(.fileprivate): self = .fileprivate

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -65,7 +65,7 @@ extension Parser {
     case star
     case identifier
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.message): self = .message
       case TokenSpec(.renamed): self = .renamed

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -34,6 +34,7 @@ add_swift_syntax_library(SwiftParser
   Statements.swift
   StringLiteralRepresentedLiteralValue.swift
   StringLiterals.swift
+  SwiftParserCompatibility.swift
   SwiftVersion.swift
   SyntaxUtils.swift
   TokenConsumer.swift
@@ -42,7 +43,7 @@ add_swift_syntax_library(SwiftParser
   TriviaParser.swift
   Types.swift
 
-  generated/ExperimentalFeatures.swift
+  generated/LanguageFeatures.swift
   generated/IsLexerClassified.swift
   generated/LayoutNodes+Parsable.swift
   generated/Parser+TokenSpecSet.swift

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -791,7 +791,7 @@ extension Parser {
             case postfixOperator
             case prefixOperator
 
-            init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+            init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
               switch (lexeme.rawTokenKind, lexeme.tokenText) {
               case (.colon, _): self = .colon
               case (.binaryOperator, "=="): self = .binaryOperator
@@ -2083,7 +2083,7 @@ extension Parser {
       case higherThan
       case lowerThan
 
-      init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+      init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
         switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.associativity): self = .associativity
         case TokenSpec(.assignment): self = .assignment

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -34,7 +34,7 @@ extension Parser {
       }
     }
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.poundElseif): self = .poundElseif
       case TokenSpec(.poundElse): self = .poundElse

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -269,7 +269,7 @@ extension Parser {
       case arrow
       case `throws`
 
-      init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+      init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
         switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.binaryOperator): self = .binaryOperator
         case TokenSpec(.infixQuestionMark): self = .infixQuestionMark
@@ -499,7 +499,7 @@ extension Parser {
       )
 
     case (._borrow, let handle)?:
-      assert(self.experimentalFeatures.contains(.oldOwnershipOperatorSpellings))
+      assert(self.languageFeatures.contains(.oldOwnershipOperatorSpellings))
       fallthrough
     case (.borrow, let handle)?:
       if !atContextualKeywordPrefixedSyntax(exprFlavor: flavor) {
@@ -537,7 +537,7 @@ extension Parser {
       )
 
     case (._move, let handle)?:
-      assert(self.experimentalFeatures.contains(.oldOwnershipOperatorSpellings))
+      assert(self.languageFeatures.contains(.oldOwnershipOperatorSpellings))
       fallthrough
     case (.consume, let handle)?:
       if !atContextualKeywordPrefixedSyntax(exprFlavor: flavor) {
@@ -1200,7 +1200,7 @@ extension Parser {
         )
 
         // If fully applied method component, parse as a keypath method.
-        if self.experimentalFeatures.contains(.keypathWithMethodMembers)
+        if self.languageFeatures.contains(.keypathWithMethodMembers)
           && self.at(.leftParen)
         {
           var (unexpectedBeforeLParen, leftParen) = self.expect(.leftParen)
@@ -2344,7 +2344,7 @@ extension Parser.Lookahead {
 extension Parser {
   /// Parse a do expression.
   mutating func parseDoExpression(doHandle: RecoveryConsumptionHandle) -> RawDoExprSyntax {
-    precondition(experimentalFeatures.contains(.doExpressions))
+    precondition(languageFeatures.contains(.doExpressions))
     let (unexpectedBeforeDoKeyword, doKeyword) = self.eat(doHandle)
     let body = self.parseCodeBlock(introducer: doKeyword)
 
@@ -2655,7 +2655,7 @@ extension Parser {
   }
 
   mutating func atSwitchCaseListTerminator() -> Bool {
-    return self.experimentalFeatures.contains(.trailingComma) && self.at(.colon)
+    return self.languageFeatures.contains(.trailingComma) && self.at(.colon)
   }
 
   /// Parse a switch case with a 'default' label.

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -255,7 +255,7 @@ extension Lexer {
     }
     var position: Position
 
-    var experimentalFeatures: Parser.ExperimentalFeatures
+    var languageFeatures: Parser.LanguageFeatures
 
     /// If we have already lexed a token, the kind of the previously lexed token
     var previousTokenKind: RawTokenKind?
@@ -269,9 +269,9 @@ extension Lexer {
 
     private var stateStack: StateStack = StateStack()
 
-    init(input: UnsafeBufferPointer<UInt8>, previous: UInt8, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init(input: UnsafeBufferPointer<UInt8>, previous: UInt8, languageFeatures: Parser.LanguageFeatures) {
       self.position = Position(input: input, previous: previous)
-      self.experimentalFeatures = experimentalFeatures
+      self.languageFeatures = languageFeatures
     }
 
     /// Returns `true` if this cursor is sufficiently different to `other` in a way that indicates that the lexer has
@@ -2521,7 +2521,7 @@ extension Lexer.Cursor {
       return false
     }
 
-    guard let end = Self.findConflictEnd(start, markerKind: kind, experimentalFeatures: experimentalFeatures) else {
+    guard let end = Self.findConflictEnd(start, markerKind: kind, languageFeatures: languageFeatures) else {
       // No end of conflict marker found.
       return false
     }
@@ -2540,7 +2540,7 @@ extension Lexer.Cursor {
   static func findConflictEnd(
     _ curPtr: Lexer.Cursor,
     markerKind: ConflictMarker,
-    experimentalFeatures: Parser.ExperimentalFeatures
+    languageFeatures: Parser.LanguageFeatures
   ) -> Lexer.Cursor? {
     // Get a reference to the rest of the buffer minus the length of the start
     // of the conflict marker.
@@ -2548,7 +2548,7 @@ extension Lexer.Cursor {
     var restOfBuffer = Lexer.Cursor(
       input: .init(start: advanced, count: curPtr.input.count - markerKind.introducer.count),
       previous: curPtr.input[markerKind.introducer.count - 1],
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
     let terminator = markerKind.terminator
     let terminatorStart = terminator.first!
@@ -2570,7 +2570,7 @@ extension Lexer.Cursor {
       return Lexer.Cursor(
         input: .init(start: advanced, count: restOfBuffer.input.count - terminator.count),
         previous: restOfBuffer.input[terminator.count - 1],
-        experimentalFeatures: experimentalFeatures
+        languageFeatures: languageFeatures
       )
     }
     return nil

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -153,15 +153,15 @@ extension Lexer {
     _ input: UnsafeBufferPointer<UInt8>,
     from startIndex: Int = 0,
     lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>,
-    experimentalFeatures: Parser.ExperimentalFeatures
+    languageFeatures: Parser.LanguageFeatures
   ) -> LexemeSequence {
     precondition(input.isEmpty || startIndex < input.endIndex)
     let startChar = startIndex == input.startIndex ? UInt8(ascii: "\0") : input[startIndex - 1]
-    let start = Cursor(input: input, previous: UInt8(ascii: "\0"), experimentalFeatures: experimentalFeatures)
+    let start = Cursor(input: input, previous: UInt8(ascii: "\0"), languageFeatures: languageFeatures)
     let cursor = Cursor(
       input: UnsafeBufferPointer(rebasing: input[startIndex...]),
       previous: startChar,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
     return LexemeSequence(
       sourceBufferStart: start,

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -36,18 +36,18 @@ extension Parser {
 
     /// The experimental features that have been enabled in the underlying
     /// parser.
-    let experimentalFeatures: ExperimentalFeatures
+    let languageFeatures: LanguageFeatures
 
     private init(
       lexemes: Lexer.LexemeSequence,
       currentToken: Lexer.Lexeme,
       swiftVersion: SwiftVersion,
-      experimentalFeatures: ExperimentalFeatures
+      languageFeatures: LanguageFeatures
     ) {
       self.lexemes = lexemes
       self.currentToken = currentToken
       self.swiftVersion = swiftVersion
-      self.experimentalFeatures = experimentalFeatures
+      self.languageFeatures = languageFeatures
     }
 
     fileprivate init(cloning other: Parser) {
@@ -55,7 +55,7 @@ extension Parser {
         lexemes: other.lexemes,
         currentToken: other.currentToken,
         swiftVersion: other.swiftVersion,
-        experimentalFeatures: other.experimentalFeatures
+        languageFeatures: other.languageFeatures
       )
     }
 
@@ -66,7 +66,7 @@ extension Parser {
         lexemes: self.lexemes,
         currentToken: self.currentToken,
         swiftVersion: self.swiftVersion,
-        experimentalFeatures: self.experimentalFeatures
+        languageFeatures: self.languageFeatures
       )
     }
   }
@@ -341,7 +341,7 @@ extension Parser.Lookahead {
     case poundElse
     case poundElseif
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch lexeme.rawTokenKind {
       case .leftParen: self = .leftParen
       case .leftBrace: self = .leftBrace

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -90,7 +90,7 @@ extension Parser {
         (.declarationModifier(._local), let handle)?,
         (.declarationModifier(.__setter_access), let handle)?,
         (.declarationModifier(.reasync), let handle)?
-      where experimentalFeatures.contains(.nonescapableTypes):
+      where languageFeatures.contains(.nonescapableTypes):
         let (unexpectedBeforeKeyword, keyword) = self.eat(handle)
         elements.append(RawDeclModifierSyntax(unexpectedBeforeKeyword, name: keyword, detail: nil, arena: self.arena))
       case (.declarationModifier(.rethrows), _)?:
@@ -181,7 +181,7 @@ extension Parser {
         }
       }
 
-      init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+      init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
         switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.private): self = .private
         case TokenSpec(.fileprivate): self = .fileprivate

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -426,7 +426,7 @@ extension Lexer.Lexeme {
   func isContextualPunctuator(_ name: SyntaxText) -> Bool {
     // Currently we can ignore experimental features since a new kind of
     // non-prefix/infix/postfix operator seems unlikely.
-    return Operator(lexeme: self, experimentalFeatures: []) != nil && self.tokenText == name
+    return Operator(lexeme: self, languageFeatures: []) != nil && self.tokenText == name
   }
 
   var isLexerClassifiedKeyword: Bool {

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -340,7 +340,7 @@ extension Parser {
   }
 
   mutating func atInheritanceListTerminator() -> Bool {
-    return self.experimentalFeatures.contains(.trailingComma) && (self.at(.leftBrace) || self.at(.keyword(.where)))
+    return self.languageFeatures.contains(.trailingComma) && (self.at(.leftBrace) || self.at(.keyword(.where)))
   }
 
   mutating func parsePrimaryAssociatedTypes() -> RawPrimaryAssociatedTypeClauseSyntax {

--- a/Sources/SwiftParser/ParseSourceFile.swift
+++ b/Sources/SwiftParser/ParseSourceFile.swift
@@ -23,14 +23,14 @@ extension Parser {
     source: String,
     maximumNestingLevel: Int? = nil,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures = []
+    languageFeatures: LanguageFeatures = []
   ) -> SourceFileSyntax {
     return withParser(
       source: source,
       maximumNestingLevel: maximumNestingLevel,
       parseTransition: nil,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     ) { SourceFileSyntax.parse(from: &$0) }
   }
 
@@ -40,14 +40,14 @@ extension Parser {
     source: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int? = nil,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures = []
+    languageFeatures: LanguageFeatures = []
   ) -> SourceFileSyntax {
     return withParser(
       source: source,
       maximumNestingLevel: maximumNestingLevel,
       parseTransition: nil,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     ) { SourceFileSyntax.parse(from: &$0) }
   }
 
@@ -131,7 +131,7 @@ extension Parser {
       maximumNestingLevel: nil,
       parseTransition: parseTransition,
       swiftVersion: nil,
-      experimentalFeatures: []
+      languageFeatures: []
     ) { IncrementalParseResult(tree: SourceFileSyntax.parse(from: &$0), lookaheadRanges: $0.lookaheadRanges) }
   }
 
@@ -150,7 +150,7 @@ extension Parser {
       maximumNestingLevel: maximumNestingLevel,
       parseTransition: parseTransition,
       swiftVersion: nil,
-      experimentalFeatures: []
+      languageFeatures: []
     ) { IncrementalParseResult(tree: SourceFileSyntax.parse(from: &$0), lookaheadRanges: $0.lookaheadRanges) }
   }
 }

--- a/Sources/SwiftParser/ParseSourceFile.swift
+++ b/Sources/SwiftParser/ParseSourceFile.swift
@@ -20,27 +20,14 @@ extension Parser {
   /// Parse the source code in the given string as Swift source file. See
   /// `Parser.init` for more details.
   public static func parse(
-    source: String
-  ) -> SourceFileSyntax {
-    return withParser(
-      source: source,
-      maximumNestingLevel: nil,
-      parseTransition: nil,
-      swiftVersion: nil,
-      experimentalFeatures: []
-    ) { SourceFileSyntax.parse(from: &$0) }
-  }
-
-  /// A compiler interface that allows the enabling of experimental features.
-  @_spi(ExperimentalLanguageFeatures)
-  public static func parse(
-    source: UnsafeBufferPointer<UInt8>,
+    source: String,
+    maximumNestingLevel: Int? = nil,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures
+    experimentalFeatures: ExperimentalFeatures = []
   ) -> SourceFileSyntax {
     return withParser(
       source: source,
-      maximumNestingLevel: nil,
+      maximumNestingLevel: maximumNestingLevel,
       parseTransition: nil,
       swiftVersion: swiftVersion,
       experimentalFeatures: experimentalFeatures
@@ -52,14 +39,15 @@ extension Parser {
   public static func parse(
     source: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int? = nil,
-    swiftVersion: SwiftVersion? = nil
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: ExperimentalFeatures = []
   ) -> SourceFileSyntax {
     return withParser(
       source: source,
       maximumNestingLevel: maximumNestingLevel,
       parseTransition: nil,
       swiftVersion: swiftVersion,
-      experimentalFeatures: []
+      experimentalFeatures: experimentalFeatures
     ) { SourceFileSyntax.parse(from: &$0) }
   }
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -277,13 +277,25 @@ public struct Parser {
     }
   }
 
-  /// Private initializer for creating a ``Parser`` from the given string.
-  private init(
-    string input: String,
-    maximumNestingLevel: Int?,
-    parseTransition: IncrementalParseTransition?,
-    swiftVersion: SwiftVersion?,
-    experimentalFeatures: ExperimentalFeatures
+  /// Initializes a ``Parser`` from the given string.
+  ///
+  /// - Parameters:
+  ///   - input: The source text to parse.
+  ///   - maximumNestingLevel: To avoid overflowing the stack, the parser will
+  ///                          stop if a nesting level greater than this value
+  ///                          is reached. `defaultMaximumNestingLevel` is used
+  ///                          if this is `nil`.
+  ///   - parseTransition: The previously recorded state for an incremental
+  ///                      parse, or `nil`.
+  ///   - swiftVersion: The version of Swift to parse as, or `nil` for the
+  ///                   default.
+  ///   - experimentalFeatures: The experimental features to enable.
+  public init(
+    _ input: String,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil,
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: ExperimentalFeatures = []
   ) {
     var input = input
     input.makeContiguousUTF8()
@@ -303,45 +315,30 @@ public struct Parser {
     }
   }
 
-  /// Initializes a ``Parser`` from the given string.
-  public init(
-    _ input: String,
-    maximumNestingLevel: Int? = nil,
-    parseTransition: IncrementalParseTransition? = nil,
-    swiftVersion: SwiftVersion? = nil
-  ) {
-    // Chain to the private String initializer.
-    self.init(
-      string: input,
-      maximumNestingLevel: maximumNestingLevel,
-      parseTransition: parseTransition,
-      swiftVersion: swiftVersion,
-      experimentalFeatures: []
-    )
-  }
-
   /// Initializes a ``Parser`` from the given input buffer.
   ///
-  /// - Parameters
+  /// - Parameters:
   ///   - input: An input buffer containing Swift source text. It is copied into
   ///            a parser-owned buffer, so it can be freed after the initializer
   ///            has been called.
   ///   - maximumNestingLevel: To avoid overflowing the stack, the parser will
   ///                          stop if a nesting level greater than this value
-  ///                          is reached. The nesting level is increased
-  ///                          whenever a bracketed expression like `(` or `{`
-  ///                          is started. `defaultMaximumNestingLevel` is used
+  ///                          is reached. `defaultMaximumNestingLevel` is used
   ///                          if this is `nil`.
   ///   - parseTransition: The previously recorded state for an incremental
   ///                      parse, or `nil`.
+  ///   - swiftVersion: The version of Swift to parse as, or `nil` for the
+  ///                   default.
+  ///   - experimentalFeatures: The experimental features to enable.
   public init(
     _ input: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
-    swiftVersion: SwiftVersion? = nil
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: ExperimentalFeatures = []
   ) {
-    // Chain to the private buffer initializer. Copy the source so the caller may
-    // free `input` after this initializer returns.
+    // Copy the source so the caller may free `input` after this initializer
+    // returns.
     self.init(
       buffer: input,
       maximumNestingLevel: maximumNestingLevel,
@@ -349,44 +346,24 @@ public struct Parser {
       arena: nil,
       copySource: true,
       swiftVersion: swiftVersion,
-      experimentalFeatures: []
-    )
-  }
-
-  /// Initializes a ``Parser`` from the given input string, with a given set
-  /// of experimental language features.
-  @_spi(ExperimentalLanguageFeatures)
-  public init(
-    _ input: String,
-    maximumNestingLevel: Int? = nil,
-    parseTransition: IncrementalParseTransition? = nil,
-    swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures
-  ) {
-    // Chain to the private String initializer.
-    self.init(
-      string: input,
-      maximumNestingLevel: maximumNestingLevel,
-      parseTransition: parseTransition,
-      swiftVersion: swiftVersion,
       experimentalFeatures: experimentalFeatures
     )
   }
 
-  /// Initializes a ``Parser`` from the given input buffer, with a given set
-  /// of experimental language features.
-  @_spi(ExperimentalLanguageFeatures)
+  /// Initializes a ``Parser`` from the given input buffer, allocating the parsed
+  /// syntax into the given arena.
+  @_spi(RawSyntax)
   public init(
     _ input: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
-    arena: ParsingRawSyntaxArena? = nil,
+    arena: ParsingRawSyntaxArena,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures
+    experimentalFeatures: ExperimentalFeatures = []
   ) {
-    // Chain to the private buffer initializer. Copy the source so the caller may
-    // free `input` after this initializer returns, and so the resulting tree
-    // does not depend on `input` (its tokens are interned into `arena`).
+    // Copy the source so the caller may free `input` after this initializer
+    // returns, and so the resulting tree does not depend on `input` (its tokens
+    // are interned into `arena`).
     self.init(
       buffer: input,
       maximumNestingLevel: maximumNestingLevel,
@@ -416,38 +393,8 @@ public struct Parser {
     source input: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
-    body: (inout Parser) -> T
-  ) -> T {
-    return withParser(
-      source: input,
-      maximumNestingLevel: maximumNestingLevel,
-      parseTransition: parseTransition,
-      swiftVersion: nil,
-      experimentalFeatures: [],
-      body: body
-    )
-  }
-
-  /// Runs `body` with a `Parser` that lexes directly over `input` without
-  /// copying it into a parser-owned buffer, with a given Swift version and set
-  /// of experimental language features.
-  ///
-  /// This is the no-copy fast path: the entire parse runs inside this scope,
-  /// where `input` is guaranteed valid, and each token's text is interned into
-  /// the arena so the resulting tree is self-contained once `body` returns.
-  ///
-  /// - Important: `input` must remain valid for the entire duration of `body`.
-  ///   It is *not* referenced after `body` returns.
-  /// - Important: The `Parser` passed to `body` must not escape the closure. It
-  ///   lexes directly over `input`, so it is only valid within this scope.
-  @_spi(RawSyntax)
-  @_spi(ExperimentalLanguageFeatures)
-  public static func withParser<T>(
-    source input: UnsafeBufferPointer<UInt8>,
-    maximumNestingLevel: Int? = nil,
-    parseTransition: IncrementalParseTransition? = nil,
-    swiftVersion: SwiftVersion?,
-    experimentalFeatures: ExperimentalFeatures,
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: ExperimentalFeatures = [],
     body: (inout Parser) -> T
   ) -> T {
     var parser = Parser(
@@ -462,8 +409,7 @@ public struct Parser {
     return body(&parser)
   }
 
-  /// Runs `body` with a no-copy `Parser` over the UTF-8 of `input`, with a given
-  /// Swift version and set of experimental language features.
+  /// Runs `body` with a no-copy `Parser` over the UTF-8 of `input`.
   ///
   /// The entire parse runs inside `String.withUTF8`, where the contiguous UTF-8
   /// storage is valid, so no copy of the source is needed.
@@ -471,13 +417,12 @@ public struct Parser {
   /// - Important: The `Parser` passed to `body` must not escape the closure. It
   ///   lexes directly over `input`, so it is only valid within this scope.
   @_spi(RawSyntax)
-  @_spi(ExperimentalLanguageFeatures)
   public static func withParser<T>(
     source input: String,
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
-    swiftVersion: SwiftVersion?,
-    experimentalFeatures: ExperimentalFeatures,
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: ExperimentalFeatures = [],
     body: (inout Parser) -> T
   ) -> T {
     var input = input

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -131,7 +131,7 @@ public struct Parser {
   let swiftVersion: SwiftVersion
 
   /// The experimental features that have been enabled.
-  let experimentalFeatures: ExperimentalFeatures
+  let languageFeatures: LanguageFeatures
 
   /// A default maximum nesting level that is used if the client didn't
   /// explicitly specify one. Debug builds of the parser consume a lot more stack
@@ -226,7 +226,7 @@ public struct Parser {
   ///                 only read while lexing, which happens during that lifetime).
   ///  - swiftVersion: The version of Swift using which the file should be parsed.
   ///                  Defaults to the latest version.
-  ///  - experimentalFeatures: The experimental features enabled for the parser.
+  ///  - languageFeatures: The experimental features enabled for the parser.
   private init(
     buffer input: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int?,
@@ -234,7 +234,7 @@ public struct Parser {
     arena: ParsingRawSyntaxArena?,
     copySource: Bool,
     swiftVersion: SwiftVersion?,
-    experimentalFeatures: ExperimentalFeatures
+    languageFeatures: LanguageFeatures
   ) {
     self.arena = arena ?? ParsingRawSyntaxArena(parseTriviaFunction: TriviaParser.parseTrivia)
 
@@ -261,13 +261,13 @@ public struct Parser {
 
     self.maximumNestingLevel = maximumNestingLevel ?? Self.defaultMaximumNestingLevel
     self.swiftVersion = swiftVersion ?? Self.defaultSwiftVersion
-    self.experimentalFeatures = experimentalFeatures
+    self.languageFeatures = languageFeatures
     self.lookaheadTrackerOwner = LookaheadTrackerOwner()
 
     self.lexemes = Lexer.tokenize(
       input,
       lookaheadTracker: lookaheadTrackerOwner.lookaheadTracker,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
     self.currentToken = self.lexemes.advance()
     if let parseTransition {
@@ -289,13 +289,13 @@ public struct Parser {
   ///                      parse, or `nil`.
   ///   - swiftVersion: The version of Swift to parse as, or `nil` for the
   ///                   default.
-  ///   - experimentalFeatures: The experimental features to enable.
+  ///   - languageFeatures: The experimental features to enable.
   public init(
     _ input: String,
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures = []
+    languageFeatures: LanguageFeatures = []
   ) {
     var input = input
     input.makeContiguousUTF8()
@@ -310,7 +310,7 @@ public struct Parser {
         // copied into a parser-owned buffer.
         copySource: true,
         swiftVersion: swiftVersion,
-        experimentalFeatures: experimentalFeatures
+        languageFeatures: languageFeatures
       )
     }
   }
@@ -329,13 +329,13 @@ public struct Parser {
   ///                      parse, or `nil`.
   ///   - swiftVersion: The version of Swift to parse as, or `nil` for the
   ///                   default.
-  ///   - experimentalFeatures: The experimental features to enable.
+  ///   - languageFeatures: The experimental features to enable.
   public init(
     _ input: UnsafeBufferPointer<UInt8>,
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures = []
+    languageFeatures: LanguageFeatures = []
   ) {
     // Copy the source so the caller may free `input` after this initializer
     // returns.
@@ -346,7 +346,7 @@ public struct Parser {
       arena: nil,
       copySource: true,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
   }
 
@@ -359,7 +359,7 @@ public struct Parser {
     parseTransition: IncrementalParseTransition? = nil,
     arena: ParsingRawSyntaxArena,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures = []
+    languageFeatures: LanguageFeatures = []
   ) {
     // Copy the source so the caller may free `input` after this initializer
     // returns, and so the resulting tree does not depend on `input` (its tokens
@@ -371,7 +371,7 @@ public struct Parser {
       arena: arena,
       copySource: true,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
   }
 
@@ -394,7 +394,7 @@ public struct Parser {
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures = [],
+    languageFeatures: LanguageFeatures = [],
     body: (inout Parser) -> T
   ) -> T {
     var parser = Parser(
@@ -404,7 +404,7 @@ public struct Parser {
       arena: nil,
       copySource: false,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     )
     return body(&parser)
   }
@@ -422,7 +422,7 @@ public struct Parser {
     maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil,
     swiftVersion: SwiftVersion? = nil,
-    experimentalFeatures: ExperimentalFeatures = [],
+    languageFeatures: LanguageFeatures = [],
     body: (inout Parser) -> T
   ) -> T {
     var input = input
@@ -433,7 +433,7 @@ public struct Parser {
         maximumNestingLevel: maximumNestingLevel,
         parseTransition: parseTransition,
         swiftVersion: swiftVersion,
-        experimentalFeatures: experimentalFeatures,
+        languageFeatures: languageFeatures,
         body: body
       )
     }

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -25,7 +25,7 @@ extension Parser {
       case identifier
       case dollarIdentifier  // For recovery
 
-      init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+      init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
         switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.leftParen): self = .leftParen
         case TokenSpec(.wildcard): self = .wildcard
@@ -298,7 +298,7 @@ extension Parser.Lookahead {
       case wildcard
       case leftParen
 
-      init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+      init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
         switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.identifier): self = .identifier
         case TokenSpec(.wildcard): self = .wildcard

--- a/Sources/SwiftParser/Specifiers.swift
+++ b/Sources/SwiftParser/Specifiers.swift
@@ -24,7 +24,7 @@ public enum AsyncEffectSpecifier: TokenSpecSet {
   case await
   case reasync
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     // We'll take 'await' too for recovery but they have to be on the same line
     // as the declaration they're modifying.
     switch PrepareForKeywordMatch(lexeme) {
@@ -61,7 +61,7 @@ public enum ThrowsEffectSpecifier: TokenSpecSet {
   case `throws`
   case `try`
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     // We'll take 'throw' and 'try' too for recovery but they have to
     // be on the same line as the declaration they're modifying.
     switch PrepareForKeywordMatch(lexeme) {
@@ -99,10 +99,10 @@ public enum EffectSpecifier: TokenSpecSet {
   case asyncSpecifier(AsyncEffectSpecifier)
   case throwsSpecifier(ThrowsEffectSpecifier)
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
-    if let subset = AsyncEffectSpecifier(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
+    if let subset = AsyncEffectSpecifier(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .asyncSpecifier(subset)
-    } else if let subset = ThrowsEffectSpecifier(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    } else if let subset = ThrowsEffectSpecifier(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .throwsSpecifier(subset)
     } else {
       return nil
@@ -228,7 +228,7 @@ extension RawFunctionEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
   enum MisspelledAsyncTokenKinds: TokenSpecSet {
     case await
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.await, allowAtStartOfLine: false): self = .await
       default: return nil
@@ -246,7 +246,7 @@ extension RawFunctionEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case async
     case reasync
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.async): self = .async
       case TokenSpec(.reasync): self = .reasync
@@ -266,7 +266,7 @@ extension RawFunctionEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `try`
     case `throw`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.try, allowAtStartOfLine: false): self = .try
       case TokenSpec(.throw, allowAtStartOfLine: false): self = .throw
@@ -286,7 +286,7 @@ extension RawFunctionEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `rethrows`
     case `throws`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.rethrows): self = .rethrows
       case TokenSpec(.throws): self = .throws
@@ -308,7 +308,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case await
     case reasync
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.await, allowAtStartOfLine: false): self = .await
       case TokenSpec(.reasync): self = .reasync
@@ -327,7 +327,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
   enum CorrectAsyncTokenKinds: TokenSpecSet {
     case async
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.async): self = .async
       default: return nil
@@ -346,7 +346,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `try`
     case `throw`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.rethrows): self = .rethrows
       case TokenSpec(.try, allowAtStartOfLine: false): self = .try
@@ -367,7 +367,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
   enum CorrectThrowsTokenKinds: TokenSpecSet {
     case `throws`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.throws): self = .throws
       default: return nil
@@ -387,7 +387,7 @@ extension RawAccessorEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case await
     case reasync
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.await, allowAtStartOfLine: false): self = .await
       case TokenSpec(.reasync): self = .reasync
@@ -406,7 +406,7 @@ extension RawAccessorEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
   enum CorrectAsyncTokenKinds: TokenSpecSet {
     case async
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.async): self = .async
       default: return nil
@@ -425,7 +425,7 @@ extension RawAccessorEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `try`
     case `throw`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.rethrows): self = .rethrows
       case TokenSpec(.try, allowAtStartOfLine: false): self = .try
@@ -446,7 +446,7 @@ extension RawAccessorEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
   enum CorrectThrowsTokenKinds: TokenSpecSet {
     case `throws`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.throws): self = .throws
       default: return nil
@@ -466,7 +466,7 @@ extension RawDeinitializerEffectSpecifiersSyntax: RawMisplacedEffectSpecifiersTr
     case await
     case reasync
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.await, allowAtStartOfLine: false): self = .await
       case TokenSpec(.reasync): self = .reasync
@@ -485,7 +485,7 @@ extension RawDeinitializerEffectSpecifiersSyntax: RawMisplacedEffectSpecifiersTr
   enum CorrectAsyncTokenKinds: TokenSpecSet {
     case async
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.async): self = .async
       default: return nil
@@ -505,7 +505,7 @@ extension RawDeinitializerEffectSpecifiersSyntax: RawMisplacedEffectSpecifiersTr
     case `throw`
     case `throws`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.rethrows): self = .rethrows
       case TokenSpec(.try, allowAtStartOfLine: false): self = .try
@@ -528,7 +528,7 @@ extension RawDeinitializerEffectSpecifiersSyntax: RawMisplacedEffectSpecifiersTr
   enum CorrectThrowsTokenKinds: TokenSpecSet {
     // Uninhabited
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       return nil
     }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -68,7 +68,7 @@ extension Parser {
     case (.do, let handle)?:
       // If we have 'do' expressions enabled, we parse a DoExprSyntax, and wrap
       // it in an ExpressionStmtSyntax.
-      if self.experimentalFeatures.contains(.doExpressions) {
+      if self.languageFeatures.contains(.doExpressions) {
         let doExpr = self.parseDoExpression(doHandle: handle)
         let doStmt = RawExpressionStmtSyntax(
           expression: doExpr,
@@ -179,7 +179,7 @@ extension Parser {
   }
 
   mutating func atConditionListTerminator(isGuardStatement: Bool) -> Bool {
-    guard experimentalFeatures.contains(.trailingComma) else {
+    guard languageFeatures.contains(.trailingComma) else {
       return false
     }
     // Condition terminator is `else` for `guard` statements.
@@ -559,7 +559,7 @@ extension Parser {
     let unsafeKeyword: RawTokenSyntax?
     if let modifierKeyword = ExpressionModifierKeyword(
       lexeme: self.currentToken,
-      experimentalFeatures: self.experimentalFeatures
+      languageFeatures: self.languageFeatures
     ), modifierKeyword == .unsafe, !self.peek(isAt: .keyword(.in), .colon) {
       unsafeKeyword = self.expectWithoutRecovery(.keyword(.unsafe))
     } else {
@@ -649,7 +649,7 @@ extension Parser {
       case poundElseif
       case endOfFile
 
-      init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+      init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
         switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.rightBrace): self = .rightBrace
         case TokenSpec(.case): self = .case
@@ -785,7 +785,7 @@ extension Parser {
 extension Parser {
   /// Parse a `then` statement.
   mutating func parseThenStatement(handle: RecoveryConsumptionHandle) -> RawStmtSyntax {
-    assert(experimentalFeatures.contains(.thenStatements))
+    assert(languageFeatures.contains(.thenStatements))
 
     let (unexpectedBeforeThen, then) = self.eat(handle)
     let hasMisplacedTry = unexpectedBeforeThen?.containsToken(where: { TokenSpec(.try) ~= $0 }) ?? false
@@ -937,7 +937,7 @@ extension TokenConsumer {
         return true
       case .if, .switch:
         return true
-      case .do where self.experimentalFeatures.contains(.doExpressions):
+      case .do where self.languageFeatures.contains(.doExpressions):
         return true
 
       default:

--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -90,7 +90,7 @@ extension StringSegmentSyntax {
     }
 
     rawText.withBuffer { buffer in
-      var cursor = Lexer.Cursor(input: buffer, previous: 0, experimentalFeatures: [])
+      var cursor = Lexer.Cursor(input: buffer, previous: 0, languageFeatures: [])
 
       // Put the cursor in the string literal lexing state. This is just
       // defensive as it's currently not used by `lexCharacterInStringLiteral`.

--- a/Sources/SwiftParser/SwiftParserCompatibility.swift
+++ b/Sources/SwiftParser/SwiftParserCompatibility.swift
@@ -11,13 +11,87 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
-internal import SwiftSyntax
+public import SwiftSyntax
 #else
 import SwiftSyntax
 #endif
 
 // This file provides compatibility aliases to keep dependents of SwiftSyntax building.
 // All users of the declarations in this file should transition away from them ASAP.
+
+extension Parser {
+  @_spi(ExperimentalLanguageFeatures)
+  @available(*, deprecated, renamed: "LanguageFeatures")
+  public typealias ExperimentalFeatures = LanguageFeatures
+
+  @_spi(ExperimentalLanguageFeatures)
+  @available(*, deprecated, renamed: "init(_:maximumNestingLevel:parseTransition:swiftVersion:languageFeatures:)")
+  public init(
+    _ input: String,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil,
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: LanguageFeatures
+  ) {
+    self.init(
+      input,
+      maximumNestingLevel: maximumNestingLevel,
+      parseTransition: parseTransition,
+      swiftVersion: swiftVersion,
+      languageFeatures: experimentalFeatures
+    )
+  }
+
+  @_spi(ExperimentalLanguageFeatures)
+  @available(*, deprecated, renamed: "init(_:maximumNestingLevel:parseTransition:swiftVersion:languageFeatures:)")
+  public init(
+    _ input: UnsafeBufferPointer<UInt8>,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil,
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: LanguageFeatures
+  ) {
+    self.init(
+      input,
+      maximumNestingLevel: maximumNestingLevel,
+      parseTransition: parseTransition,
+      swiftVersion: swiftVersion,
+      languageFeatures: experimentalFeatures
+    )
+  }
+
+  @_spi(ExperimentalLanguageFeatures)
+  @available(*, deprecated, renamed: "parse(source:maximumNestingLevel:swiftVersion:languageFeatures:)")
+  public static func parse(
+    source: String,
+    maximumNestingLevel: Int? = nil,
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: LanguageFeatures
+  ) -> SourceFileSyntax {
+    return parse(
+      source: source,
+      maximumNestingLevel: maximumNestingLevel,
+      swiftVersion: swiftVersion,
+      languageFeatures: experimentalFeatures
+    )
+  }
+
+  @_spi(ExperimentalLanguageFeatures)
+  @available(*, deprecated, renamed: "parse(source:maximumNestingLevel:swiftVersion:languageFeatures:)")
+  public static func parse(
+    source: UnsafeBufferPointer<UInt8>,
+    maximumNestingLevel: Int? = nil,
+    swiftVersion: SwiftVersion? = nil,
+    experimentalFeatures: LanguageFeatures
+  ) -> SourceFileSyntax {
+    return parse(
+      source: source,
+      maximumNestingLevel: maximumNestingLevel,
+      swiftVersion: swiftVersion,
+      languageFeatures: experimentalFeatures
+    )
+  }
+}
 
 extension TokenSpec {
   @available(*, deprecated, renamed: "leftSquare")

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -25,7 +25,7 @@ protocol TokenConsumer {
   var swiftVersion: Parser.SwiftVersion { get }
 
   /// The experimental features that have been enabled.
-  var experimentalFeatures: Parser.ExperimentalFeatures { get }
+  var languageFeatures: Parser.LanguageFeatures { get }
 
   /// Whether the current token matches the given kind.
   mutating func consumeAnyToken() -> Token
@@ -146,7 +146,7 @@ extension TokenConsumer {
       recordAlternativeTokenChoice(for: self.currentToken, choices: specSet.allCases.map(\.spec))
     }
     #endif
-    if let matchedKind = SpecSet(lexeme: self.currentToken, experimentalFeatures: self.experimentalFeatures) {
+    if let matchedKind = SpecSet(lexeme: self.currentToken, languageFeatures: self.languageFeatures) {
       precondition(matchedKind.spec ~= self.currentToken)
       return (
         matchedKind,
@@ -160,7 +160,7 @@ extension TokenConsumer {
   /// If this is the case, return the corresponding `SpecSet` case.
   @inline(__always)
   func peek<SpecSet: TokenSpecSet>(isAtAnyIn specSet: SpecSet.Type) -> SpecSet? {
-    guard let matchedKind = SpecSet(lexeme: self.peek(), experimentalFeatures: self.experimentalFeatures) else {
+    guard let matchedKind = SpecSet(lexeme: self.peek(), languageFeatures: self.languageFeatures) else {
       return nil
     }
     precondition(matchedKind.spec ~= self.peek())

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -22,8 +22,8 @@ protocol TokenSpecSet: CaseIterable {
   var spec: TokenSpec { get }
 
   /// Creates an instance if `lexeme` satisfies the condition of this subset,
-  /// taking into account any `experimentalFeatures` active.
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures)
+  /// taking into account any `languageFeatures` active.
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures)
 }
 
 /// A way to combine two token spec sets into an aggregate token spec set.
@@ -31,12 +31,12 @@ enum EitherTokenSpecSet<LHS: TokenSpecSet, RHS: TokenSpecSet>: TokenSpecSet {
   case lhs(LHS)
   case rhs(RHS)
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
-    if let x = LHS(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
+    if let x = LHS(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .lhs(x)
       return
     }
-    if let y = RHS(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    if let y = RHS(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .rhs(y)
       return
     }
@@ -68,7 +68,7 @@ enum AccessorModifier: TokenSpecSet {
   case nonmutating
   case yielding
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.__consuming): self = .__consuming
     case TokenSpec(.consuming): self = .consuming
@@ -110,7 +110,7 @@ enum CanBeStatementStart: TokenSpecSet {
   case `while`
   case yield
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.break): self = .break
     case TokenSpec(.continue): self = .continue
@@ -124,7 +124,7 @@ enum CanBeStatementStart: TokenSpecSet {
     case TokenSpec(.repeat): self = .repeat
     case TokenSpec(.return): self = .return
     case TokenSpec(.switch): self = .switch
-    case TokenSpec(.then) where experimentalFeatures.contains(.thenStatements): self = .then
+    case TokenSpec(.then) where languageFeatures.contains(.thenStatements): self = .then
     case TokenSpec(.throw): self = .throw
     case TokenSpec(.while): self = .while
     case TokenSpec(.yield): self = .yield
@@ -159,7 +159,7 @@ enum CompilationCondition: TokenSpecSet {
   case compiler
   case canImport
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.swift): self = .swift
     case TokenSpec(.compiler): self = .compiler
@@ -206,7 +206,7 @@ enum ContextualDeclKeyword: TokenSpecSet {
   case unowned
   case weak
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.__consuming): self = .__consuming
     case TokenSpec(._compilerInitialized): self = ._compilerInitialized
@@ -295,7 +295,7 @@ enum PureDeclarationKeyword: TokenSpecSet {
   case pound
   case using
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.actor): self = .actor
     case TokenSpec(.macro): self = .macro
@@ -315,7 +315,7 @@ enum PureDeclarationKeyword: TokenSpecSet {
     case TokenSpec(.subscript): self = .subscript
     case TokenSpec(.typealias): self = .typealias
     case TokenSpec(.pound): self = .pound
-    case TokenSpec(.using) where experimentalFeatures.contains(.defaultIsolationPerFile): self = .using
+    case TokenSpec(.using) where languageFeatures.contains(.defaultIsolationPerFile): self = .using
     default: return nil
     }
   }
@@ -388,7 +388,7 @@ enum DeclarationModifier: TokenSpecSet {
   case unowned
   case weak
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.__consuming): self = .__consuming
     case TokenSpec(.__setter_access): self = .__setter_access
@@ -479,10 +479,10 @@ enum DeclarationStart: TokenSpecSet {
   case declarationModifier(DeclarationModifier)
   case declarationKeyword(DeclarationKeyword)
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
-    if let subset = DeclarationModifier(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
+    if let subset = DeclarationModifier(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .declarationModifier(subset)
-    } else if let subset = DeclarationKeyword(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    } else if let subset = DeclarationKeyword(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .declarationKeyword(subset)
     } else {
       return nil
@@ -507,7 +507,7 @@ enum Operator: TokenSpecSet {
   case postfixOperator
   case prefixOperator
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     // NOTE: If you ever add any experimental features here,
     // `isContextualPunctuator` will need updating to handle that.
     switch lexeme.rawTokenKind {
@@ -534,7 +534,7 @@ enum BinaryOperatorLike: TokenSpecSet {
   case equal
   case arrow
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch lexeme.rawTokenKind {
     case .binaryOperator: self = .binaryOperator
     case .infixQuestionMark: self = .infixQuestionMark
@@ -560,7 +560,7 @@ enum PostfixOperatorLike: TokenSpecSet {
   case exclamationMark
   case postfixQuestionMark
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch lexeme.rawTokenKind {
     case .postfixOperator: self = .postfixOperator
     case .exclamationMark: self = .exclamationMark
@@ -584,16 +584,16 @@ enum OperatorLike: TokenSpecSet {
   case binaryOperatorLike(BinaryOperatorLike)
   case postfixOperatorLike(PostfixOperatorLike)
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     if case .prefixOperator = lexeme.rawTokenKind {
       self = .prefixOperator
       return
     }
-    if let binOp = BinaryOperatorLike(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    if let binOp = BinaryOperatorLike(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .binaryOperatorLike(binOp)
       return
     }
-    if let postfixOp = PostfixOperatorLike(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    if let postfixOp = PostfixOperatorLike(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .postfixOperatorLike(postfixOp)
       return
     }
@@ -618,7 +618,7 @@ enum SwitchCaseStart: TokenSpecSet {
   case `case`
   case `default`
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.case): self = .case
     case TokenSpec(.default): self = .default
@@ -651,7 +651,7 @@ enum TypeAttribute: TokenSpecSet {
   case unchecked
   case isolated
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(._local): self = ._local
     case TokenSpec(._noMetadata): self = ._noMetadata
@@ -708,11 +708,11 @@ enum ExpressionModifierKeyword: TokenSpecSet {
   case any
   case unsafe
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.await): self = .await
-    case TokenSpec(._move) where experimentalFeatures.contains(.oldOwnershipOperatorSpellings): self = ._move
-    case TokenSpec(._borrow) where experimentalFeatures.contains(.oldOwnershipOperatorSpellings): self = ._borrow
+    case TokenSpec(._move) where languageFeatures.contains(.oldOwnershipOperatorSpellings): self = ._move
+    case TokenSpec(._borrow) where languageFeatures.contains(.oldOwnershipOperatorSpellings): self = ._borrow
     case TokenSpec(.try): self = .try
     case TokenSpec(.borrow): self = .borrow
     case TokenSpec(.consume): self = .consume
@@ -747,9 +747,9 @@ enum SingleValueStatementExpression: TokenSpecSet {
   case `if`
   case `switch`
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
-    case TokenSpec(.do) where experimentalFeatures.contains(.doExpressions): self = .do
+    case TokenSpec(.do) where languageFeatures.contains(.doExpressions): self = .do
     case TokenSpec(.if): self = .if
     case TokenSpec(.switch): self = .switch
     default: return nil
@@ -770,7 +770,7 @@ enum ExpressionPrefixOperator: TokenSpecSet {
   case prefixAmpersand
   case prefixOperator
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch lexeme.rawTokenKind {
     case .backslash: self = .backslash
     case .prefixAmpersand: self = .prefixAmpersand
@@ -795,7 +795,7 @@ enum ExpressionPrefixOperator: TokenSpecSet {
 enum PureMatchingPatternStart: TokenSpecSet {
   case `is`
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.is): self = .is
     default: return nil
@@ -818,7 +818,7 @@ enum ParameterModifier: TokenSpecSet {
   case _const
   case isolated
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(._const): self = ._const
     case TokenSpec(.isolated): self = .isolated
@@ -866,7 +866,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
   case multilineStringQuote
   case singleQuote
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.Any): self = .Any
     case TokenSpec(.atSign): self = .atSign
@@ -949,14 +949,14 @@ enum ExpressionStart: TokenSpecSet {
   case primaryExpressionStart(PrimaryExpressionStart)
   case singleValueStatement(SingleValueStatementExpression)
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
-    if let subset = ExpressionModifierKeyword(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
+    if let subset = ExpressionModifierKeyword(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .awaitTryMove(subset)
-    } else if let subset = ExpressionPrefixOperator(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    } else if let subset = ExpressionPrefixOperator(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .expressionPrefixOperator(subset)
-    } else if let subset = PrimaryExpressionStart(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    } else if let subset = PrimaryExpressionStart(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .primaryExpressionStart(subset)
-    } else if let subset = SingleValueStatementExpression(lexeme: lexeme, experimentalFeatures: experimentalFeatures) {
+    } else if let subset = SingleValueStatementExpression(lexeme: lexeme, languageFeatures: languageFeatures) {
       self = .singleValueStatement(subset)
     } else {
       return nil
@@ -989,7 +989,7 @@ enum EffectSpecifiers: TokenSpecSet {
   case `throws`
   case `try`
 
-  init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+  init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.async): self = .async
     case TokenSpec(.await, allowAtStartOfLine: false): self = .await

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -47,7 +47,7 @@ extension Parser {
     let shebang: RawTokenSyntax?
     let items: RawCodeBlockItemListSyntax
 
-    if !self.experimentalFeatures.contains(._test_EverythingUnexpected) {
+    if !self.languageFeatures.contains(._test_EverythingUnexpected) {
       shebang = self.consume(if: .shebang)
       items = self.parseTopLevelCodeBlockItems()
     } else {

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -27,7 +27,7 @@ public struct TriviaParser {
       input: UnsafeBufferPointer(start: source.baseAddress, count: source.count),
       previous: 0,
       // There are currently no experimental features that affect trivia parsing.
-      experimentalFeatures: []
+      languageFeatures: []
     )
 
     while true {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -324,7 +324,7 @@ extension Parser {
       case leftSquare
       case wildcard
 
-      init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+      init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
         switch PrepareForKeywordMatch(lexeme) {
         case .keyword(.Self): self = .Self
         case .keyword(.Any): self = .Any
@@ -858,7 +858,7 @@ extension Parser.Lookahead {
     }
 
     // When LiteralExpressions is enabled, try parsing a parenthesized expression
-    if self.experimentalFeatures.contains(.literalExpressions) && self.at(.leftParen)
+    if self.languageFeatures.contains(.literalExpressions) && self.at(.leftParen)
       && self.withLookahead({
         $0.skipSingle()
         return $0.at(.comma, TokenSpec(.of, allowAtStartOfLine: false)) || $0.at(prefix: ">")
@@ -1382,7 +1382,7 @@ extension Parser {
       if let (_, specifierHandle) = self.at(anyIn: SimpleTypeSpecifierSyntax.SpecifierOptions.self) {
         specifiers.append(parseSimpleTypeSpecifier(specifierHandle: specifierHandle))
       } else if self.at(.keyword(.dependsOn)) {
-        if self.experimentalFeatures.contains(.nonescapableTypes) {
+        if self.languageFeatures.contains(.nonescapableTypes) {
           specifiers.append(parseLifetimeTypeSpecifier())
         } else {
           break SPECIFIER_PARSING

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -14,7 +14,10 @@
 // swift-format-ignore-file
 
 extension Parser {
-  @_spi(ExperimentalLanguageFeatures)
+  /// The type is public so it can appear in the (non-SPI) parser API, but
+  /// the individual features are `@_spi(ExperimentalLanguageFeatures)` since
+  /// they are unstable. Clients that don't enable experimental features only
+  /// ever use the empty set.
   public struct ExperimentalFeatures: OptionSet, Hashable, Sendable {
     public let rawValue: UInt
 
@@ -26,43 +29,56 @@ extension Parser {
 
 extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of reference bindings.
+  @_spi(ExperimentalLanguageFeatures)
   public static let referenceBindings = Self (rawValue: 1 << 0)
 
   /// Whether to enable the parsing of 'then' statements.
+  @_spi(ExperimentalLanguageFeatures)
   public static let thenStatements = Self (rawValue: 1 << 1)
 
   /// Whether to enable the parsing of 'do' expressions.
+  @_spi(ExperimentalLanguageFeatures)
   public static let doExpressions = Self (rawValue: 1 << 2)
 
   /// Whether to enable the parsing of non-escapable types.
+  @_spi(ExperimentalLanguageFeatures)
   public static let nonescapableTypes = Self (rawValue: 1 << 3)
 
   /// Whether to enable the parsing of trailing commas.
+  @_spi(ExperimentalLanguageFeatures)
   public static let trailingComma = Self (rawValue: 1 << 4)
 
   /// Whether to enable the parsing of coroutine accessors.
+  @_spi(ExperimentalLanguageFeatures)
   public static let coroutineAccessors = Self (rawValue: 1 << 5)
 
   /// Whether to enable the parsing of keypaths with method members.
+  @_spi(ExperimentalLanguageFeatures)
   public static let keypathWithMethodMembers = Self (rawValue: 1 << 6)
 
   /// Whether to enable the parsing of `_move` and `_borrow` as ownership operators.
+  @_spi(ExperimentalLanguageFeatures)
   public static let oldOwnershipOperatorSpellings = Self (rawValue: 1 << 7)
 
   /// Whether to enable the parsing of set default actor isolation for a file.
+  @_spi(ExperimentalLanguageFeatures)
   public static let defaultIsolationPerFile = Self (rawValue: 1 << 8)
 
   /// Whether to enable the parsing of borrow and mutate accessors.
+  @_spi(ExperimentalLanguageFeatures)
   public static let borrowAndMutateAccessors = Self (rawValue: 1 << 9)
 
   /// Whether to enable the parsing of constant-foldable literal expressions.
+  @_spi(ExperimentalLanguageFeatures)
   public static let literalExpressions = Self (rawValue: 1 << 10)
 
   /// Whether to enable the parsing of a test feature that parses everything as unexpected.
+  @_spi(ExperimentalLanguageFeatures)
   public static let _test_EverythingUnexpected = Self (rawValue: 1 << 11)
 
   /// Creates a new value representing the experimental feature with the
   /// given name, or returns nil if the name is not recognized.
+  @_spi(ExperimentalLanguageFeatures)
   public init?(name: String) {
     switch name {
     case "ReferenceBindings":

--- a/Sources/SwiftParser/generated/LanguageFeatures.swift
+++ b/Sources/SwiftParser/generated/LanguageFeatures.swift
@@ -18,7 +18,7 @@ extension Parser {
   /// the individual features are `@_spi(ExperimentalLanguageFeatures)` since
   /// they are unstable. Clients that don't enable experimental features only
   /// ever use the empty set.
-  public struct ExperimentalFeatures: OptionSet, Hashable, Sendable {
+  public struct LanguageFeatures: OptionSet, Hashable, Sendable {
     public let rawValue: UInt
 
     public init(rawValue: UInt) {
@@ -27,7 +27,7 @@ extension Parser {
   }
 }
 
-extension Parser.ExperimentalFeatures {
+extension Parser.LanguageFeatures {
   /// Whether to enable the parsing of reference bindings.
   @_spi(ExperimentalLanguageFeatures)
   public static let referenceBindings = Self (rawValue: 1 << 0)

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -42,7 +42,7 @@ extension AccessorDeclSyntax {
     case borrow
     case mutate
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.get):
         self = .get
@@ -66,11 +66,11 @@ extension AccessorDeclSyntax {
         self = .mutableAddressWithNativeOwner
       case TokenSpec(._read):
         self = ._read
-      case TokenSpec(.read) where experimentalFeatures.contains(.coroutineAccessors):
+      case TokenSpec(.read) where languageFeatures.contains(.coroutineAccessors):
         self = .read
       case TokenSpec(._modify):
         self = ._modify
-      case TokenSpec(.modify) where experimentalFeatures.contains(.coroutineAccessors):
+      case TokenSpec(.modify) where languageFeatures.contains(.coroutineAccessors):
         self = .modify
       case TokenSpec(.`init`):
         self = .`init`
@@ -214,7 +214,7 @@ extension AsExprSyntax {
     case postfixQuestionMark
     case exclamationMark
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.postfixQuestionMark):
         self = .postfixQuestionMark
@@ -266,7 +266,7 @@ extension AvailabilityConditionSyntax {
     case poundAvailable
     case poundUnavailable
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.poundAvailable):
         self = .poundAvailable
@@ -321,7 +321,7 @@ extension AvailabilityLabeledArgumentSyntax {
     case obsoleted
     case deprecated
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.message):
         self = .message
@@ -397,7 +397,7 @@ extension BooleanLiteralExprSyntax {
     case `true`
     case `false`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.true):
         self = .true
@@ -449,7 +449,7 @@ extension BorrowExprSyntax {
     case _borrow
     case borrow
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._borrow):
         self = ._borrow
@@ -501,7 +501,7 @@ extension _CanImportVersionInfoSyntax {
     case _version
     case _underlyingVersion
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._version):
         self = ._version
@@ -553,7 +553,7 @@ extension ClosureCaptureSpecifierSyntax {
     case weak
     case unowned
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.weak):
         self = .weak
@@ -605,7 +605,7 @@ extension ClosureCaptureSpecifierSyntax {
     case safe
     case unsafe
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.safe):
         self = .safe
@@ -657,7 +657,7 @@ extension ClosureCaptureSyntax {
     case identifier
     case `self`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -709,7 +709,7 @@ extension ClosureParameterSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -761,7 +761,7 @@ extension ClosureParameterSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -813,7 +813,7 @@ extension ClosureShorthandParameterSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -865,7 +865,7 @@ extension ConsumeExprSyntax {
     case _move
     case consume
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._move):
         self = ._move
@@ -952,7 +952,7 @@ extension DeclModifierSyntax {
     case sending
     case yielding
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.__consuming):
         self = .__consuming
@@ -1291,7 +1291,7 @@ extension DeclReferenceExprSyntax {
     case binaryOperator
     case integerLiteral
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -1400,7 +1400,7 @@ extension DerivativeAttributeArgumentsSyntax {
     case set
     case _modify
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.get):
         self = .get
@@ -1461,7 +1461,7 @@ extension DifferentiabilityArgumentSyntax {
     case integerLiteral
     case `self`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -1522,7 +1522,7 @@ extension DifferentiableAttributeArgumentsSyntax {
     case reverse
     case _linear
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._forward):
         self = ._forward
@@ -1582,7 +1582,7 @@ extension DocumentationAttributeArgumentSyntax {
     case visibility
     case metadata
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.visibility):
         self = .visibility
@@ -1634,7 +1634,7 @@ extension EnumCaseParameterSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -1686,7 +1686,7 @@ extension EnumCaseParameterSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -1740,7 +1740,7 @@ extension FunctionDeclSyntax {
     case prefixOperator
     case postfixOperator
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -1808,7 +1808,7 @@ extension FunctionEffectSpecifiersSyntax {
     case async
     case reasync
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.async):
         self = .async
@@ -1860,7 +1860,7 @@ extension FunctionParameterSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -1912,7 +1912,7 @@ extension FunctionParameterSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -1964,7 +1964,7 @@ extension GenericParameterSyntax {
     case each
     case `let`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.each):
         self = .each
@@ -2019,7 +2019,7 @@ extension IdentifierPatternSyntax {
     case `deinit`
     case `subscript`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -2097,7 +2097,7 @@ extension IdentifierTypeSyntax {
     case `Any`
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -2166,7 +2166,7 @@ extension IfConfigClauseSyntax {
     case poundElseif
     case poundElse
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.poundIf):
         self = .poundIf
@@ -2233,7 +2233,7 @@ extension ImportDeclSyntax {
     case `func`
     case `inout`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.typealias):
         self = .typealias
@@ -2343,7 +2343,7 @@ extension ImportPathComponentSyntax {
     case prefixOperator
     case postfixOperator
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -2411,7 +2411,7 @@ extension ImportPathComponentSyntax {
     case period
     case colonColon
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.period):
         self = .period
@@ -2463,7 +2463,7 @@ extension InitializerDeclSyntax {
     case postfixQuestionMark
     case exclamationMark
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.postfixQuestionMark):
         self = .postfixQuestionMark
@@ -2515,7 +2515,7 @@ extension KeyPathOptionalComponentSyntax {
     case postfixQuestionMark
     case exclamationMark
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.postfixQuestionMark):
         self = .postfixQuestionMark
@@ -2567,7 +2567,7 @@ extension LabeledExprSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -2623,7 +2623,7 @@ extension LabeledSpecializeArgumentSyntax {
     case spi
     case spiModule
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.target):
         self = .target
@@ -2714,7 +2714,7 @@ extension LayoutRequirementSyntax {
     case _BridgeObject
     case _TrivialStride
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._Trivial):
         self = ._Trivial
@@ -2823,7 +2823,7 @@ extension LifetimeSpecifierArgumentSyntax {
     case `self`
     case integerLiteral
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -2883,7 +2883,7 @@ extension MemberTypeSyntax {
     case identifier
     case `self`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -2935,7 +2935,7 @@ extension MetatypeTypeSyntax {
     case `Type`
     case `Protocol`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.Type):
         self = .Type
@@ -2987,7 +2987,7 @@ extension MultipleTrailingClosureElementSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -3040,7 +3040,7 @@ extension OperatorDeclSyntax {
     case postfix
     case infix
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.prefix):
         self = .prefix
@@ -3101,7 +3101,7 @@ extension OperatorDeclSyntax {
     case prefixOperator
     case postfixOperator
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.binaryOperator):
         self = .binaryOperator
@@ -3167,7 +3167,7 @@ extension OptionalBindingConditionSyntax {
     @_spi(ExperimentalLanguageFeatures)
     case _consuming
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.let):
         self = .let
@@ -3175,11 +3175,11 @@ extension OptionalBindingConditionSyntax {
         self = .var
       case TokenSpec(.inout):
         self = .inout
-      case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._mutating) where languageFeatures.contains(.referenceBindings):
         self = ._mutating
       case TokenSpec(._borrowing):
         self = ._borrowing
-      case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._consuming) where languageFeatures.contains(.referenceBindings):
         self = ._consuming
       default:
         return nil
@@ -3251,7 +3251,7 @@ extension PrecedenceGroupAssignmentSyntax {
     case `true`
     case `false`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.true):
         self = .true
@@ -3304,7 +3304,7 @@ extension PrecedenceGroupAssociativitySyntax {
     case right
     case none
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.left):
         self = .left
@@ -3364,7 +3364,7 @@ extension PrecedenceGroupRelationSyntax {
     case higherThan
     case lowerThan
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.higherThan):
         self = .higherThan
@@ -3417,7 +3417,7 @@ extension SameTypeRequirementSyntax {
     case prefixOperator
     case postfixOperator
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.binaryOperator):
         self = .binaryOperator
@@ -3477,7 +3477,7 @@ extension SimpleStringLiteralExprSyntax {
     case stringQuote
     case multilineStringQuote
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.stringQuote):
         self = .stringQuote
@@ -3529,7 +3529,7 @@ extension SimpleStringLiteralExprSyntax {
     case stringQuote
     case multilineStringQuote
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.stringQuote):
         self = .stringQuote
@@ -3587,7 +3587,7 @@ extension SimpleTypeSpecifierSyntax {
     case consuming
     case sending
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.inout):
         self = .inout
@@ -3687,7 +3687,7 @@ extension SomeOrAnyTypeSyntax {
     case some
     case any
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.some):
         self = .some
@@ -3740,7 +3740,7 @@ extension StringLiteralExprSyntax {
     case multilineStringQuote
     case singleQuote
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.stringQuote):
         self = .stringQuote
@@ -3801,7 +3801,7 @@ extension StringLiteralExprSyntax {
     case multilineStringQuote
     case singleQuote
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.stringQuote):
         self = .stringQuote
@@ -3861,7 +3861,7 @@ extension ThrowsClauseSyntax {
     case `throws`
     case `rethrows`
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.throws):
         self = .throws
@@ -3913,7 +3913,7 @@ extension TryExprSyntax {
     case postfixQuestionMark
     case exclamationMark
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.postfixQuestionMark):
         self = .postfixQuestionMark
@@ -3965,7 +3965,7 @@ extension TupleTypeElementSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -4017,7 +4017,7 @@ extension TupleTypeElementSyntax {
     case identifier
     case wildcard
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.identifier):
         self = .identifier
@@ -4069,7 +4069,7 @@ extension UnresolvedAsExprSyntax {
     case postfixQuestionMark
     case exclamationMark
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.postfixQuestionMark):
         self = .postfixQuestionMark
@@ -4128,7 +4128,7 @@ extension ValueBindingPatternSyntax {
     case _consuming
     case borrowing
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.let):
         self = .let
@@ -4136,11 +4136,11 @@ extension ValueBindingPatternSyntax {
         self = .var
       case TokenSpec(.inout):
         self = .inout
-      case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._mutating) where languageFeatures.contains(.referenceBindings):
         self = ._mutating
       case TokenSpec(._borrowing):
         self = ._borrowing
-      case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._consuming) where languageFeatures.contains(.referenceBindings):
         self = ._consuming
       case TokenSpec(.borrowing):
         self = .borrowing
@@ -4226,7 +4226,7 @@ extension VariableDeclSyntax {
     @_spi(ExperimentalLanguageFeatures)
     case _consuming
 
-    init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
+    init?(lexeme: Lexer.Lexeme, languageFeatures: Parser.LanguageFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.let):
         self = .let
@@ -4234,11 +4234,11 @@ extension VariableDeclSyntax {
         self = .var
       case TokenSpec(.inout):
         self = .inout
-      case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._mutating) where languageFeatures.contains(.referenceBindings):
         self = ._mutating
       case TokenSpec(._borrowing):
         self = ._borrowing
-      case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._consuming) where languageFeatures.contains(.referenceBindings):
         self = ._consuming
       default:
         return nil

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -190,7 +190,7 @@ private func assertTokens(
 func assertLexemes(
   _ markedSource: String,
   lexemes expectedLexemes: [LexemeSpec],
-  experimentalFeatures: Parser.ExperimentalFeatures = [],
+  languageFeatures: Parser.LanguageFeatures = [],
   file: StaticString = #filePath,
   line: UInt = #line
 ) {
@@ -211,7 +211,7 @@ func assertLexemes(
       buf,
       from: 0,
       lookaheadTracker: lookaheadTracker,
-      experimentalFeatures: experimentalFeatures
+      languageFeatures: languageFeatures
     ) {
       lexemes.append(token)
 
@@ -501,7 +501,7 @@ extension ParserTestCase {
     source: [UInt8],
     _ parse: (inout Parser) -> some SyntaxProtocol,
     swiftVersion: Parser.SwiftVersion?,
-    experimentalFeatures: Parser.ExperimentalFeatures,
+    languageFeatures: Parser.LanguageFeatures,
     file: StaticString,
     line: UInt
   ) {
@@ -509,7 +509,7 @@ extension ParserTestCase {
       let mutatedSource = String(decoding: buf, as: UTF8.self)
       // Check that we don't hit any assertions in the parser while parsing
       // the mutated source and that it round-trips
-      var mutatedParser = Parser(buf, swiftVersion: swiftVersion, experimentalFeatures: experimentalFeatures)
+      var mutatedParser = Parser(buf, swiftVersion: swiftVersion, languageFeatures: languageFeatures)
       let mutatedTree = parse(&mutatedParser)
       // Run the diagnostic generator to make sure it doesn’t crash
       _ = ParseDiagnosticsGenerator.diagnostics(for: mutatedTree)
@@ -579,7 +579,7 @@ extension ParserTestCase {
     fixedSource expectedFixedSource: String? = nil,
     options: AssertParseOptions = [],
     swiftVersion: Parser.SwiftVersion? = nil,
-    experimentalFeatures: Parser.ExperimentalFeatures? = nil,
+    languageFeatures: Parser.LanguageFeatures? = nil,
     file: StaticString = #filePath,
     line: UInt = #line
   ) {
@@ -594,7 +594,7 @@ extension ParserTestCase {
       } ?? [],
       options: options,
       swiftVersion: swiftVersion,
-      experimentalFeatures: experimentalFeatures,
+      languageFeatures: languageFeatures,
       file: file,
       line: line
     )
@@ -638,7 +638,7 @@ extension ParserTestCase {
   ///     will generate a certain expected fixed source. An empty list means no fix-its are expected.
   ///   - swiftVersion: The version of Swift using which the file should be parsed.
   ///      Defaults to the latest version.
-  ///   - experimentalFeatures: A list of experimental features to enable, or
+  ///   - languageFeatures: A list of experimental features to enable, or
   ///     `nil` to enable the default set of features provided by the test case.
   func assertParse(
     _ markedSource: String,
@@ -649,17 +649,17 @@ extension ParserTestCase {
     fixItsApplications: [FixItsApplication] = [],
     options: AssertParseOptions = [],
     swiftVersion: Parser.SwiftVersion? = nil,
-    experimentalFeatures: Parser.ExperimentalFeatures? = nil,
+    languageFeatures: Parser.LanguageFeatures? = nil,
     file: StaticString = #filePath,
     line: UInt = #line
   ) {
-    let experimentalFeatures = experimentalFeatures ?? self.experimentalFeatures
+    let languageFeatures = languageFeatures ?? self.languageFeatures
 
     // Verify the parser can round-trip the source
     var (markerLocations, source) = extractMarkers(markedSource)
     markerLocations["START"] = 0
 
-    var parser = Parser(source, swiftVersion: swiftVersion, experimentalFeatures: experimentalFeatures)
+    var parser = Parser(source, swiftVersion: swiftVersion, languageFeatures: languageFeatures)
     #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
     if !longTestsDisabled {
       parser.enableAlternativeTokenChoices()
@@ -750,7 +750,7 @@ extension ParserTestCase {
         source: source,
         parse: parse,
         swiftVersion: swiftVersion,
-        experimentalFeatures: experimentalFeatures,
+        languageFeatures: languageFeatures,
         file: file,
         line: line
       )
@@ -764,7 +764,7 @@ extension ParserTestCase {
           source: flippedTokenTree.syntaxTextBytes,
           parse,
           swiftVersion: swiftVersion,
-          experimentalFeatures: experimentalFeatures,
+          languageFeatures: languageFeatures,
           file: file,
           line: line
         )
@@ -786,7 +786,7 @@ extension ParserTestCase {
           source: alternateSource,
           parse,
           swiftVersion: swiftVersion,
-          experimentalFeatures: experimentalFeatures,
+          languageFeatures: languageFeatures,
           file: file,
           line: line
         )
@@ -828,11 +828,11 @@ func assertBasicFormat(
   source: String,
   parse: (inout Parser) -> some SyntaxProtocol,
   swiftVersion: Parser.SwiftVersion?,
-  experimentalFeatures: Parser.ExperimentalFeatures,
+  languageFeatures: Parser.LanguageFeatures,
   file: StaticString = #filePath,
   line: UInt = #line
 ) {
-  var parser = Parser(source, swiftVersion: swiftVersion, experimentalFeatures: experimentalFeatures)
+  var parser = Parser(source, swiftVersion: swiftVersion, languageFeatures: languageFeatures)
   let sourceTree = parse(&parser)
   let withoutTrivia = TriviaRemover(viewMode: .sourceAccurate).rewrite(sourceTree)
   let formatted = withoutTrivia.formatted()
@@ -840,7 +840,7 @@ func assertBasicFormat(
   var formattedParser = Parser(
     formatted.description,
     swiftVersion: swiftVersion,
-    experimentalFeatures: experimentalFeatures
+    languageFeatures: languageFeatures
   )
   let formattedReparsed = Syntax(parse(&formattedParser))
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3382,7 +3382,7 @@ final class DeclarationTests: ParserTestCase {
   func testInitializerWithReturnType() {
     assertParse(
       "init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> dependsOn(a) Self",
-      experimentalFeatures: .nonescapableTypes
+      languageFeatures: .nonescapableTypes
     )
 
     // Not actually valid, needs to be diagnosed during type checking
@@ -3474,7 +3474,7 @@ final class DeclarationTests: ParserTestCase {
         }
       }
       """,
-      experimentalFeatures: .coroutineAccessors
+      languageFeatures: .coroutineAccessors
     )
     assertParse(
       """
@@ -3493,7 +3493,7 @@ final class DeclarationTests: ParserTestCase {
         }
       }
       """,
-      experimentalFeatures: .coroutineAccessors
+      languageFeatures: .coroutineAccessors
     )
     assertParse(
       """
@@ -3676,7 +3676,7 @@ final class DeclarationTests: ParserTestCase {
 }
 
 final class UsingDeclarationTests: ParserTestCase {
-  override var experimentalFeatures: Parser.ExperimentalFeatures {
+  override var languageFeatures: Parser.LanguageFeatures {
     [.defaultIsolationPerFile]
   }
 

--- a/Tests/SwiftParserTest/DoExpressionTests.swift
+++ b/Tests/SwiftParserTest/DoExpressionTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 
 final class DoExpressionTests: ParserTestCase {
-  override var experimentalFeatures: Parser.ExperimentalFeatures {
+  override var languageFeatures: Parser.LanguageFeatures {
     [.doExpressions, .thenStatements]
   }
 
@@ -285,7 +285,7 @@ final class DoExpressionTests: ParserTestCase {
         return
         do { 5 }
         """,
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 
@@ -301,7 +301,7 @@ final class DoExpressionTests: ParserTestCase {
             IntegerLiteralExprSyntax(5)
           }
         ),
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 
@@ -316,7 +316,7 @@ final class DoExpressionTests: ParserTestCase {
             IntegerLiteralExprSyntax(5)
           }
         ),
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 
@@ -334,7 +334,7 @@ final class DoExpressionTests: ParserTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected code 'as Int' in source file")
       ],
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 
@@ -350,7 +350,7 @@ final class DoExpressionTests: ParserTestCase {
         )
       ],
       fixedSource: "let x = <#expression#>do { 5 }",
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 }

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -350,7 +350,7 @@ final class ExpressionTests: ParserTestCase {
           )
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -377,7 +377,7 @@ final class ExpressionTests: ParserTestCase {
           )
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -404,7 +404,7 @@ final class ExpressionTests: ParserTestCase {
           )
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -431,7 +431,7 @@ final class ExpressionTests: ParserTestCase {
           )
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -458,7 +458,7 @@ final class ExpressionTests: ParserTestCase {
           )
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -496,7 +496,7 @@ final class ExpressionTests: ParserTestCase {
           ),
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -519,7 +519,7 @@ final class ExpressionTests: ParserTestCase {
           )
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -555,7 +555,7 @@ final class ExpressionTests: ParserTestCase {
           )
         ])
       ),
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -570,7 +570,7 @@ final class ExpressionTests: ParserTestCase {
         )
       ],
       fixedSource: #"\Foo.method(<#expression#>)"#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -579,7 +579,7 @@ final class ExpressionTests: ParserTestCase {
         DiagnosticSpec(message: "expected identifier in key path method component", fixIts: ["insert identifier"])
       ],
       fixedSource: #"\Foo.<#identifier#>()"#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -590,7 +590,7 @@ final class ExpressionTests: ParserTestCase {
           message: "unexpected code '<Int>' in key path method component"
         )
       ],
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -607,77 +607,77 @@ final class ExpressionTests: ParserTestCase {
         ),
       ],
       fixedSource: #"\Foo.method<Int>(arg: <#expression#>)"#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       S()[keyPath: \.i] = 1
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       public let keyPath2FromLibB = \AStruct.Type.property
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       public let keyPath9FromLibB = \AStruct.Type.init(val: 2025)
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       _ = ([S]()).map(\.i)
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       let some = Some(keyPath: \Demo.here)
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       _ = ([S.Type]()).map(\.init)
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       \Lens<Lens<Point>>.obj.x
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       _ = \Lens<Point>.y
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       _ = f(\String?.!.count)
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
       #"""
       let _ = \K.Type.init(val: 2025)
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
 
     assertParse(
@@ -685,7 +685,7 @@ final class ExpressionTests: ParserTestCase {
       let _ = \K.Type.init
       let _ = \K.Type.init()
       """#,
-      experimentalFeatures: .keypathWithMethodMembers
+      languageFeatures: .keypathWithMethodMembers
     )
   }
 

--- a/Tests/SwiftParserTest/ExpressionTypeTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTypeTests.swift
@@ -156,7 +156,7 @@ final class ExpressionTypeTests: ParserTestCase {
       assertParse(
         "\(source)()",
         { ExprSyntax.parse(from: &$0) },
-        experimentalFeatures: .literalExpressions,
+        languageFeatures: .literalExpressions,
         line: line
       )
     }
@@ -176,7 +176,7 @@ final class ExpressionTypeTests: ParserTestCase {
         { ExprSyntax.parse(from: &$0) },
         substructure: IdentifierTypeSyntax(name: .identifier("X")),
         substructureAfterMarker: "1️⃣",
-        experimentalFeatures: .literalExpressions,
+        languageFeatures: .literalExpressions,
         line: line
       )
     }

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -22,7 +22,7 @@ private func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Void) 
   lookaheadTracker.initialize(to: LookaheadTracker())
   try sourceBytes.withUnsafeBufferPointer { (buf) in
     var lexemes = [Lexer.Lexeme]()
-    for token in Lexer.tokenize(buf, from: 0, lookaheadTracker: lookaheadTracker, experimentalFeatures: []) {
+    for token in Lexer.tokenize(buf, from: 0, lookaheadTracker: lookaheadTracker, languageFeatures: []) {
       lexemes.append(token)
 
       if token.rawTokenKind == .endOfFile {

--- a/Tests/SwiftParserTest/ParserTestCase.swift
+++ b/Tests/SwiftParserTest/ParserTestCase.swift
@@ -17,5 +17,5 @@ import XCTest
 /// The base class for all parser test cases.
 class ParserTestCase: XCTestCase {
   /// The default set of experimental features to test with.
-  var experimentalFeatures: Parser.ExperimentalFeatures { [] }
+  var languageFeatures: Parser.LanguageFeatures { [] }
 }

--- a/Tests/SwiftParserTest/TestEverythingUnexpectedTests.swift
+++ b/Tests/SwiftParserTest/TestEverythingUnexpectedTests.swift
@@ -27,7 +27,7 @@ final class TestEverythingUnexpectedTests: ParserTestCase {
       }
       """
 
-    var parser = Parser(source, experimentalFeatures: ._test_EverythingUnexpected)
+    var parser = Parser(source, languageFeatures: ._test_EverythingUnexpected)
     let sourceFile = SourceFileSyntax.parse(from: &parser)
 
     // With _test_EverythingUnexpected, statements should be empty

--- a/Tests/SwiftParserTest/ThenStatementTests.swift
+++ b/Tests/SwiftParserTest/ThenStatementTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 final class ThenStatementTests: ParserTestCase {
   // Enable then statements by default.
-  override var experimentalFeatures: Parser.ExperimentalFeatures {
+  override var languageFeatures: Parser.LanguageFeatures {
     return .thenStatements
   }
 
@@ -721,7 +721,7 @@ final class ThenStatementTests: ParserTestCase {
         then
         0
         """,
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 
@@ -746,7 +746,7 @@ final class ThenStatementTests: ParserTestCase {
         ),
       ],
       fixedSource: "<#statement#>then 0",
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 }

--- a/Tests/SwiftParserTest/TrailingCommaTests.swift
+++ b/Tests/SwiftParserTest/TrailingCommaTests.swift
@@ -116,29 +116,29 @@ final class TrailingCommaTests: ParserTestCase {
   }
 
   func testIfConditions() {
-    assertParse("if true, { }", experimentalFeatures: .trailingComma)
+    assertParse("if true, { }", languageFeatures: .trailingComma)
 
-    assertParse("if true, { }; { }()", experimentalFeatures: .trailingComma)
+    assertParse("if true, { }; { }()", languageFeatures: .trailingComma)
 
     assertParse(
       """
       if true, { print("if-body") } else { print("else-body") }
       """,
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
       """
       if true, { print("if-body") } else if true, { print("else-if-body") } { print("else-body") }
       """,
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
-    assertParse("if true, { if true { { } } }", experimentalFeatures: .trailingComma)
+    assertParse("if true, { if true { { } } }", languageFeatures: .trailingComma)
 
-    assertParse("{ if true, { print(0) } }", experimentalFeatures: .trailingComma)
+    assertParse("{ if true, { print(0) } }", languageFeatures: .trailingComma)
 
-    assertParse("( if true, { print(0) } )", experimentalFeatures: .trailingComma)
+    assertParse("( if true, { print(0) } )", languageFeatures: .trailingComma)
 
     assertParse(
       """
@@ -151,7 +151,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -165,7 +165,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -179,7 +179,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -193,7 +193,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -207,7 +207,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ true }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -222,7 +222,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -237,7 +237,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -251,7 +251,7 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
@@ -269,36 +269,36 @@ final class TrailingCommaTests: ParserTestCase {
         ],
         body: "{ print(0) }"
       ),
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
       "if 1️⃣, { }",
       diagnostics: [DiagnosticSpec(message: "missing condition in 'if' statement")],
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
   }
 
   func testGuardConditions() {
-    assertParse("guard true, else { break }", experimentalFeatures: .trailingComma)
+    assertParse("guard true, else { break }", languageFeatures: .trailingComma)
 
     assertParse(
       "guard true, 1️⃣, else { return }",
       diagnostics: [DiagnosticSpec(message: "expected expression in 'guard' statement", fixIts: ["insert expression"])],
       fixedSource: "guard true, <#expression#>, else { return }",
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
       "guard true, 1️⃣{ return }",
       diagnostics: [DiagnosticSpec(message: "expected 'else' in 'guard' statement", fixIts: ["insert 'else'"])],
       fixedSource: "guard true, else { return }",
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
   }
 
   func testWhileConditions() {
-    assertParse("while true, { print(0) }", experimentalFeatures: .trailingComma)
+    assertParse("while true, { print(0) }", languageFeatures: .trailingComma)
   }
 
   func testSwitchCaseLabel() {
@@ -311,7 +311,7 @@ final class TrailingCommaTests: ParserTestCase {
           break
       }
       """,
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
   }
 
@@ -320,14 +320,14 @@ final class TrailingCommaTests: ParserTestCase {
       """
       struct T: P1, P2, { }
       """,
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
 
     assertParse(
       """
       struct T: P1, P2, where P1: Equatable, P2: Equatable { }
       """,
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
   }
 
@@ -336,7 +336,7 @@ final class TrailingCommaTests: ParserTestCase {
       """
       struct T: P1, P2, where P1: Equatable, P2: Equatable, { }
       """,
-      experimentalFeatures: .trailingComma
+      languageFeatures: .trailingComma
     )
   }
 }

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -438,9 +438,9 @@ final class TypeTests: ParserTestCase {
   }
 
   func testLifetimeSpecifier() {
-    assertParse("func foo() -> dependsOn(x) X", experimentalFeatures: [.nonescapableTypes])
+    assertParse("func foo() -> dependsOn(x) X", languageFeatures: [.nonescapableTypes])
 
-    assertParse("func foo() -> dependsOn(x, y) X", experimentalFeatures: [.nonescapableTypes])
+    assertParse("func foo() -> dependsOn(x, y) X", languageFeatures: [.nonescapableTypes])
 
     assertParse(
       "func foo() -> dependsOn(1️⃣) X",
@@ -452,7 +452,7 @@ final class TypeTests: ParserTestCase {
         )
       ],
       fixedSource: "func foo() -> dependsOn(<#identifier#>) X",
-      experimentalFeatures: [.nonescapableTypes]
+      languageFeatures: [.nonescapableTypes]
     )
 
     assertParse(
@@ -465,12 +465,12 @@ final class TypeTests: ParserTestCase {
         )
       ],
       fixedSource: "func foo() -> dependsOn(x, <#identifier#>) X",
-      experimentalFeatures: [.nonescapableTypes]
+      languageFeatures: [.nonescapableTypes]
     )
 
-    assertParse("func foo() -> dependsOn(x) dependsOn(scoped y) X", experimentalFeatures: [.nonescapableTypes])
+    assertParse("func foo() -> dependsOn(x) dependsOn(scoped y) X", languageFeatures: [.nonescapableTypes])
 
-    assertParse("func foo() -> dependsOn(scoped x) X", experimentalFeatures: [.nonescapableTypes])
+    assertParse("func foo() -> dependsOn(scoped x) X", languageFeatures: [.nonescapableTypes])
 
     assertParse(
       "func foo() -> dependsOn1️⃣ X",
@@ -482,7 +482,7 @@ final class TypeTests: ParserTestCase {
         )
       ],
       fixedSource: "func foo() -> dependsOn(<#identifier#>) X",
-      experimentalFeatures: [.nonescapableTypes]
+      languageFeatures: [.nonescapableTypes]
     )
 
     assertParse(
@@ -496,7 +496,7 @@ final class TypeTests: ParserTestCase {
       ],
       fixedSource:
         "func foo() -> dependsOn(<#identifier#>) @Sendable (Int, isolated (any Actor)?) async throws -> Void",
-      experimentalFeatures: [.nonescapableTypes]
+      languageFeatures: [.nonescapableTypes]
     )
 
     assertParse(
@@ -510,12 +510,12 @@ final class TypeTests: ParserTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '*' in lifetime specifier"),
       ],
       fixedSource: "func foo() -> dependsOn(<#identifier#>*) X",
-      experimentalFeatures: [.nonescapableTypes]
+      languageFeatures: [.nonescapableTypes]
     )
 
-    assertParse("func foo() -> dependsOn(0) X", diagnostics: [], experimentalFeatures: [.nonescapableTypes])
+    assertParse("func foo() -> dependsOn(0) X", diagnostics: [], languageFeatures: [.nonescapableTypes])
 
-    assertParse("func foo() -> dependsOn(self) X", experimentalFeatures: [.nonescapableTypes])
+    assertParse("func foo() -> dependsOn(self) X", languageFeatures: [.nonescapableTypes])
 
     assertParse(
       "func foo() -> dependsOn1️⃣(0)2️⃣ X",
@@ -548,7 +548,7 @@ final class TypeTests: ParserTestCase {
         DiagnosticSpec(message: "unexpected code '-1' in lifetime specifier"),
       ],
       fixedSource: "func foo() -> dependsOn(<#identifier#>-1) X",
-      experimentalFeatures: [.nonescapableTypes]
+      languageFeatures: [.nonescapableTypes]
     )
   }
 
@@ -898,7 +898,7 @@ final class InlineArrayTypeTests: ParserTestCase {
         trailingComma: .commaToken()
       ),
       substructureAfterMarker: "1️⃣",
-      experimentalFeatures: .literalExpressions
+      languageFeatures: .literalExpressions
     )
   }
 
@@ -929,7 +929,7 @@ final class InlineArrayTypeTests: ParserTestCase {
         separator: .keyword(.of),
         element: .init(argument: .type(TypeSyntax("Int")))
       ),
-      experimentalFeatures: .literalExpressions
+      languageFeatures: .literalExpressions
     )
   }
 
@@ -937,7 +937,7 @@ final class InlineArrayTypeTests: ParserTestCase {
     // Nested inline arrays with expression counts
     assertParse(
       "[(1 + 1) of [(2 + 1) of Int]]",
-      experimentalFeatures: .literalExpressions
+      languageFeatures: .literalExpressions
     )
   }
 }

--- a/Tests/SwiftParserTest/translated/BorrowExprTests.swift
+++ b/Tests/SwiftParserTest/translated/BorrowExprTests.swift
@@ -26,7 +26,7 @@ final class BorrowExprTests: ParserTestCase {
         useString(_borrow global)
       }
       """,
-      experimentalFeatures: [.oldOwnershipOperatorSpellings]
+      languageFeatures: [.oldOwnershipOperatorSpellings]
     )
   }
 
@@ -40,7 +40,7 @@ final class BorrowExprTests: ParserTestCase {
           useString(_borrow t)
       }
       """,
-      experimentalFeatures: [.oldOwnershipOperatorSpellings]
+      languageFeatures: [.oldOwnershipOperatorSpellings]
     )
   }
 

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -89,7 +89,7 @@ final class MatchingPatternsTests: ParserTestCase {
         ()
       }
       """#,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -122,7 +122,7 @@ final class MatchingPatternsTests: ParserTestCase {
         ()
       }
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -134,7 +134,7 @@ final class MatchingPatternsTests: ParserTestCase {
         ()
       }
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -146,7 +146,7 @@ final class MatchingPatternsTests: ParserTestCase {
         ()
       }
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -418,7 +418,7 @@ final class MatchingPatternsTests: ParserTestCase {
         acceptInt(x)
       }
       """#,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -503,7 +503,7 @@ final class MatchingPatternsTests: ParserTestCase {
         ()
       }
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -584,7 +584,7 @@ final class MatchingPatternsTests: ParserTestCase {
       if case _mutating x = y {}
       guard case _mutating z = y else {}
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -594,7 +594,7 @@ final class MatchingPatternsTests: ParserTestCase {
       if case _consuming x = y {}
       guard case _consuming z = y else {}
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -604,7 +604,7 @@ final class MatchingPatternsTests: ParserTestCase {
       if case _borrowing x = y {}
       guard case _borrowing z = y else {}
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 

--- a/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
+++ b/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
@@ -1794,7 +1794,7 @@ final class ModuleSelectorTests: ParserTestCase {
           CodeBlockItemSyntax(item: .expr(ExprSyntax(IntegerLiteralExprSyntax(integerLiteral: 1))))
         }
       ),
-      experimentalFeatures: [.doExpressions]
+      languageFeatures: [.doExpressions]
     )
     assertParse(
       """
@@ -1808,7 +1808,7 @@ final class ModuleSelectorTests: ParserTestCase {
         let x = Swift::<#identifier#>
         do { 1 }
         """,
-      experimentalFeatures: [.doExpressions]
+      languageFeatures: [.doExpressions]
     )
     assertParse(
       "let x = Swift::if1️⃣ y { 1 } 2️⃣else { 0 }",

--- a/Tests/SwiftParserTest/translated/MoveExprTests.swift
+++ b/Tests/SwiftParserTest/translated/MoveExprTests.swift
@@ -25,7 +25,7 @@ final class MoveExprTests: ParserTestCase {
           let _ = _move global
       }
       """,
-      experimentalFeatures: [.oldOwnershipOperatorSpellings]
+      languageFeatures: [.oldOwnershipOperatorSpellings]
     )
   }
 
@@ -37,7 +37,7 @@ final class MoveExprTests: ParserTestCase {
           let _ = _move t
       }
       """,
-      experimentalFeatures: [.oldOwnershipOperatorSpellings]
+      languageFeatures: [.oldOwnershipOperatorSpellings]
 
     )
   }
@@ -51,7 +51,7 @@ final class MoveExprTests: ParserTestCase {
           let _ = _move t
       }
       """,
-      experimentalFeatures: [.oldOwnershipOperatorSpellings]
+      languageFeatures: [.oldOwnershipOperatorSpellings]
     )
   }
 
@@ -66,7 +66,7 @@ final class MoveExprTests: ParserTestCase {
         arguments: [.init(expression: DeclReferenceExprSyntax(baseName: .identifier("t")))],
         rightParen: .rightParenToken()
       ),
-      experimentalFeatures: [.oldOwnershipOperatorSpellings]
+      languageFeatures: [.oldOwnershipOperatorSpellings]
     )
   }
 
@@ -81,7 +81,7 @@ final class MoveExprTests: ParserTestCase {
         arguments: [.init(expression: DeclReferenceExprSyntax(baseName: .identifier("t")))],
         rightParen: .rightParenToken()
       ),
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 
@@ -101,7 +101,7 @@ final class MoveExprTests: ParserTestCase {
         _move
         t
         """,
-      experimentalFeatures: []
+      languageFeatures: []
     )
   }
 

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -25,7 +25,7 @@ final class PatternWithoutVariablesTests: ParserTestCase {
       _borrowing _ = 1
       _consuming _ = 1
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -40,7 +40,7 @@ final class PatternWithoutVariablesTests: ParserTestCase {
         _consuming _ = 1
       }
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 
@@ -59,7 +59,7 @@ final class PatternWithoutVariablesTests: ParserTestCase {
         _consuming (_, _) = (1, 2)
       }
       """,
-      experimentalFeatures: .referenceBindings
+      languageFeatures: .referenceBindings
     )
   }
 

--- a/Tests/SwiftWarningControlTest/WarningControlTests.swift
+++ b/Tests/SwiftWarningControlTest/WarningControlTests.swift
@@ -413,7 +413,7 @@ public class WarningGroupControlTests: XCTestCase {
       using @diagnose(GroupID, as: error)
       3️⃣let k = 1
       """,
-      experimentalFeatures: [.defaultIsolationPerFile],
+      languageFeatures: [.defaultIsolationPerFile],
       diagnosticGroupID: "GroupID",
       states: [
         "0️⃣": .error,
@@ -440,7 +440,7 @@ public class WarningGroupControlTests: XCTestCase {
       }
 
       """,
-      experimentalFeatures: [.defaultIsolationPerFile],
+      languageFeatures: [.defaultIsolationPerFile],
       diagnosticGroupID: "GroupID",
       states: [
         "0️⃣": .none,
@@ -748,7 +748,7 @@ private func assertWarningGroupControl(
   customConditions: Set<String> = [],
   globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
   groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil,
-  experimentalFeatures: Parser.ExperimentalFeatures? = nil,
+  languageFeatures: Parser.LanguageFeatures? = nil,
   diagnosticGroupID: DiagnosticGroupIdentifier,
   states: [String: WarningGroupControl?],
   file: StaticString = #filePath,
@@ -756,8 +756,8 @@ private func assertWarningGroupControl(
 ) throws {
   // Pull out the markers that we'll use to dig out nodes to query.
   let (markerLocations, source) = extractMarkers(markedSource)
-  let experimentalFeatures = experimentalFeatures ?? []
-  var parser = Parser(source, experimentalFeatures: experimentalFeatures)
+  let languageFeatures = languageFeatures ?? []
+  var parser = Parser(source, languageFeatures: languageFeatures)
   let tree = SourceFileSyntax.parse(from: &parser)
   let buildConfig = StaticBuildConfiguration(
     customConditions: customConditions,


### PR DESCRIPTION
Introduce a public `Parser.LanguageFeatures` option set so it can appear in the non-SPI parser API, replacing the previously `@_spi(ExperimentalLanguageFeatures)`-only `Parser.ExperimentalFeatures`, while keeping the individual feature flags behind `@_spi(ExperimentalLanguageFeatures)` since they remain experimental.

Now that the type is public, the overloads that previously existed only to accept the feature set can be collapsed. `Parser.init|parse|withParser` now take `languageFeatures` as a defaulted parameter (`= []`) instead of via separate `@_spi(ExperimentalLanguageFeatures)` overloads, leaving a minimal set of overloads.

The type and the `experimentalFeatures` parameter/property are renamed to `LanguageFeatures` / `languageFeatures` throughout; the `@_spi(ExperimentalLanguageFeatures)` SPI group name is unchanged, since the individual flags remain experimental. `StaticBuildConfiguration.experimentalFeatures` is renamed to `parserLanguageFeatures` to match the neighboring `parserSwiftVersion`.

No source-breaking changes to the public API. Deprecated `@_spi(ExperimentalLanguageFeatures)` compatibility shims keep existing clients (e.g. sourcekit-lsp, swift-format) building without changes.