### PR TITLE
Expand macros on members guarded by an #if

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -905,10 +905,18 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
     return CodeBlockItemListSyntax(newItems)
   }
 
-  override func visit(_ node: MemberBlockSyntax) -> MemberBlockSyntax {
-    let parentDeclGroup = node
-      .parent?
-      .as(DeclSyntax.self)
+  /// Expand the macros in `members`, which are the members of `parentDeclGroup`.
+  ///
+  /// This is used both for the members of a member block and for the members
+  /// guarded by an `#if` inside such a block, so that both are treated the same
+  /// way. `isInsideIfConfig` describes which of the two it is, since macros
+  /// whose expansion is not inserted in place of the member cannot be expanded
+  /// inside an `#if`.
+  private func expandMemberBlockItems(
+    _ members: MemberBlockItemListSyntax,
+    parentDeclGroup: DeclSyntax?,
+    isInsideIfConfig: Bool
+  ) -> [MemberBlockItemSyntax] {
     var newItems: [MemberBlockItemSyntax] = []
 
     func addResult(_ node: MemberBlockItemSyntax) {
@@ -932,10 +940,24 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
       for peer in expandMemberDeclPeers(of: node.decl) {
         addResult(peer)
       }
-      extensions += expandExtensions(of: node.decl)
+
+      // Extensions are added to the top level, outside of any `#if` that
+      // guards the member they were expanded from. Expanding them here would
+      // thus extend a type that might not be compiled at all.
+      if !isInsideIfConfig {
+        extensions += expandExtensions(of: node.decl)
+      }
     }
 
-    for var item in node.members {
+    for var item in members {
+      // Members guarded by an `#if` are expanded inside the clause that
+      // contains them, so that they are treated like any other member.
+      if let ifConfigDecl = item.decl.as(IfConfigDeclSyntax.self) {
+        item.decl = DeclSyntax(expandIfConfigDeclMembers(ifConfigDecl, parentDeclGroup: parentDeclGroup))
+        newItems.append(item)
+        continue
+      }
+
       // Expand member attribute members attached to the declaration context.
       // Note that MemberAttribute macros are _not_ applied to generated members
       if let parentDeclGroup, let decl = item.decl.asProtocol(WithAttributesSyntax.self) {
@@ -961,12 +983,51 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
       addResult(item)
     }
 
-    // Expand any member macros of parent.
-    if let parentDeclGroup {
+    // Expand any member macros of parent. The members they add belong to the
+    // declaration itself, not to any `#if` that happens to be nested in it.
+    if !isInsideIfConfig, let parentDeclGroup {
       for member in expandMembers(of: parentDeclGroup) {
         addResult(member)
       }
     }
+
+    return newItems
+  }
+
+  /// Expand the macros attached to the members of each clause of `node`.
+  ///
+  /// Macros are expanded in every clause, not just the one that is active for
+  /// some particular build configuration: the clause that ends up being
+  /// compiled should have its macros expanded, and which one that is isn't
+  /// known here.
+  private func expandIfConfigDeclMembers(
+    _ node: IfConfigDeclSyntax,
+    parentDeclGroup: DeclSyntax?
+  ) -> IfConfigDeclSyntax {
+    let newClauses = node.clauses.map { clause in
+      guard case .decls(let members) = clause.elements else {
+        return clause
+      }
+      let newMembers = expandMemberBlockItems(
+        members,
+        parentDeclGroup: parentDeclGroup,
+        isInsideIfConfig: true
+      )
+      return clause.with(\.elements, .decls(MemberBlockItemListSyntax(newMembers)))
+    }
+
+    return node.with(\.clauses, IfConfigClauseListSyntax(newClauses))
+  }
+
+  override func visit(_ node: MemberBlockSyntax) -> MemberBlockSyntax {
+    let parentDeclGroup = node
+      .parent?
+      .as(DeclSyntax.self)
+    let newItems = expandMemberBlockItems(
+      node.members,
+      parentDeclGroup: parentDeclGroup,
+      isInsideIfConfig: false
+    )
 
     /// Returns an leading trivia for the member blocks closing brace.
     /// It will add a leading newline, if there is none.

--- a/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
@@ -334,6 +334,28 @@ final class DeclarationMacroTests: XCTestCase {
     )
   }
 
+  func testFreestandingDeclInsideIfConfigDeclInMemberDeclList() {
+    assertMacroExpansion(
+      """
+      struct Foo {
+        #if true
+        #decls("func foo() {}")
+        #endif
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          #if true
+          func foo() {
+          }
+          #endif
+        }
+        """,
+      macros: ["decls": DeclsFromStringsMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
   func testFreestandingDeclThatIncludesDocComment() {
     assertMacroExpansion(
       #"""

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
@@ -66,6 +66,30 @@ final class ExtensionMacroTests: XCTestCase {
     )
   }
 
+  func testNotExpandedInsideIfConfigDecl() {
+    // Extensions are added at the top level, where the `#if` no longer applies,
+    // so expanding the macro here would extend a type that may not be compiled.
+    assertMacroExpansion(
+      """
+      struct Wrapper {
+        #if os(macOS)
+        @AddSendableExtension
+        struct MyType {}
+        #endif
+      }
+      """,
+      expandedSource: """
+        struct Wrapper {
+          #if os(macOS)
+          struct MyType {}
+          #endif
+        }
+        """,
+      macros: ["AddSendableExtension": SendableExtensionMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
   func testNestedInExtensionExpansion() {
     assertMacroExpansion(
       """

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
@@ -101,6 +101,83 @@ final class MemberAttributeMacroTests: XCTestCase {
     )
   }
 
+  func testAttributeWithIfConfigDecl() {
+    assertMacroExpansion(
+      """
+      @wrapAllProperties struct S {
+        #if true
+        var value = 1
+        #endif
+      }
+      """,
+      expandedSource: """
+        struct S {
+          #if true
+          @Wrapper
+          var value = 1
+          #endif
+        }
+        """,
+      macros: ["wrapAllProperties": WrapAllProperties.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testAttributeWithIfConfigDeclElseBranch() {
+    assertMacroExpansion(
+      """
+      @wrapAllProperties struct S {
+        #if os(macOS)
+        var value = 1
+        #else
+        var value = 2
+        func f() {}
+        #endif
+      }
+      """,
+      expandedSource: """
+        struct S {
+          #if os(macOS)
+          @Wrapper
+          var value = 1
+          #else
+          @Wrapper
+          var value = 2
+          func f() {}
+          #endif
+        }
+        """,
+      macros: ["wrapAllProperties": WrapAllProperties.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testAttributeWithNestedIfConfigDecl() {
+    assertMacroExpansion(
+      """
+      @wrapAllProperties struct S {
+        #if true
+        #if true
+        var value = 1
+        #endif
+        #endif
+      }
+      """,
+      expandedSource: """
+        struct S {
+          #if true
+          #if true
+          @Wrapper
+          var value = 1
+          #endif
+          #endif
+        }
+        """,
+      macros: ["wrapAllProperties": WrapAllProperties.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
   func testWrapStoredProperties() {
     struct WrapStoredProperties: MemberAttributeMacro {
       static func expansion(

--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -217,6 +217,40 @@ final class PeerMacroTests: XCTestCase {
     )
   }
 
+  func testPeerMacroOnMemberInsideIfConfigDecl() {
+    struct TestMacro: PeerMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return ["var peer: Int = 0"]
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      struct S {
+        #if true
+        @Test
+        var value = 1
+        #endif
+      }
+      """,
+      expandedSource: """
+        struct S {
+          #if true
+          var value = 1
+
+          var peer: Int = 0
+          #endif
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
   func testAddCompletionHandlerWhereThereIsNotAsync() {
     assertMacroExpansion(
       """


### PR DESCRIPTION
`MacroApplication` expands the members of a declaration in `visit(_: MemberBlockSyntax)`, but the members guarded by an `#if` are not stored in a `MemberBlockSyntax` — they live directly in the `IfConfigClauseSyntax` as a `MemberBlockItemListSyntax`, for which there is no override. Those members are therefore never routed through the member expansion, and macros attached to them are silently dropped.

This affects more than member attribute macros:

```swift
@wrapAllProperties struct S {
  #if true
  var value = 1     // never gets @Wrapper
  #endif
}

struct S {
  #if true
  @AddPeer
  var value = 1     // attribute is removed, peer is never added
  #endif
}
```

Freestanding declaration macros inside such an `#if` are likewise left unexpanded. (Top-level `#if` already works, because there the clause holds a `CodeBlockItemListSyntax`, which does have an override.)

The member handling is extracted from `visit(_: MemberBlockSyntax)` into `expandMemberBlockItems(_:parentDeclGroup:isInsideIfConfig:)`, which is then also applied to the members of every clause of an `#if`, recursively.

Two roles are deliberately not expanded inside an `#if`, because their output does not stay where the member is:

- **Extension macros.** Extensions are hoisted to the top level, where the `#if` no longer applies, so expanding them would emit an extension of a type that may not be compiled at all. They keep being skipped, and there is now a test that pins this down.
- **Member macros of the enclosing declaration.** The members they add belong to the declaration, not to a nested `#if`, so they are still added once, to the outer member block.

Macros are expanded in every clause rather than only in the active one. `MacroApplication` does not resolve `#if` itself and keeps all branches in its output, so restricting expansion to one clause would leave the others looking unexpanded; expanding per clause is also correct whichever branch ends up being compiled, since these macros are applied per member. If you would rather gate this on the `BuildConfiguration` that `assertMacroExpansion` already accepts (as suggested in the issue), I am happy to follow up — that would also let the inactive clauses be left entirely untouched.

Fixes #3106
