### PR TITLE
[SwiftRefactor] Fix add-target-dependency matching nested target references

### DIFF
--- a/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
+++ b/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
@@ -198,7 +198,15 @@ extension FunctionCallExprSyntax {
       return literalValue == targetName
     }
 
-    guard let targetCall = FunctionCallExprSyntax.findFirst(in: targetArray, matching: matchesTargetCall) else {
+    // Only consider the top-level elements of the `targets` array. A
+    // recursive search would incorrectly match a `.target(name:)` reference
+    // nested inside another target's `dependencies` array before reaching the
+    // actual target definition. See swiftlang/swift-package-manager#10122.
+    guard
+      let targetCall = targetArray.elements.lazy
+        .compactMap({ $0.expression.as(FunctionCallExprSyntax.self) })
+        .first(where: matchesTargetCall)
+    else {
       throw ManifestEditError.cannotFindTarget(targetName: targetName)
     }
 

--- a/Tests/SwiftRefactorTest/ManifestEditTests.swift
+++ b/Tests/SwiftRefactorTest/ManifestEditTests.swift
@@ -642,6 +642,56 @@ final class ManifestEditTests: XCTestCase {
     )
   }
 
+  func testAddTargetDependencyToTargetReferencedByAnotherTarget() throws {
+    // Regression test for swiftlang/swift-package-manager#10122: the target to
+    // modify must be found among the top-level `targets` elements, not a
+    // `.target(name:)` reference nested in another target's dependencies.
+    try assertManifestRefactor(
+      """
+      // swift-tools-version: 5.5
+      let package = Package(
+          name: "packages",
+          targets: [
+              .target(
+                  name: "MyLib",
+                  dependencies: [
+                      .target(name: "TargetOne"),
+                  ]
+              ),
+              .target(
+                  name: "TargetOne"
+              ),
+          ]
+      )
+      """,
+      expectedManifest: """
+        // swift-tools-version: 5.5
+        let package = Package(
+            name: "packages",
+            targets: [
+                .target(
+                    name: "MyLib",
+                    dependencies: [
+                        .target(name: "TargetOne"),
+                    ]
+                ),
+                .target(
+                    name: "TargetOne",
+                    dependencies: [
+                        .target(name: "TargetTwo"),
+                    ]
+                ),
+            ]
+        )
+        """,
+      provider: AddTargetDependency.self,
+      context: .init(
+        dependency: .target(name: "TargetTwo"),
+        targetName: "TargetOne"
+      )
+    )
+  }
+
   func testAddJava2SwiftPlugin() throws {
     try assertManifestRefactor(
       """


### PR DESCRIPTION
### Summary

`swift package add-target-dependency` can produce a `Package.swift` that no longer compiles when the target being modified is also referenced as a dependency of another target. The root cause is in `SwiftRefactor`, so fixing it here.

Reported as swiftlang/swift-package-manager#10122.

### Details

`findManifestTargetCall(targetName:)` locates the target to modify with a recursive `FunctionCallExprSyntax.findFirst(in: targetArray, ...)`. Because that walks the whole subtree, given a manifest like:

```swift
targets: [
    .target(
        name: "MyLib",
        dependencies: [
            .target(name: "TargetOne"),   // <- matched first
        ]
    ),
    .target(name: "TargetOne"),           // <- the real definition
]
```

it matches the nested `.target(name: "TargetOne")` *reference* before the actual top-level definition, then appends a `dependencies:` argument to that reference, yielding malformed output such as:

```swift
.target(name: "TargetOne",dependencies: [
    .target(name: "TargetThree"),]),
```

which fails to compile (`extra argument 'dependencies' in call`).

### Fix

Match only the top-level elements of the `targets` array rather than recursively descending into nested calls, so the target definition is always the node that gets modified.

### Test

Added `testAddTargetDependencyToTargetReferencedByAnotherTarget` to `ManifestEditTests`, which reproduces the case above. It fails before the change and passes after; the full `ManifestEditTests` suite (19 tests) passes.