### PR TITLE
[SwiftParser] Parse module-selected keyword references

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -21,7 +21,7 @@ extension TokenConsumer {
     if self.isAtModuleSelector() {
       var lookahead = self.lookahead()
       _ = lookahead.consumeModuleSelectorTokensIfPresent()
-      return lookahead.atStartOfExpression()
+      return lookahead.atStartOfExpression() || lookahead.currentToken.isLexerClassifiedKeyword
     }
 
     switch self.at(anyIn: ExpressionStart.self) {

--- a/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
+++ b/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
@@ -1783,6 +1783,9 @@ final class ModuleSelectorTests: ParserTestCase {
   }
 
   func testModuleSelectorExpr() {
+    assertParse("Module::as(x)")
+    assertParse("Module::is(x)")
+
     assertParse(
       "let x = Swift::1️⃣do { 1 }",
       substructure: FunctionCallExprSyntax(


### PR DESCRIPTION
## Summary

- keep module-selected keyword references eligible at expression start
- add regression coverage for `Module::as(x)` and `Module::is(x)`

Fixes #3387.

## Validation

- `swift build --product SwiftParser`
- `git diff --check`

The focused XCTest target could not run on this machine because the installed CommandLineTools SDK does not provide the XCTest module.