### PR TITLE
Add missing imports for MemberImportVisibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ if(SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
   add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
 endif()
 
+# Require every file to import the modules that define the members it uses.
+# Keep in sync with Package.swift.
+add_compile_options(
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>"
+)
+
 if(NOT DEFINED Swift_COMPILER_PACKAGE_CMO_SUPPORT AND SWIFTSYNTAX_EMIT_MODULE)
   swift_get_package_cmo_support(Swift_COMPILER_PACKAGE_CMO_SUPPORT)
 endif()

--- a/Package.swift
+++ b/Package.swift
@@ -470,6 +470,12 @@ package.targets.append(
   )
 )
 
+// Require every file to import the modules that define the members it uses, so that missing
+// imports can't creep back in. Toolchains that don't know the upcoming feature ignore the flag.
+for target in package.targets where target.type == .regular || target.type == .test {
+  target.swiftSettings = (target.swiftSettings ?? []) + [.enableUpcomingFeature("MemberImportVisibility")]
+}
+
 // MARK: - Parse build arguments
 
 func hasEnvironmentVariable(_ name: String) -> Bool {

--- a/Package.swift
+++ b/Package.swift
@@ -472,7 +472,8 @@ package.targets.append(
 
 // Require every file to import the modules that define the members it uses, so that missing
 // imports can't creep back in. Toolchains that don't know the upcoming feature ignore the flag.
-for target in package.targets where target.type == .regular || target.type == .test {
+// When updating this, also update CMakeLists.txt accordingly.
+for target in package.targets where target.type != .plugin {
   target.swiftSettings = (target.swiftSettings ?? []) + [.enableUpcomingFeature("MemberImportVisibility")]
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -319,7 +319,14 @@ let package = Package(
 
     .target(
       name: "SwiftSyntaxMacroExpansion",
-      dependencies: ["SwiftSyntax", "SwiftSyntaxBuilder", "SwiftSyntaxMacros", "SwiftDiagnostics", "SwiftOperators"],
+      dependencies: [
+        "SwiftBasicFormat",
+        "SwiftSyntax",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftDiagnostics",
+        "SwiftOperators",
+      ],
       exclude: ["CMakeLists.txt"]
     ),
 

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -13,9 +13,11 @@
 #if compiler(>=6)
 internal import SwiftDiagnostics
 internal import SwiftSyntax
+internal import SwiftSyntaxMacros
 #else
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxMacros
 #endif
 
 /// Errors in macro handing.

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -13,6 +13,7 @@
 import SwiftDiagnostics
 import SwiftOperators
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Evaluate the condition of an `#if`.
 /// - Parameters:

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -11,10 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
+internal import SwiftBasicFormat
 public import SwiftDiagnostics
 @_spi(Diagnostics) internal import SwiftParser
 @_spi(ExperimentalLanguageFeatures) public import SwiftSyntax
 #else
+import SwiftBasicFormat
 import SwiftDiagnostics
 @_spi(Diagnostics) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax

--- a/Sources/SwiftRefactor/PackageManifest/ManifestSyntaxRepresentable.swift
+++ b/Sources/SwiftRefactor/PackageManifest/ManifestSyntaxRepresentable.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Describes an entity in the package model that can be represented as
 /// a syntax node.

--- a/Sources/SwiftRefactor/PackageManifest/PackageTarget.swift
+++ b/Sources/SwiftRefactor/PackageManifest/PackageTarget.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Syntactic wrapper type that describes a target for refactoring
 /// purposes but does not interpret its contents.

--- a/Sources/SwiftRefactor/PackageManifest/ProductDescription.swift
+++ b/Sources/SwiftRefactor/PackageManifest/ProductDescription.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Syntactic wrapper type that describes a product for refactoring
 /// purposes but does not interpret its contents.

--- a/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
+++ b/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
@@ -13,6 +13,7 @@
 import SwiftBasicFormat
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Default indent when we have to introduce indentation but have no context
 /// to get it right.

--- a/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
+internal import SwiftBasicFormat
 internal import SwiftSyntax
 #else
+import SwiftBasicFormat
 import SwiftSyntax
 #endif
 

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
-import SwiftBasicFormat
+internal import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftIfConfig
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
@@ -12,9 +12,11 @@
 
 #if compiler(>=6)
 public import SwiftSyntax
+internal import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 #else
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 #endif
 

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
+internal import SwiftBasicFormat
 internal import SwiftDiagnostics
 internal import SwiftOperators
 @_spi(MacroExpansion) internal import SwiftParser
@@ -18,6 +19,7 @@ internal import SwiftOperators
 internal import SwiftSyntaxBuilder
 @_spi(MacroExpansion) @_spi(ExperimentalLanguageFeatures) public import SwiftSyntaxMacros
 #else
+import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftOperators
 @_spi(MacroExpansion) import SwiftParser

--- a/Tests/SwiftDiagnosticsTest/FixItTests.swift
+++ b/Tests/SwiftDiagnosticsTest/FixItTests.swift
@@ -14,6 +14,7 @@ import SwiftDiagnostics
 import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftIDEUtilsTest/FixItApplierTests.swift
+++ b/Tests/SwiftIDEUtilsTest/FixItApplierTests.swift
@@ -12,6 +12,7 @@
 
 @_spi(FixItApplier) import SwiftIDEUtils
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 private extension SourceEdit {

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -14,6 +14,7 @@ import SwiftDiagnostics
 import SwiftIfConfig
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 @_spi(XCTestFailureLocation) @_spi(Testing) import SwiftSyntaxMacrosGenericTestSupport
 import XCTest
 import _SwiftSyntaxGenericTestSupport

--- a/Tests/SwiftIfConfigTest/VisitorTests.swift
+++ b/Tests/SwiftIfConfigTest/VisitorTests.swift
@@ -14,6 +14,7 @@ import SwiftDiagnostics
 @_spi(Compiler) import SwiftIfConfig
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 @_spi(XCTestFailureLocation) @_spi(Testing) import SwiftSyntaxMacrosGenericTestSupport
 import XCTest
 import _SwiftSyntaxGenericTestSupport

--- a/Tests/SwiftLexicalLookupTest/ValueDeclTests.swift
+++ b/Tests/SwiftLexicalLookupTest/ValueDeclTests.swift
@@ -13,6 +13,7 @@
 @_spi(Experimental) @_spi(_QualifiedLookup) import SwiftLexicalLookup
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 /// Visitor class helper used in ``SyntaxProtocol/children``

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -13,6 +13,7 @@
 @_spi(Testing) import SwiftOperators
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -10,12 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftBasicFormat
 import SwiftDiagnostics
 @_spi(FixItApplier) import SwiftIDEUtils
 @_spi(Testing) @_spi(RawSyntax) @_spi(AlternateTokenIntrospection) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) import SwiftParserDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
 import XCTest
+import _SwiftSyntaxGenericTestSupport
 import _SwiftSyntaxTestSupport
 
 // MARK: Lexing Assertions

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 @_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class AttributeTests: ParserTestCase {

--- a/Tests/SwiftParserTest/DirectiveTests.swift
+++ b/Tests/SwiftParserTest/DirectiveTests.swift
@@ -12,6 +12,7 @@
 
 @_spi(RawSyntax) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class DirectiveTests: ParserTestCase {

--- a/Tests/SwiftParserTest/DoExpressionTests.swift
+++ b/Tests/SwiftParserTest/DoExpressionTests.swift
@@ -12,6 +12,7 @@
 
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class DoExpressionTests: ParserTestCase {

--- a/Tests/SwiftParserTest/ExpressionInterpretedAsVersionTupleTests.swift
+++ b/Tests/SwiftParserTest/ExpressionInterpretedAsVersionTupleTests.swift
@@ -12,6 +12,7 @@
 
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class ExpressionTests: ParserTestCase {

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 @_spi(RawSyntax) @_spi(Testing) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 import XCTest

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -12,6 +12,7 @@
 
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 class EntryTests: ParserTestCase {

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax

--- a/Tests/SwiftParserTest/RegexLiteralTests.swift
+++ b/Tests/SwiftParserTest/RegexLiteralTests.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class RegexLiteralTests: ParserTestCase {

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -12,6 +12,7 @@
 
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class StatementTests: ParserTestCase {

--- a/Tests/SwiftParserTest/ThenStatementTests.swift
+++ b/Tests/SwiftParserTest/ThenStatementTests.swift
@@ -12,6 +12,7 @@
 
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class ThenStatementTests: ParserTestCase {

--- a/Tests/SwiftParserTest/TrailingCommaTests.swift
+++ b/Tests/SwiftParserTest/TrailingCommaTests.swift
@@ -12,6 +12,7 @@
 
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class TrailingCommaTests: ParserTestCase {

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -12,6 +12,7 @@
 
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class TypeTests: ParserTestCase {

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class VariadicGenericsTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -13,6 +13,7 @@
 // This test file has been translated from swift/test/Parse/errors.swift
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class ErrorsTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
@@ -14,6 +14,7 @@
 
 @_spi(RawSyntax) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class ForwardSlashRegexTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
+++ b/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
@@ -14,6 +14,7 @@
 
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class ModuleSelectorTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -13,6 +13,7 @@
 // This test file has been translated from swift/test/Parse/recovery.swift
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class RecoveryTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -12,6 +12,7 @@
 
 // This test file has been translated from swift/test/Parse/type_expr.swift
 
+import SwiftParser
 import SwiftSyntax
 import XCTest
 

--- a/Tests/SwiftSyntaxBuilderTest/Assertions.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Assertions.swift
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftBasicFormat
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import XCTest
+import _SwiftSyntaxGenericTestSupport
 import _SwiftSyntaxTestSupport
 
 func assertBuildResult<T: SyntaxProtocol>(

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -15,6 +15,7 @@ import SwiftParser
 import SwiftSyntax
 @_spi(Testing) import SwiftSyntaxBuilder
 import XCTest
+import _SwiftSyntaxGenericTestSupport
 import _SwiftSyntaxTestSupport
 
 class TwoSpacesFormat: BasicFormat {

--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -20,8 +20,10 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
@@ -12,6 +12,7 @@
 
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 @_spi(Testing) import SwiftSyntaxMacroExpansion
 import XCTest
 import _SwiftSyntaxTestSupport

--- a/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
@@ -20,8 +20,10 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 @_spi(Testing) import SwiftSyntaxMacroExpansion
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
@@ -19,7 +19,9 @@
 //==========================================================================//
 
 import SwiftDiagnostics
+import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport

--- a/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
@@ -19,9 +19,12 @@
 //==========================================================================//
 
 import SwiftDiagnostics
+import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
@@ -18,9 +18,12 @@
 // macros are invoked.                                                      //
 //==========================================================================//
 
+import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
@@ -20,6 +20,7 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport

--- a/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
@@ -19,6 +19,7 @@
 //==========================================================================//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
@@ -20,6 +20,7 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
@@ -19,9 +19,12 @@
 //==========================================================================//
 
 import SwiftDiagnostics
+import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/MultiRoleMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MultiRoleMacroTests.swift
@@ -19,6 +19,7 @@
 //==========================================================================//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport

--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -20,8 +20,10 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
@@ -20,8 +20,10 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 @_spi(Testing) import SwiftSyntaxMacroExpansion
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/StringInterpolationErrorTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/StringInterpolationErrorTests.swift
@@ -15,6 +15,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -12,6 +12,7 @@
 
 #if canImport(Testing)
 import Testing
+import SwiftSyntax
 import SwiftSyntaxMacrosTestSupport
 
 @Suite("Swift Testing Macro Expansion Tests")

--- a/Tests/SwiftSyntaxMacrosTestSupportTests/AssertionsTests.swift
+++ b/Tests/SwiftSyntaxMacrosTestSupportTests/AssertionsTests.swift
@@ -13,6 +13,7 @@
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
+++ b/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
@@ -12,6 +12,7 @@
 
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftSyntaxTest/IdentifierTests.swift
+++ b/Tests/SwiftSyntaxTest/IdentifierTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 class IdentifierTests: XCTestCase {

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftBasicFormat
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 class SyntaxTests: XCTestCase {

--- a/Tests/SwiftSyntaxTestSupportTest/IncrementalParseTestUtilsTest.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/IncrementalParseTestUtilsTest.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftParser
 import SwiftSyntax
 import XCTest
 import _SwiftSyntaxTestSupport


### PR DESCRIPTION
Building swift-syntax with the `MemberImportVisibility` upcoming feature enabled currently fails: a number of files use declarations from modules that are only imported transitively — mostly the string-interpolation conformances from `SwiftSyntaxBuilder` and the indentation helpers from `SwiftBasicFormat`.

This PR adds the missing direct imports so that

```
swift build --build-tests -Xswiftc -enable-upcoming-feature -Xswiftc MemberImportVisibility
```

builds cleanly. All changes are plain `import` additions, with two exceptions:

- `SwiftSyntaxMacroExpansion` used `SwiftBasicFormat` without declaring it in `Package.swift` (the module was only available transitively; its `CMakeLists.txt` already links it), so the dependency is now declared.
- The existing `import SwiftBasicFormat` in `MacroExpansion.swift` becomes `internal import` to avoid an "ambiguous implicit access level for import" error once other files in the module import it as `internal`.

No `CMakeLists.txt` changes are needed — all affected modules already link the corresponding libraries.

The full test suite passes with the feature enabled, and `swift format lint` is clean on the touched files. A possible follow-up would be to enable the feature in `Package.swift` so new violations can't creep in.

Fixes #3301
