### PR TITLE
Preserve lookahead ranges for reused nodes

### DIFF
--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -24,6 +24,12 @@ extension Parser {
 
     let currentOffset = self.lexemes.offsetToStart(self.currentToken)
     if let node = parseLookup!.lookUp(AbsolutePosition(utf8Offset: currentOffset), kind: kind) {
+      if let lookaheadLength = parseLookup!.lookaheadLength(for: node.raw) {
+        lookaheadRanges.registerNodeForIncrementalParse(
+          node: node.raw,
+          lookaheadLength: lookaheadLength
+        )
+      }
       self.lexemes.advance(by: node.totalLength.utf8Length, currentToken: &self.currentToken)
       return node
     }
@@ -148,6 +154,10 @@ struct IncrementalParseLookup {
 
   fileprivate var reusedCallback: ReusedNodeCallback? {
     return transition.reusedNodeCallback
+  }
+
+  fileprivate func lookaheadLength(for node: RawSyntax) -> Int? {
+    transition.previousIncrementalParseResult.lookaheadRanges.lookaheadRanges[node.id]
   }
 
   /// Does a lookup to see if the current source `offset` should be associated

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -1035,6 +1035,9 @@ public struct LookaheadRanges: Sendable {
   public init() {}
 
   mutating func registerNodeForIncrementalParse(node: RawSyntax, lookaheadLength: Int) {
-    self.lookaheadRanges[node.id] = lookaheadLength
+    // Reused nodes may already have a lookahead range from the previous parse.
+    // Keep the larger range so registering the node after advancing the lexer
+    // cannot discard lookahead that was recorded before the node was reused.
+    self.lookaheadRanges[node.id] = max(self.lookaheadRanges[node.id] ?? 0, lookaheadLength)
   }
 }

--- a/Tests/SwiftParserTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftParserTest/IncrementalParsingTests.swift
@@ -40,6 +40,79 @@ class IncrementalParsingTests: ParserTestCase {
     )
   }
 
+  public func testLookaheadRangeDoesNotShrinkWhenNodeIsReused() {
+    func replacing(
+      _ oldText: String,
+      with newText: String,
+      in source: String
+    ) -> (String, SourceEdit) {
+      let range = source.range(of: oldText)!
+      let lowerBound = source.utf8.distance(
+        from: source.utf8.startIndex,
+        to: range.lowerBound.samePosition(in: source.utf8)!
+      )
+      let upperBound = source.utf8.distance(
+        from: source.utf8.startIndex,
+        to: range.upperBound.samePosition(in: source.utf8)!
+      )
+      var editedSource = source
+      editedSource.replaceSubrange(range, with: newText)
+      return (
+        editedSource,
+        SourceEdit(
+          range: AbsolutePosition(utf8Offset: lowerBound)..<AbsolutePosition(utf8Offset: upperBound),
+          replacement: newText
+        )
+      )
+    }
+
+    let originalSource = """
+      foo() {}
+      label: switch x {
+        default: break
+      }
+      bar() {}
+      """
+    let originalResult = Parser.parseIncrementally(source: originalSource, parseTransition: nil)
+
+    // Reuse `foo() {}` while applying an unrelated edit. Its original parse
+    // looked through `label: switch` to rule out a labeled trailing closure.
+    let (intermediateSource, unrelatedEdit) = replacing("bar", with: "baz", in: originalSource)
+    var initiallyReusedNodes: [Syntax] = []
+    let intermediateResult = Parser.parseIncrementally(
+      source: intermediateSource,
+      parseTransition: IncrementalParseTransition(
+        previousIncrementalParseResult: originalResult,
+        edits: ConcurrentEdits(unrelatedEdit),
+        reusedNodeCallback: { initiallyReusedNodes.append($0) }
+      )
+    )
+    XCTAssertTrue(initiallyReusedNodes.contains(where: { $0.trimmedDescription == "foo() {}" }))
+
+    // Changing `switch ...` to a closure makes `label: {}` a labeled trailing
+    // closure of `foo()`. The reused node must therefore be invalidated.
+    let (finalSource, lookaheadEdit) = replacing(
+      "switch x {\n  default: break\n}",
+      with: "{}",
+      in: intermediateSource
+    )
+    let incrementalTree = Parser.parseIncrementally(
+      source: finalSource,
+      parseTransition: IncrementalParseTransition(
+        previousIncrementalParseResult: intermediateResult,
+        edits: ConcurrentEdits(lookaheadEdit)
+      )
+    ).tree
+    let fullyParsedTree = Parser.parse(source: finalSource)
+
+    let subtreeMatcher = SubtreeMatcher(incrementalTree, markers: [:])
+    do {
+      try subtreeMatcher.assertSameStructure(fullyParsedTree, includeTrivia: true)
+    } catch {
+      XCTFail("Matching for a subtree failed with error: \(error)")
+    }
+  }
+
   public func testAddElse() {
     assertIncrementalParse(
       """


### PR DESCRIPTION
## Summary

- Preserve a reused syntax node's previously recorded lookahead range when registering it for the next incremental parse.
- Keep the larger range when a reused node is registered again, so the range cannot be shortened by the post-reuse lexer state.
- Add a regression test covering the multi-step edit sequence from the issue.

Fixes #3397

## Testing

- `swift test --filter testLookaheadRangeDoesNotShrinkWhenNodeIsReused`
- `swift format lint --strict --parallel --recursive Sources/SwiftParser/IncrementalParseTransition.swift Tests/SwiftParserTest/IncrementalParsingTests.swift`
- `git diff --check`
