### PR TITLE
[Diagnostics] Render tabs for diagnostic markers

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -319,14 +319,12 @@ public struct DiagnosticsFormatter {
           + diagnosticDecorator.decorateBufferOutline("|") + " "
         var sourceCharacters = annotatedLine.sourceString.makeIterator()
         for c in 1..<column {
-          let sourceCharacter = sourceCharacters.next()
-
-          if columnsWithDiagnostics.contains(c) {
-            preMessage.append("|")
-          } else if sourceCharacter == "\t" {
-            // Use tabs in the same columns where source had them, to render
-            // with the same width.
+          if sourceCharacters.next() == "\t" {
+            // Reproduce the tab even when a diagnostic is anchored on it, so its
+            // width still matches the source line (the column loses its arm).
             preMessage.append("\t")
+          } else if columnsWithDiagnostics.contains(c) {
+            preMessage.append("|")
           } else {
             preMessage.append(" ")
           }

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -282,7 +282,7 @@ public struct DiagnosticsFormatter {
       // add indentation
       annotatedSource.append(indentString)
 
-      // print the source line
+      // print the source line (verbatim, with tabs!)
       annotatedSource.append(linePrefix)
       annotatedSource.append(
         colorizeSourceLine(
@@ -316,10 +316,17 @@ public struct DiagnosticsFormatter {
         // compute the string that is shown before each message
         var preMessage =
           indentString + String(repeating: " ", count: maxNumberOfDigits) + " "
-          + diagnosticDecorator.decorateBufferOutline("|")
-        for c in 0..<column {
+          + diagnosticDecorator.decorateBufferOutline("|") + " "
+        var sourceCharacters = annotatedLine.sourceString.makeIterator()
+        for c in 1..<column {
+          let sourceCharacter = sourceCharacters.next()
+
           if columnsWithDiagnostics.contains(c) {
             preMessage.append("|")
+          } else if sourceCharacter == "\t" {
+            // Use tabs in the same columns where source had them, to render
+            // with the same width.
+            preMessage.append("\t")
           } else {
             preMessage.append(" ")
           }

--- a/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
+++ b/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
@@ -96,6 +96,18 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
   }
 
+  func testDiagnosticAnchoredOnTab() {
+    // If we don't prioritize a tab over '|' we would fall out of alignment...
+    let source = "a\tb\tc"
+    let expectedOutput = """
+      1 | a\tb\tc
+        |  \t `- error: consecutive statements on a line must be separated by newline or ';'
+        |  `- error: consecutive statements on a line must be separated by newline or ';'
+
+      """
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
+  }
+
   func testLineSkipping() {
     let source = """
       var i = 1

--- a/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
+++ b/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
@@ -50,6 +50,52 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
   }
 
+  func testTabIndentedSingleDiagnostic() {
+    let source = "\tfoo.[]"
+    let expectedOutput = """
+      1 | \tfoo.[]
+        | \t    `- error: expected name in member access
+
+      """
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
+  }
+
+  func testTabIndentedMultipleDiagnostics() {
+    let source = "\tfoo.[].[].[]"
+    let expectedOutput = """
+      1 | \tfoo.[].[].[]
+        | \t    |  |  `- error: expected name in member access
+        | \t    |  `- error: expected name in member access
+        | \t    `- error: expected name in member access
+
+      """
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
+  }
+
+  func testMultipleTabIndentedMultipleDiagnostics() {
+    let source = "\tfoo\t.[]\t.[]\t.[]"
+    let expectedOutput = """
+      1 | \tfoo\t.[]\t.[]\t.[]
+        | \t   \t | \t | \t `- error: expected name in member access
+        | \t   \t | \t `- error: expected name in member access
+        | \t   \t `- error: expected name in member access
+
+      """
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
+  }
+
+  func testInteriorTab() {
+    // `testRightParenLocation` with the space after `:` replaced by tab
+    let source = "let _ :\tFloat  -> Int"
+    let expectedOutput = """
+      1 | let _ :\tFloat  -> Int
+        |        \t|    `- error: expected ')' in function type
+        |        \t`- error: expected '(' to start function type
+
+      """
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
+  }
+
   func testLineSkipping() {
     let source = """
       var i = 1
@@ -136,7 +182,7 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
   }
 
-  func testRighParenLocation() {
+  func testRightParenLocation() {
     let source = """
       let _ : Float  -> Int
       """


### PR DESCRIPTION
This is kind of a partial fix, the more correct thing to (consider?) is normalizing tabs by figuring out where each tab stop would be and adding the appropriate amount of spaces. Apparently, the C++ diagnostic formatter we had normalized tabs to two spaces unconditionally? That isn't ideal since it would render code in diagnostics differently from how it is seen in editors (tabs are supposed to pad until the next tabstop). But how tabs look isn't consistent, I could have my terminal configured to let tabstops be 8 columns wide for example. Very possible that tab normalization isn't done on purpose! Assuming so, this PR adds tabs for each column in the source that has a tab. This way, our diagnostics pad to the same column as the source they are pointing at. If we put a diagnostic on a tab (the tab itself), and it's stacked below another diagnostic, this means we need to emit a tab instead of the `|`, which is a little unfortunate. If we normalized tabs, we wouldn't need to do that... It looks like `testDiagnosticAnchoredOnTab` in the bad case, which isn't so bad.

for a file like this (with a tab):

```
	tabbed
```


before (we emit the one space we always emit + 1 space for the "one character" tab):
```
error: cannot find 'tabbed' in scope
1 |     tabbed
  |  `- error: cannot find 'tabbed' in scope
2 |
```

now (we emit the one space we always emit + corresponding tab):
```
error: cannot find 'tabbed' in scope
1 |     tabbed
  |     `- error: cannot find 'tabbed' in scope
2 |
```

Which lets errors point at the right column in code that uses tabs.

Resolves swiftlang/swift#87173
Resolves rdar://170194350