### PR TITLE
[SwiftLexicalLookup] Make function types into errors in partial type resolution

### DIFF
--- a/Sources/SwiftLexicalLookup/LookupConfig.swift
+++ b/Sources/SwiftLexicalLookup/LookupConfig.swift
@@ -34,6 +34,23 @@ public struct LookupConfig {
   /// returned by lookup would be the `a` declaration from inside function body.
   public var finishInSequentialScope: Bool
   public var configuredRegions: ConfiguredRegions?
+  /// Documentated at internal init
+  internal var _lookupTopScope: Bool = false
+  /// Doesn't return `.lookForGenericParameters` for the extended type
+  /// of an extension.
+  ///
+  /// This flag should likely be removed and become the default behavior.
+  ///
+  /// For instance, if we turn on `_dontFindGenericParametersForExtendedType`:
+  /// ```
+  /// extension A where // <- Looking up `A` here doesn't look for generic parameters
+  ///                   //    of the extended type `A`
+  ///   T == Int // <- Looking up `T` here *will* look for generic parameters of `A`
+  /// { ... }
+  /// ```
+  /// If the flag is off, looking up `A` in `extension A` will also tell us to
+  /// look for generic parameters of `A` (the very syntax we're looking up).
+  internal var _dontFindGenericParametersForExtendedType: Bool = false
 
   /// Creates a new lookup configuration.
   ///
@@ -45,5 +62,26 @@ public struct LookupConfig {
   ) {
     self.finishInSequentialScope = finishInSequentialScope
     self.configuredRegions = configuredRegions
+  }
+
+  /// Creates a new lookup configuration, setting `_lookupTopScope`.
+  ///
+  /// - `finishInSequentialScope` - specifies whether lookup should finish
+  ///   in the closest sequential scope. `false` by default.
+  /// - `_lookupTopScope` - Whether the top-level scope (SourceFileSyntax) introduces name
+  ///   to the lookup (other than what's introduced from guard statements).
+  /// - `_dontFindGenericParametersForExtendedType`: Whether we should avoid
+  ///   returning generic parameters for lookup initiated in an extension's
+  ///   extended-type syntax.
+  @_spi(Experimental) public init(
+    finishInSequentialScope: Bool = false,
+    configuredRegions: ConfiguredRegions? = nil,
+    _lookupTopScope: Bool,
+    _dontFindGenericParametersForExtendedType: Bool
+  ) {
+    self.finishInSequentialScope = finishInSequentialScope
+    self.configuredRegions = configuredRegions
+    self._lookupTopScope = _lookupTopScope
+    self._dontFindGenericParametersForExtendedType = _dontFindGenericParametersForExtendedType
   }
 }

--- a/Sources/SwiftLexicalLookup/QualifiedLookup/DeclGroupLookup.swift
+++ b/Sources/SwiftLexicalLookup/QualifiedLookup/DeclGroupLookup.swift
@@ -132,7 +132,7 @@ private func _visitDirectMembersOfDecl(
   /// Process a member or a member nested inside an if-config declaration.
   ///
   /// This pattern is similar to the SyntaxVisitor pattern, but a SyntaxVisitor
-  /// doesn't work because we use protocols like `NamedDeclSyntax`
+  /// doesn't work because we use custom syntax like `ValueDeclSyntax`
   func processMember(decl: DeclSyntax) {
     // Get only value declarations
     if let valueDecl = decl.as(ValueDeclSyntax.self) {
@@ -177,7 +177,7 @@ private func _visitDirectMembersOfDecl(
   processMember(decl: decl)
 }
 
-extension CodeBlockItemListSyntax {  //: _MemberBlockLike {
+extension CodeBlockItemListSyntax {
   func _visitDirectMembers(
     configuredRegions: ConfiguredRegions?,
     visit: (ValueDeclSyntax) -> Void,

--- a/Sources/SwiftLexicalLookup/QualifiedLookup/DeclGroupLookup.swift
+++ b/Sources/SwiftLexicalLookup/QualifiedLookup/DeclGroupLookup.swift
@@ -180,7 +180,7 @@ private func _visitDirectMembersOfDecl(
 extension CodeBlockItemListSyntax {
   func _visitDirectMembers(
     configuredRegions: ConfiguredRegions?,
-    visit: (ValueDeclSyntax) -> Void,
+    visit: (ValueDeclSyntax) -> Void
   ) {
     for listItem in self {
       guard case .decl(let decl) = listItem.item else { continue }

--- a/Sources/SwiftLexicalLookup/QualifiedLookup/DeclGroupLookup.swift
+++ b/Sources/SwiftLexicalLookup/QualifiedLookup/DeclGroupLookup.swift
@@ -26,8 +26,7 @@ import SwiftSyntax
   }
 
   public static let structure: SwiftSyntax.SyntaxNodeStructure = .choices([
-    .node(StructDeclSyntax.self), .node(EnumDeclSyntax.self), .node(ClassDeclSyntax.self),
-    .node(ActorDeclSyntax.self), .node(ProtocolDeclSyntax.self), .node(ExtensionDeclSyntax.self),
+    .node(NominalTypeDeclSyntax.self), .node(ExtensionDeclSyntax.self),
   ])
 }
 
@@ -51,7 +50,6 @@ import SwiftSyntax
     }
   }
   private mutating func _setGroupProp<T>(
-    // _ visitor: some _DeclGroupVisitor<T>, newValue: T
     _ keyPath: WritableKeyPath<(any DeclGroupSyntax), T>,
     newValue: T
   ) {
@@ -126,7 +124,85 @@ import SwiftSyntax
 
 // MARK: Lookup
 
+private func _visitDirectMembersOfDecl(
+  decl: DeclSyntax,
+  configuredRegions: ConfiguredRegions?,
+  visit: (ValueDeclSyntax) -> Void
+) {
+  /// Process a member or a member nested inside an if-config declaration.
+  ///
+  /// This pattern is similar to the SyntaxVisitor pattern, but a SyntaxVisitor
+  /// doesn't work because we use protocols like `NamedDeclSyntax`
+  func processMember(decl: DeclSyntax) {
+    // Get only value declarations
+    if let valueDecl = decl.as(ValueDeclSyntax.self) {
+      visit(valueDecl)
+    }
+    // Visit variable declarations to get identifier patterns
+    else if let varDecl = decl.as(VariableDeclSyntax.self) {
+      for binding in varDecl.bindings {
+        guard let valueDecl = ValueDeclSyntax(binding.pattern.as(IdentifierPatternSyntax.self)) else { continue }
+        visit(valueDecl)
+      }
+    }
+    // Visit enum cases to get enum elements
+    else if let enumCase = decl.as(EnumCaseDeclSyntax.self) {
+      for enumElement in enumCase.elements {
+        visit(ValueDeclSyntax(enumElement))
+      }
+    }
+    // If configuredRegions is set, visit the members of the active clause (if it exists)
+    //
+    // We do this recursively to handle nested if-config declarations
+    else if let ifConfigDecl = decl.as(IfConfigDeclSyntax.self),
+      let configuredRegions,
+      case .decls(let members) = configuredRegions.activeClause(for: ifConfigDecl)?.elements
+    {
+      for member in members {
+        processMember(decl: member.decl)
+      }
+    }
+    // If configuredRegions is nil, visit all if-config clauses
+    else if let ifConfigDecl = decl.as(IfConfigDeclSyntax.self) {
+      for clause in ifConfigDecl.clauses {
+        guard case .decls(let members) = clause.elements else { return }
+        for member in members {
+          processMember(decl: member.decl)
+        }
+      }
+    }
+  }
+
+  // Find all ValueDeclSyntax members in this declaration
+  processMember(decl: decl)
+}
+
+extension CodeBlockItemListSyntax {  //: _MemberBlockLike {
+  func _visitDirectMembers(
+    configuredRegions: ConfiguredRegions?,
+    visit: (ValueDeclSyntax) -> Void,
+  ) {
+    for listItem in self {
+      guard case .decl(let decl) = listItem.item else { continue }
+      _visitDirectMembersOfDecl(
+        decl: decl,
+        configuredRegions: configuredRegions,
+        visit: visit
+      )
+    }
+  }
+}
+
 extension DeclGroupSyntax {
+  @_spi(_QualifiedLookup) public func visitDirectMembers(
+    configuredRegions: ConfiguredRegions?,
+    visit: (ValueDeclSyntax) -> Void
+  ) {
+    for member in memberBlock.members {
+      _visitDirectMembersOfDecl(decl: member.decl, configuredRegions: configuredRegions, visit: visit)
+    }
+  }
+
   /// Find named member declarations in the given group declaration.
   ///
   /// Results are filtered in the following ways:
@@ -142,66 +218,24 @@ extension DeclGroupSyntax {
     kind memberKind: MemberKind = .default,
     configuredRegions: ConfiguredRegions? = nil
   ) -> [ValueDeclSyntax] {
-    /// Filter the given declaration based on the given ``name`` and ``memberKind``
-    func filterDecl(_ valueDecl: ValueDeclSyntax) -> ValueDeclSyntax? {
-      // If given a name, check for a match
-      if let expectedName = name,
-        case .failure = valueDecl.declName.tryMatch(reference: expectedName.baseName)
-      {
-        return nil
-      }
-      // Filter for the kind
-      guard valueDecl.isKind(memberKind) else { return nil }
+    var valueDecls = [ValueDeclSyntax]()
+    visitDirectMembers(
+      configuredRegions: configuredRegions,
+      visit: { valueDecl in
+        // If given a name, check for a match
+        if let expectedName = name,
+          case .failure = valueDecl.declName.tryMatch(reference: expectedName.baseName)
+        {
+          return
+        }
+        // Filter for the kind
+        guard valueDecl.isKind(memberKind) else { return }
 
-      return valueDecl
-    }
-
-    /// Process a member or a member nested inside an if-config declaration.
-    ///
-    /// This pattern is similar to the SyntaxVisitor pattern, but a SyntaxVisitor
-    /// doesn't work because we use protocols like `NamedDeclSyntax`
-    func processMember(member: MemberBlockItemSyntax) -> [ValueDeclSyntax] {
-      // Get only value declarations
-      if let valueDecl = member.decl.as(ValueDeclSyntax.self) {
-        return if let valueDecl = filterDecl(valueDecl) { [valueDecl] } else { [] }
+        // Add to the results
+        valueDecls.append(valueDecl)
       }
-      // Visit variable declarations to get identifier patterns
-      else if let varDecl = member.decl.as(VariableDeclSyntax.self) {
-        return varDecl.bindings.compactMap({ binding in
-          ValueDeclSyntax(binding.pattern.as(IdentifierPatternSyntax.self)).flatMap(filterDecl(_:))
-        })
-      }
-      // Visit enum cases to get enum elements
-      else if let enumCase = member.decl.as(EnumCaseDeclSyntax.self) {
-        return enumCase.elements.compactMap({ enumElement in
-          filterDecl(ValueDeclSyntax(enumElement))
-        })
-      }
-      // If configuredRegions is set, visit the members of the active clause (if it exists)
-      //
-      // We do this recursively to handle nested if-config declarations
-      else if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self),
-        let configuredRegions,
-        case .decls(let members) = configuredRegions.activeClause(for: ifConfigDecl)?.elements
-      {
-        return members.flatMap(processMember(member:))
-      }
-      // If configuredRegions is nil, visit all if-config clauses
-      else if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
-        return ifConfigDecl.clauses.flatMap({ clause -> [ValueDeclSyntax] in
-          guard case .decls(let members) = clause.elements else { return [] }
-          return members.flatMap(processMember(member:))
-        })
-      }
-      // No name, no gain
-      else {
-        return []
-      }
-    }
-
-    // Add each member in the group declaration
-    return self.memberBlock.members
-      .flatMap(processMember(member:))
+    )
+    return valueDecls
   }
 }
 
@@ -239,5 +273,17 @@ extension DeclGroupSyntax {
   /// readability in debug output.
   @_spi(_QualifiedLookupTests) public var _memberlessDescription: String {
     self.with(\.memberBlock, MemberBlockSyntax(members: [])).trimmedDescription
+  }
+}
+
+extension Attached where Node: DeclGroupSyntax {
+  internal var _memberlessDescription: String {
+    node._memberlessDescription
+  }
+}
+
+extension Attached where Node == DeclGroupSyntaxType {
+  internal init<DeclGroup: DeclGroupSyntax>(_ syntax: Attached<DeclGroup>) {
+    self = syntax.as(DeclGroupSyntaxType.self)!
   }
 }

--- a/Sources/SwiftLexicalLookup/QualifiedLookup/TypeDeclSyntax.swift
+++ b/Sources/SwiftLexicalLookup/QualifiedLookup/TypeDeclSyntax.swift
@@ -71,7 +71,7 @@ extension TypeDeclSyntax {
 // MARK: Upcasts
 
 extension TypeDeclSyntax {
-  public init(_ nominalType: NominalTypeDeclSyntax) {
+  public init(_ nominalType: some NominalTypeDeclSyntaxProtocol) {
     self = Syntax(nominalType).cast(TypeDeclSyntax.self)
   }
 
@@ -85,5 +85,22 @@ extension TypeDeclSyntax {
 
   public init(_ genericParameter: GenericParameterSyntax) {
     self = Syntax(genericParameter).cast(TypeDeclSyntax.self)
+  }
+}
+
+// MARK: Debug Description
+
+extension TypeDeclSyntax {
+  /// Uses the trimmed description of the type decl and removes
+  /// the member block for structs/enums/classes/actors/protocols/extensions,
+  /// similar to `DeclGroupSyntax/_memberlessDescription`.
+  var _memberlessDescription: String {
+    self.as(DeclGroupSyntaxType.self)?._memberlessDescription ?? trimmedDescription
+  }
+}
+
+extension Attached where Node == TypeDeclSyntax {
+  internal var _memberlessDescription: String {
+    node._memberlessDescription
   }
 }

--- a/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/ScopeImplementations.swift
@@ -47,16 +47,26 @@ import SwiftSyntax
     at lookUpPosition: AbsolutePosition,
     with config: LookupConfig
   ) -> [LookupResult] {
-    return statements.flatMap { codeBlockItem in
-      if let guardStmt = codeBlockItem.item.as(GuardStmtSyntax.self) {
-        return guardStmt.lookupFromSequentialParent(
-          identifier,
-          at: lookUpPosition,
-          with: config
-        )
-      } else {
-        return []
+    // Default is not to lookup the top scope
+    if !config._lookupTopScope {
+      return statements.flatMap { codeBlockItem in
+        if let guardStmt = codeBlockItem.item.as(GuardStmtSyntax.self) {
+          return guardStmt.lookupFromSequentialParent(
+            identifier,
+            at: lookUpPosition,
+            with: config
+          )
+        } else {
+          return []
+        }
       }
+    } else {  // if config._lookupTopScope
+      return sequentialLookup(
+        in: statements,
+        identifier,
+        at: lookUpPosition,
+        with: config
+      )
     }
   }
 }
@@ -504,6 +514,18 @@ import SwiftSyntax
 
       return [.lookForGenericParameters(of: self)]
         + defaultLookupImplementation(identifier, at: lookUpPosition, with: config)
+    }
+
+    // TODO: This looks like a bug fix that shouldn't be gated behind a feature flag
+    //
+    // We took care of look ups within the member block & the generic where clause above.
+    // We also handle inheritance clauses where a generic where clause is defined.
+    //
+    // So just check we're not in the inheritance clause (if it exists).
+    if config._dontFindGenericParametersForExtendedType,
+      inheritanceClause?.range.contains(lookUpPosition) != true
+    {
+      return lookupInParent(identifier, at: lookUpPosition, with: config)
     }
 
     return [.lookForGenericParameters(of: self)]
@@ -1073,5 +1095,4 @@ extension SubscriptDeclSyntax: WithGenericParametersScopeSyntax, CanInterleaveRe
   @_spi(Experimental) public var scopeDebugName: String {
     "IfConfigScope"
   }
-
 }

--- a/Sources/SwiftLexicalLookup/TypeLookup/PartialTypeResolution.swift
+++ b/Sources/SwiftLexicalLookup/TypeLookup/PartialTypeResolution.swift
@@ -26,14 +26,21 @@ import SwiftSyntax
 /// ```
 @_spi(_QualifiedLookupTests)
 public enum PartiallyResolvedType {
+  /// `Any`, a suppressed type like `~Escapable`, or a composition thereof.
   case anyType
+  /// A bare type identifier, such as 'A', 'Self', '`Self`', '`Any`',
+  /// 'Module::A', or 'Module::Any'.
   case typeIdentifier(Result<TypeReference, InvalidTypeIdentifierFailure>)
-  case function(argumentCount: Int)
   case tuple(labels: [Identifier?])
   case member(
     base: Attached<TypeSyntax>,
     memberComponent: Result<TypeReference, InvalidTypeIdentifierFailure>
   )
+  /// A composition of type syntax.
+  ///
+  /// Each
+  ///
+  /// E.g. A & B & (Int) -> Void
   case composition([Attached<TypeSyntax>])
 }
 
@@ -68,6 +75,9 @@ public struct TypeReference: Sendable, CustomDebugStringConvertible {
 
 @_spi(_QualifiedLookupTests)
 public enum PartialTypeResolutionFailure: Error {
+  /// Function types aren't interesting for lookup; we defer to SEMA.
+  case functionType
+
   /// Missing types produce errors
   case missingType
 
@@ -125,29 +135,17 @@ extension TypeReference {
 /// Otherwise, returns the appropriate failures.
 private func _parseModuleAndIdentifier(
   moduleNameToken: TokenSyntax?,
-  nameToken: TokenSyntax,
+  name: Identifier?,
   typeSyntax: Attached<TypeSyntax>
 ) -> Result<TypeReference, InvalidTypeIdentifierFailure> {
-  switch (moduleNameToken.map({ Identifier(validating: $0) }), Identifier(validating: nameToken)) {
+  switch (moduleNameToken.map({ Identifier(validating: $0) }), name) {
   // Valid cases are:
   // (a) no module, valid name
   case (nil, let name?):
-    return .success(
-      TypeReference(
-        module: nil,
-        name: name,
-        introducingSyntax: typeSyntax
-      )
-    )
+    return .success(TypeReference(module: nil, name: name, introducingSyntax: typeSyntax))
   // (b) valid module, valid name
   case (let moduleName??, let name?):
-    return .success(
-      TypeReference(
-        module: moduleName,
-        name: name,
-        introducingSyntax: typeSyntax
-      )
-    )
+    return .success(TypeReference(module: moduleName, name: name, introducingSyntax: typeSyntax))
   // Invalid cases
   // (c) invalid name/module
   case (_, nil), (nil?, _):
@@ -169,8 +167,8 @@ extension Attached where Node: TypeSyntaxProtocol {
     // Non-nominal base cases
     //
     // Functions
-    case .functionType(let functionType):
-      return Result.success(PartiallyResolvedType.function(argumentCount: functionType.parameters.count))
+    case .functionType:
+      return Result.failure(PartialTypeResolutionFailure.functionType)
     // Valid tuples (we treat single-element tuples as their only contained type below)
     case .tupleType(let tupleType):
       // Single-element tuples are just the type, e.g., the tuple type syntax
@@ -202,7 +200,7 @@ extension Attached where Node: TypeSyntaxProtocol {
       // According to the docs, `moduleSelector.moduleName` should be an identifier
       // and `name` is an identifier, `Self`, `Any` or `_`. Here's how we handle each:
       let moduleNameToken = identifierType.moduleSelector?.moduleName
-      let nameToken: TokenSyntax
+      let name: Identifier?
       switch (identifierType.moduleSelector, identifierType.name.tokenKind) {
       // === Wildcard `_` ===
       // We can't do anything smart, so we defer to the type checker.
@@ -232,7 +230,7 @@ extension Attached where Node: TypeSyntaxProtocol {
       case (nil, .keyword(.Any)):
         return Result.success(PartiallyResolvedType.anyType)
       case (_?, .keyword(.Any)):
-        nameToken = identifierType.name.with(\.tokenKind, .identifier("Any"))
+        name = Identifier(canonicalName: "Any")
       // === `Self` ===
       // Basically the opposite of `Any`: Whether with or without a module
       // selector, we treat "Self" like the backtick-escaped identifier
@@ -263,15 +261,15 @@ extension Attached where Node: TypeSyntaxProtocol {
       //   struct A { struct B {}; func f(_: MyModule::B) }
       //  fails because `B` is nested within `A`.
       case (_, .keyword(.Self)):
-        nameToken = identifierType.name.with(\.tokenKind, .identifier("Self"))
+        name = Identifier(canonicalName: "Self")
       default:
-        nameToken = identifierType.name
+        name = Identifier(validating: identifierType.name)
       }
 
       // Parse the module name (if provided), and the type name
       let parsedResult = _parseModuleAndIdentifier(
         moduleNameToken: moduleNameToken,
-        nameToken: nameToken,
+        name: name,
         typeSyntax: _castChild(TypeSyntax(identifierType))
       )
       return Result.success(PartiallyResolvedType.typeIdentifier(parsedResult))
@@ -302,20 +300,19 @@ extension Attached where Node: TypeSyntaxProtocol {
       // type lookup fails:
       //   let _: Int.`self` // ❌ error: 'self' is not a member type of struct 'output.A'
       //   let _: Int.self   // ❌ error: (same exact error)
-      // TODO: Handle implicit `.self` lookup. E.g. 'Int.self' vs 'Int.`self`' are different.
       let moduleNameToken = memberType.moduleSelector?.moduleName
-      let nameToken: TokenSyntax
+      let name: Identifier?
       if memberType.name.tokenKind == .keyword(.`self`) {
-        nameToken = memberType.name.with(\.tokenKind, .identifier("self"))
+        name = Identifier(canonicalName: "self")
       } else {
-        nameToken = memberType.name
+        name = Identifier(validating: memberType.name)
       }
 
       // Parse the module name (if provided), and member-type name; then,
       // append to base types
       let parsedResult = _parseModuleAndIdentifier(
         moduleNameToken: moduleNameToken,
-        nameToken: nameToken,
+        name: name,
         typeSyntax: _castChild(TypeSyntax(memberType))
       )
       return Result.success(
@@ -409,6 +406,7 @@ extension InvalidTypeIdentifierFailure: CustomDebugStringConvertible {
 extension PartialTypeResolutionFailure: CustomDebugStringConvertible {
   public var debugDescription: String {
     switch self {
+    case .functionType: return ".functionType"
     case .missingType: return ".missingType"
     case .unknownSuppressedType: return ".unknownSuppressedType"
     case .wildcardType: return ".wildcardType"
@@ -423,8 +421,6 @@ extension PartiallyResolvedType: CustomDebugStringConvertible {
       return ".anyType"
     case .typeIdentifier(let typeIdentifierResult):
       return ".typeIdentifier(\(typeIdentifierResult._debugDescription))"
-    case .function(let argumentCount):
-      return ".function(argumentCount: \(argumentCount))"
     case .tuple(let labels):
       return ".tuple([\(labels.map({ $0?.name ?? "nil" }).joined(separator: ", "))])"
     case .member(let base, let memberComponent):

--- a/Tests/SwiftLexicalLookupTest/InlineAssertions.swift
+++ b/Tests/SwiftLexicalLookupTest/InlineAssertions.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(_QualifiedLookup) @_spi(_QualifiedLookupTests) import SwiftLexicalLookup
 import SwiftParser
 import SwiftSyntax
 import XCTest
@@ -65,7 +66,7 @@ protocol LexicalMatcher {
 ///
 /// All annotations should be placed before the target token.
 ///
-/// Look for examples in `assertDirectLookup` and related assertion methods.
+/// Look for examples in `assertTypeResolution` and related assertion methods.
 struct LexicalLookupSource<Matcher: LexicalMatcher>: ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
   enum Annotation {
     case definition(definition: Matcher.Definition)
@@ -78,9 +79,12 @@ struct LexicalLookupSource<Matcher: LexicalMatcher>: ExpressibleByStringLiteral,
 
   struct Interpolation: StringInterpolationProtocol {
     fileprivate var components: [Component]
+    /// A strong reference to identifier tokens used by `allocateIdentifier`
+    fileprivate var identifierTokens: [TokenSyntax]
 
-    init(literalCapacity: Int, interpolationCount: Int) {
+    init(literalCapacity: Int = 0, interpolationCount: Int = 0) {
       components = []
+      identifierTokens = []
     }
     mutating func appendLiteral(_ literal: String) {
       components.append(.stringFragment(literal))
@@ -98,6 +102,15 @@ struct LexicalLookupSource<Matcher: LexicalMatcher>: ExpressibleByStringLiteral,
       line: UInt = #line
     ) {
       components.append(.annotation(annotation: .expectations(expectations: expectations), file: file, line: line))
+    }
+    /// A correct way to create identifiers from strings. These identifier's lifetime
+    /// is tired to `LexicalLookupSource.Interpolation`, passed onto `LexicalLookupSource`
+    /// and should stay alive for `_assertLexicalLookup`.
+    mutating func allocateIdentifier(string: String) -> Identifier {
+      let token = TokenSyntax.identifier(string)
+      identifierTokens.append(token)
+      // Force unwrap because we're passing an identifier token.
+      return Identifier(token)!
     }
   }
 
@@ -210,7 +223,7 @@ enum LexicalMatcherExpectationFailure<Definition: LexicalAnnotation & Identifiab
 /// to verify lookup results.
 ///
 /// You should wrap this method using a custom `Matcher`
-/// for each use-case. See `assertDirectLookup` as an example.
+/// for each use-case. See `assertTypeResolution` as an example.
 ///
 /// Note: We don't diagnose unused definition annotations.
 func _assertLexicalLookup<Matcher: LexicalMatcher>(
@@ -354,7 +367,7 @@ enum LexicalAssertionUtilities {
       }
 
       XCTFail(
-        "Invalid annotation placement: Token '\(introducerToken.trimmedDescription)' should have a \(Parent.self) parent\(messageQualifier).",
+        "Invalid annotation placement: Token '\(introducerToken.trimmedDescription)' should have a \(Parent.self) parent (not '\(rawParent.kind)')\(messageQualifier).",
         file: file,
         line: line
       )
@@ -373,10 +386,6 @@ enum LexicalAssertionUtilities {
     let expectedMarkers = Set(expected.map(\.annotation.id))
     let actualMarkers = Set(actual.map(\.annotation.id))
 
-    if expected.map(\.annotation.id) != actual.map(\.annotation.id) {
-      print("Comparing \(expected) vs \(actual)")
-    }
-
     // Calculate differences
     let missingDefinitions = expected.filter({ !actualMarkers.contains($0.annotation.id) })
     if !missingDefinitions.isEmpty {
@@ -393,5 +402,61 @@ enum LexicalAssertionUtilities {
     {
       failures.append(.invalidResultOrder(expected: expected, actual: actual))
     }
+  }
+}
+
+// MARK: Attached + String Literal
+
+public protocol ParsableByAttached: SyntaxProtocol {
+  static func fileContents(syntaxString: String) -> String
+}
+
+extension TypeSyntax: ParsableByAttached {
+  public static func fileContents(syntaxString: String) -> String {
+    "typealias = \(syntaxString)"
+  }
+}
+extension TypeDeclSyntax: ParsableByAttached {
+  public static func fileContents(syntaxString: String) -> String {
+    // Type declarations parse as declarations
+    syntaxString
+  }
+}
+extension GenericParameterSyntax: ParsableByAttached {
+  public static func fileContents(syntaxString: String) -> String {
+    // Create a fake function to parse `< ... >` as a GenericParameterClauseSyntax
+    "func <\(syntaxString)>"
+  }
+}
+extension GenericParameterClauseSyntax: ParsableByAttached {
+  public static func fileContents(syntaxString: String) -> String {
+    // Create a fake function to parse the given `<T1, ..., TN>`
+    // as a GenericParameterClauseSyntax
+    "func \(syntaxString)"
+  }
+}
+extension ExtensionDeclSyntax: ParsableByAttached {
+  public static func fileContents(syntaxString: String) -> String { syntaxString }
+}
+extension DeclGroupSyntaxType: ParsableByAttached {
+  public static func fileContents(syntaxString: String) -> String { syntaxString }
+}
+
+// TODO: Merge with Attached.typeSyntax(_)
+extension Attached: ExpressibleByStringLiteral
+    & ExpressibleByExtendedGraphemeClusterLiteral
+    & ExpressibleByUnicodeScalarLiteral
+where
+  Node: ParsableByAttached
+{
+  public init(stringLiteral: String) {
+    // Wrap the type syntax in a file
+    var parser = Parser(Node.fileContents(syntaxString: stringLiteral))
+    let sourceFile = SourceFileSyntax.parse(from: &parser)
+    guard let castSyntax = sourceFile.children(ofType: Node.self).first else {
+      fatalError("Couldn't parse `\(stringLiteral)` as \(Node.self).")
+    }
+    // We should now be able to cast to SourceFileRoot
+    self = Attached(castSyntax)!
   }
 }

--- a/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/NameLookupTests.swift
@@ -790,6 +790,44 @@ final class NameLookupTests: XCTestCase {
     )
   }
 
+  func testTypeDeclAvailabilityInTopLevel() {
+    let declExpectation: [ResultExpectation] = [
+      .fromScope(
+        SourceFileSyntax.self,
+        expectedNames: [
+          NameExpectation.declaration("2️⃣"),
+          NameExpectation.declaration("5️⃣"),
+          NameExpectation.declaration("8️⃣"),
+        ]
+      )
+    ]
+
+    assertLexicalNameLookup(
+      source: """
+        1️⃣a
+        2️⃣class a {}
+        3️⃣a
+        guard let x else { return }
+        4️⃣a
+        5️⃣actor a {}
+        6️⃣a
+        guard let x else { return }
+        7️⃣a
+        8️⃣struct a {}
+        9️⃣a
+        """,
+      references: [
+        "1️⃣": declExpectation,
+        "3️⃣": declExpectation,
+        "4️⃣": declExpectation,
+        "6️⃣": declExpectation,
+        "7️⃣": declExpectation,
+        "9️⃣": declExpectation,
+      ],
+      config: LookupConfig(_lookupTopScope: true, _dontFindGenericParametersForExtendedType: true)
+    )
+  }
+
   func testNonMatchingGuardScopeDoesntPartitionResult() {
     assertLexicalNameLookup(
       source: """

--- a/Tests/SwiftLexicalLookupTest/PartialTypeResolutionTests.swift
+++ b/Tests/SwiftLexicalLookupTest/PartialTypeResolutionTests.swift
@@ -82,6 +82,7 @@ final class PartialTypeResolutionTests: XCTestCase {
       typeSyntax: "Any",
       result: .success(.anyType)
     )
+
     // Suppressed
     assertPartialResolutionResult(
       typeSyntax: "~Copyable",
@@ -107,9 +108,7 @@ final class PartialTypeResolutionTests: XCTestCase {
     // Function
     assertPartialResolutionResult(
       typeSyntax: "(_ a: A, B) -> C",
-      result: .success(
-        .function(argumentCount: 2)
-      )
+      result: .failure(.functionType)
     )
 
     // Missing Type
@@ -166,13 +165,6 @@ final class PartialTypeResolutionTests: XCTestCase {
         .typeIdentifier(.failure(InvalidTypeIdentifierFailure()))
       )
     )
-    // Escaped `Any`
-    assertPartialResolutionResult(
-      typeSyntax: "`Any`",
-      result: .success(
-        .typeIdentifier(.success(TypeReference(name: "Any")))
-      )
-    )
 
     // Members
     assertPartialResolutionResult(
@@ -198,7 +190,7 @@ final class PartialTypeResolutionTests: XCTestCase {
         )
       )
     )
-    // Test 'Self' and '`Self`'
+    // Test 'Self' and '`Self`' members (not special)
     assertPartialResolutionResult(
       typeSyntax: "(() -> Int).Self",
       result: .success(
@@ -219,6 +211,49 @@ final class PartialTypeResolutionTests: XCTestCase {
             TypeReference(name: "Self")
           )
         )
+      )
+    )
+
+    // Keywords that turns into identifiers
+    //
+    // Escaped `Any`
+    assertPartialResolutionResult(
+      typeSyntax: "`Any`",
+      result: .success(
+        .typeIdentifier(.success(TypeReference(name: "Any")))
+      )
+    )
+    // Module+Any keyword -> type identifier
+    assertPartialResolutionResult(
+      typeSyntax: "MyModule::Any",
+      result: .success(.typeIdentifier(.success(TypeReference(module: "MyModule", name: "Any"))))
+    )
+    // Self -> type identifier
+    assertPartialResolutionResult(
+      typeSyntax: "Self",
+      result: .success(.typeIdentifier(.success(TypeReference(name: "Self"))))
+    )
+    assertPartialResolutionResult(
+      typeSyntax: "MyModule::Self",
+      result: .success(.typeIdentifier(.success(TypeReference(module: "MyModule", name: "Self"))))
+    )
+    // .self -> type identifier
+    assertPartialResolutionResult(
+      typeSyntax: "A.`self`",
+      result: .success(
+        .member(base: "A", memberComponent: .success(TypeReference(name: "self")))
+      )
+    )
+    assertPartialResolutionResult(
+      typeSyntax: "A.self",
+      result: .success(
+        .member(base: "A", memberComponent: .success(TypeReference(name: "self")))
+      )
+    )
+    assertPartialResolutionResult(
+      typeSyntax: "A.Module::self",
+      result: .success(
+        .member(base: "A", memberComponent: .success(TypeReference(module: "Module", name: "self")))
       )
     )
   }
@@ -277,8 +312,12 @@ final class PartialTypeResolutionTests: XCTestCase {
 
     // Attributed type
     assertPartialResolutionResult(
+      typeSyntax: "sending (A, B)",
+      result: .success(.tuple(labels: [nil, nil]))
+    )
+    assertPartialResolutionResult(
       typeSyntax: "@escapable @Sendable () -> Int",
-      result: .success(.function(argumentCount: 0))
+      result: .failure(.functionType)
     )
 
     // Opaque/any types


### PR DESCRIPTION
A follow-up to [#3399](https://github.com/swiftlang/swift-syntax/pull/3399) for the qualified name-lookup [GSoC 2026](https://summerofcode.withgoogle.com/programs/2026/projects/eRaEOB44) project. Partial-type-resolution and miscellaneous fixes before landing unqualified-type lookup.

#### Main in Change
* We now treat function types as errors in partial type resolution. Similar to wildcard types, we can’t do any lookup on them.
#### Bug Fixes & Refactoring
* Fixed bug in partial type resolution where we used ephemeral tokens to create identifiers for `Self`, `Any`, and `self`, leading to corrupt data. Added relevant tests.
* Simplified `DeclGroupLookup` with a simpler and more generic visitor mechanism.
* Fixed unqualified-lookup bug where extended-type syntax generates `.lookForMember(<extension>)` results, and added a flag for extending lookup to the top level.
* Added convenience APIs to InlineAssertions + support for storing identifier tokens for testing.


Note: With `DeclGroupLookup` supporting a visitor pattern and the new unqualified lookup at file scope, this PR sets up all the pieces for unqualified type lookup.