### PR TITLE
[SwiftParser] Coalesce parsed-token text interning

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -245,7 +245,7 @@ public struct Parser {
       // `Parser` is destroyed (i.e. when the parse call returns); each token's
       // text is interned into the arena at node-creation time, so the resulting
       // tree does not reference this buffer.
-      let owner = ParserSourceBufferOwner(copying: input)
+      let owner = ParserSourceBufferOwner(copying: input, arena: self.arena)
       self.sourceBufferOwner = owner
       input = owner.buffer
     } else {
@@ -255,6 +255,10 @@ public struct Parser {
       // and does not reference the buffer after parsing.
       self.sourceBufferOwner = nil
     }
+
+    // Let the arena coalesce copies of adjacent tokens that point into this
+    // buffer (see `ParsingRawSyntaxArena.internParsedTokenText`).
+    self.arena.setSourceBuffer(input)
 
     self.maximumNestingLevel = maximumNestingLevel ?? Self.defaultMaximumNestingLevel
     self.swiftVersion = swiftVersion ?? Self.defaultSwiftVersion
@@ -456,6 +460,9 @@ public struct Parser {
       swiftVersion: swiftVersion,
       experimentalFeatures: experimentalFeatures
     )
+    // `input` (the caller's buffer) may be freed once `body` returns, so stop
+    // the arena from coalescing against it before then.
+    defer { parser.arena.clearSourceBuffer() }
     return body(&parser)
   }
 
@@ -1066,13 +1073,21 @@ private final class LookaheadTrackerOwner {
 private final class ParserSourceBufferOwner {
   let buffer: UnsafeBufferPointer<UInt8>
 
-  init(copying input: UnsafeBufferPointer<UInt8>) {
+  /// The arena that was told about `buffer` via `setSourceBuffer`. Its
+  /// coalescing bounds point into `buffer`, and the arena can outlive this
+  /// owner (the parsed tree retains it), so those bounds must be cleared before
+  /// `buffer` is freed.
+  private let arena: ParsingRawSyntaxArena
+
+  init(copying input: UnsafeBufferPointer<UInt8>, arena: ParsingRawSyntaxArena) {
     let allocated = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: input.count)
     _ = allocated.initialize(from: input)
     self.buffer = UnsafeBufferPointer(start: allocated.baseAddress, count: input.count)
+    self.arena = arena
   }
 
   deinit {
+    self.arena.clearSourceBuffer()
     self.buffer.deallocate()
   }
 }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
@@ -202,9 +202,60 @@ public class ParsingRawSyntaxArena: RawSyntaxArena {
   /// - Important: Must never be changed to a mutable value. See `RawSyntaxArenaRef.parseTrivia`.
   private let parseTriviaFunction: ParseTriviaFunction
 
+  /// Size of the contiguous source chunk `internParsedTokenText` copies on a
+  /// miss. Larger values copy fewer, bigger chunks (cheaper full parses) at the
+  /// cost of over-copying up to this many bytes past a reused span.
+  private static let sourceMirrorChunkSize = 4096
+
+  /// Bounds of the source buffer parsed tokens are lexed from.
+  private struct SourceBounds {
+    let start: UnsafePointer<UInt8>
+    let end: UnsafePointer<UInt8>
+  }
+
+  /// A contiguous source sub-range `[start, end)` copied to `dest` in this arena.
+  private struct Mirror {
+    let start: UnsafePointer<UInt8>
+    let end: UnsafePointer<UInt8>
+    let dest: UnsafePointer<UInt8>
+  }
+
+  /// The source buffer that parsed tokens are lexed from, set via
+  /// `setSourceBuffer`. `nil` disables coalescing (each token is copied
+  /// individually).
+  private var sourceBounds: SourceBounds?
+
+  /// The most recent contiguous chunk of the source buffer copied into this
+  /// arena. `internParsedTokenText`'s fast path serves tokens falling within it
+  /// as slices of the copy. `nil` until the first chunk is mirrored.
+  private var mirror: Mirror?
+
   public init(parseTriviaFunction: @escaping ParseTriviaFunction) {
     self.parseTriviaFunction = parseTriviaFunction
     super.init(slabSize: 4096)
+  }
+
+  /// Record the source buffer that subsequent parsed tokens are lexed from so
+  /// `internParsedTokenText` can coalesce copies of adjacent tokens. Resets any
+  /// previously mirrored chunk.
+  @_spi(RawSyntax) public func setSourceBuffer(_ buffer: UnsafeBufferPointer<UInt8>) {
+    if let start = buffer.baseAddress {
+      self.sourceBounds = SourceBounds(start: start, end: start + buffer.count)
+    } else {
+      self.sourceBounds = nil
+    }
+    self.mirror = nil
+  }
+
+  /// Forget the source buffer registered by `setSourceBuffer` and disable
+  /// coalescing.
+  ///
+  /// - Important: Must be called once the source buffer is no longer valid
+  ///   (i.e. when the parse completes). The arena can outlive the source buffer,
+  ///   so the recorded bounds would otherwise dangle.
+  @_spi(RawSyntax) public func clearSourceBuffer() {
+    self.sourceBounds = nil
+    self.mirror = nil
   }
 
   /// Intern a parsed token's whole text into the arena's node allocator so the
@@ -212,10 +263,53 @@ public class ParsingRawSyntaxArena: RawSyntaxArena {
   ///
   /// Unlike `intern(_:)`, this skips the `contains` check: lexer-produced text
   /// is never already managed by the arena, so a copy is always needed.
+  ///
+  /// When the text lies within the source buffer registered by
+  /// `setSourceBuffer`, copies are coalesced: on a miss a whole contiguous
+  /// chunk of the source is mirrored, and subsequent adjacent tokens are served
+  /// as offsets into that copy without copying again. Because parsed tokens are
+  /// produced in source order with contiguous `wholeText`, a full parse copies
+  /// the source in a handful of chunks rather than once per token, and an
+  /// incremental reparse mirrors only the re-lexed spans.
   func internParsedTokenText(_ text: SyntaxText) -> SyntaxText {
-    if text.isEmpty {
+    // Empty text needs no copy; the pointer checks below also assume a non-nil
+    // base.
+    guard let base = text.baseAddress, !text.isEmpty else {
       return text
     }
+
+    // Fast path: the token already lies within the mirrored chunk. This is the
+    // common case for adjacent in-order tokens and needs only the mirror.
+    if let mirror, base >= mirror.start, base + text.count <= mirror.end {
+      return SyntaxText(baseAddress: mirror.dest + mirror.start.distance(to: base), count: text.count)
+    }
+
+    // Text outside the source buffer (e.g. synthesized tokens), or no source
+    // buffer registered: copy it directly.
+    guard let sourceBounds, base >= sourceBounds.start, base + text.count <= sourceBounds.end else {
+      return copyParsedTokenText(text)
+    }
+
+    // A token that starts before the current mirror means the parser moved
+    // backward (e.g. backtracking); that is temporary, so copy it individually
+    // and leave the forward mirror in place for when parsing resumes.
+    if let mirror, base < mirror.start {
+      return copyParsedTokenText(text)
+    }
+
+    // Mirror a fresh chunk starting at this token, reading ahead so the
+    // following contiguous tokens hit the fast path without copying.
+    let available = base.distance(to: sourceBounds.end)
+    let chunk = min(available, max(text.count, Self.sourceMirrorChunkSize))
+    let allocated = allocateTextBuffer(count: chunk)
+    _ = allocated.initialize(from: UnsafeBufferPointer(start: base, count: chunk))
+    self.mirror = Mirror(start: base, end: base + chunk, dest: UnsafePointer(allocated.baseAddress!))
+    return SyntaxText(baseAddress: allocated.baseAddress, count: text.count)
+  }
+
+  /// Copies `text` into this arena's node allocator directly, without
+  /// coalescing.
+  private func copyParsedTokenText(_ text: SyntaxText) -> SyntaxText {
     let allocated = allocateTextBuffer(count: text.count)
     _ = allocated.initialize(from: text)
     return SyntaxText(baseAddress: allocated.baseAddress, count: allocated.count)

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -66,6 +66,31 @@ class EntryTests: ParserTestCase {
     assertRoundTrips(Array("a".utf8) + [0x00] + Array("b".utf8))  // embedded NUL
   }
 
+  /// Parsed-token text is interned by mirroring contiguous chunks of the source
+  /// buffer (see `ParsingRawSyntaxArena`), so the resulting tree owns its text
+  /// and does not reference the source. These inputs exercise that coalescing:
+  /// single tokens longer than one mirror chunk, and a source whose tokens span
+  /// several chunks. `assertParse` verifies each round-trips.
+  func testParsedTokenTextInterning() throws {
+    let longIdentifier = String(repeating: "a", count: 5000)
+    let longStringContents = String(repeating: "x", count: 5000)
+
+    // Single tokens whose text exceeds the mirror chunk size (an identifier and
+    // a string-literal segment), exercising the oversized-chunk path.
+    assertParse("let \(longIdentifier) = 0")
+    assertParse("let s = \"\(longStringContents)\"")
+
+    // Several oversized tokens with ordinary tokens in between, so the mirror
+    // rolls over to a fresh chunk after each oversized token.
+    assertParse(
+      """
+      let \(longIdentifier) = 0
+      let s = "\(longStringContents)"
+      func f() { let \(longIdentifier) = 1 }
+      """
+    )
+  }
+
   func testSyntaxParse() throws {
     assertParse(
       "func test() {}",


### PR DESCRIPTION
748dde4ff changed parsing to intern each token's text individually rather than copying the whole source buffer once, so a parsed tree no longer retains the source buffer. That's a real win for incremental reparsing memory, but it regressed full-parse performance: a full parse now copies the source in as many pieces as there are tokens — each with its own bump-allocation and `memcpy` — instead of a single bulk copy.

This PR recovers most of that cost while keeping 748's self-contained-tree property. Parsed tokens are produced in source order with contiguous `wholeText`, so on a miss the arena mirrors a whole contiguous chunk of the source and serves the following adjacent tokens as slices of that copy. A full parse then copies the source in a handful of chunks instead of once per token, and because the interned text is still arena-owned, an incremental reparse mirrors only the re-lexed spans, not the whole buffer.

Mechanically: `ParsingRawSyntaxArena.setSourceBuffer` registers the buffer tokens are lexed from; `internParsedTokenText` returns a slice of the current mirrored chunk on a hit and mirrors a fresh chunk on a miss. Text that is not within the source buffer (e.g. synthesized tokens), or that starts before the current mirror (the parser moved backward, which is temporary), is copied directly so the forward mirror is preserved. The arena outlives the source buffer, so the recorded bounds are cleared once the buffer is no longer valid — `withParser` clears them when its scope ends, and the parser-owned source copy clears them when it is freed — leaving no dangling pointers on the retained arena.

Measurements — retired instructions per full parse of a 178 KB source (release, whole-package cross-module optimization, RawSyntax validation off, deterministic instruction counts):

| build                               | instructions / parse |
| ----------------------------------- | -------------------- |
| before 748 (whole-buffer interning) | ~84.8 M              |
| main (748, per-token interning)     | ~88.2 M              |
| this PR                             | ~85.4 M              |

So this recovers roughly 80% of the regression (landing ~0.8% above the pre-748 floor), with wall-clock back at the pre-748 level.
