### PR TITLE
[SwiftOperators] Expose precedence-group comparison on OperatorTable

### DIFF
--- a/Sources/SwiftOperators/OperatorTable+Semantics.swift
+++ b/Sources/SwiftOperators/OperatorTable+Semantics.swift
@@ -155,4 +155,33 @@ extension OperatorTable {
     try visitor.errors.forEach(errorHandler)
     self = visitor.opPrecedence
   }
+
+  /// Determine the precedence of one precedence group relative to another.
+  ///
+  /// - Parameters:
+  ///   - firstGroupName: The precedence group whose position is being queried.
+  ///   - secondGroupName: The precedence group being compared against.
+  ///   - syntax: A syntax node used as the reference location when reporting
+  ///     errors encountered while walking the precedence-group relationships.
+  ///   - errorHandler: A handler invoked when an inconsistency is found in
+  ///     the precedence-group relationships. By default the underlying
+  ///     `OperatorError` is re-thrown.
+  /// - Returns: ``Precedence/higherThan`` if `firstGroupName` has higher
+  ///   precedence than `secondGroupName`, ``Precedence/lowerThan`` if it has
+  ///   lower precedence, and ``Precedence/unrelated`` otherwise (including
+  ///   when both names refer to the same precedence group).
+  public func precedence(
+    of firstGroupName: PrecedenceGroupName,
+    relativeTo secondGroupName: PrecedenceGroupName,
+    referencedFrom syntax: Syntax,
+    errorHandler: OperatorErrorHandler = { throw $0 }
+  ) rethrows -> Precedence {
+    return try precedenceGraph.precedence(
+      relating: firstGroupName,
+      to: secondGroupName,
+      startSyntax: syntax,
+      endSyntax: syntax,
+      errorHandler: errorHandler
+    )
+  }
 }

--- a/Sources/SwiftOperators/PrecedenceGraph.swift
+++ b/Sources/SwiftOperators/PrecedenceGraph.swift
@@ -17,13 +17,13 @@ import SwiftSyntax
 #endif
 
 /// Describes the relative precedence of two groups.
-enum Precedence: Sendable {
+public enum Precedence: Sendable {
   case unrelated
   case higherThan
   case lowerThan
 
   /// Flip the precedence order around.
-  var flipped: Precedence {
+  public var flipped: Precedence {
     switch self {
     case .unrelated:
       return .unrelated

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -441,4 +441,59 @@ class OperatorPrecedenceTests: XCTestCase {
     let folded = try OperatorTable.standardOperators.foldAll(original)
     XCTAssertEqual(original.description, folded.description)
   }
+
+  func testPrecedenceGroupComparison() throws {
+    let opPrecedence = OperatorTable.standardOperators
+    let syntax = Syntax(ExprSyntax("x"))
+
+    // MultiplicationPrecedence has "higherThan: AdditionPrecedence" in the
+    // standard operators, so comparing the two groups directly should return
+    // the corresponding relationship in both directions.
+    XCTAssertEqual(
+      try opPrecedence.precedence(
+        of: "MultiplicationPrecedence",
+        relativeTo: "AdditionPrecedence",
+        referencedFrom: syntax
+      ),
+      .higherThan
+    )
+    XCTAssertEqual(
+      try opPrecedence.precedence(
+        of: "AdditionPrecedence",
+        relativeTo: "MultiplicationPrecedence",
+        referencedFrom: syntax
+      ),
+      .lowerThan
+    )
+
+    // Comparing a group to itself should always be reported as unrelated.
+    XCTAssertEqual(
+      try opPrecedence.precedence(
+        of: "AdditionPrecedence",
+        relativeTo: "AdditionPrecedence",
+        referencedFrom: syntax
+      ),
+      .unrelated
+    )
+
+    // Two groups that both sit above `TernaryPrecedence` but have no direct
+    // or transitive relationship to each other should be reported as unrelated.
+    // In the standard operator table, `DefaultPrecedence` and
+    // `LogicalDisjunctionPrecedence` are both declared `higherThan:
+    // TernaryPrecedence` with no other links between them.
+    XCTAssertEqual(
+      try opPrecedence.precedence(
+        of: "DefaultPrecedence",
+        relativeTo: "LogicalDisjunctionPrecedence",
+        referencedFrom: syntax
+      ),
+      .unrelated
+    )
+  }
+
+  func testPrecedenceGroupFlipped() {
+    XCTAssertEqual(Precedence.higherThan.flipped, .lowerThan)
+    XCTAssertEqual(Precedence.lowerThan.flipped, .higherThan)
+    XCTAssertEqual(Precedence.unrelated.flipped, .unrelated)
+  }
 }


### PR DESCRIPTION
## Summary

Adds a public API to `OperatorTable` that reports the relationship between two precedence groups, so callers can determine whether one group has higher, lower, or unrelated precedence to another without re-implementing the traversal:

```swift
public func precedence(
  of firstGroupName: PrecedenceGroupName,
  relativeTo secondGroupName: PrecedenceGroupName,
  referencedFrom syntax: Syntax,
  errorHandler: OperatorErrorHandler = { throw \$0 }
) rethrows -> Precedence
```

The `Precedence` enum (and its `flipped` accessor) are also made public so callers can consume the result.

## Motivation

This resolves #2258. The existing use case is [swift-format PR apple/swift-format#647](https://github.com/apple/swift-format/pull/647), where a caller wanted to compare the precedence of two operators. That comparison lived on the internal `PrecedenceGraph.precedence(relating:to:startSyntax:endSyntax:)` helper, so callers had no supported way to obtain the information short of re-implementing the traversal.

This PR does **not** change the algorithm — it lifts the existing internal capability to the public surface.

## Design notes

- The public method is added to `OperatorTable+Semantics.swift` because that file already declares `public import SwiftSyntax`, so its public API can accept `Syntax` in the signature (needed to preserve the same error-reporting semantics as the internal helper).
- The `referencedFrom:` parameter mirrors the pattern used by the existing internal `lookupOperatorPrecedenceGroupName(_:referencedFrom:errorHandler:)` helper on `OperatorTable`. Callers that already have a syntax node (e.g. the operator token being compared) simply pass it through.
- The `errorHandler` default matches the rest of the module: `{ throw \$0 }` (re-throw the underlying `OperatorError`).

## Test plan

Three unit tests in `OperatorTableTests`:

- `testPrecedenceGroupComparison` exercises the new API on the standard operator table across four scenarios:
  - Direct `higherThan` relationship (`MultiplicationPrecedence` vs `AdditionPrecedence`).
  - The flipped direction returning `.lowerThan`.
  - The same-group case returning `.unrelated`.
  - Two groups that both sit above `TernaryPrecedence` with no other links between them (`DefaultPrecedence` vs `LogicalDisjunctionPrecedence`) returning `.unrelated`.
- `testPrecedenceGroupFlipped` covers `Precedence.flipped` for all three cases.

## Files changed

- `Sources/SwiftOperators/PrecedenceGraph.swift`: mark `Precedence` and `Precedence.flipped` `public` — **+2 / -2**.
- `Sources/SwiftOperators/OperatorTable+Semantics.swift`: add `precedence(of:relativeTo:referencedFrom:errorHandler:)` — **+29 / -0**.
- `Tests/SwiftOperatorsTest/OperatorTableTests.swift`: add two new tests — **+55 / -0**.

Total: **+86 / -2**.

Resolves #2258.