### PR TITLE
[SwiftLexicalLookup] Add unqualified type lookup

### DIFF
--- a/Sources/SwiftLexicalLookup/CMakeLists.txt
+++ b/Sources/SwiftLexicalLookup/CMakeLists.txt
@@ -35,6 +35,7 @@ add_swift_syntax_library(SwiftLexicalLookup
   QualifiedLookup/ValueDeclSyntax.swift
 
   TypeLookup/PartialTypeResolution.swift
+  TypeLookup/UnqualifiedTypeLookup.swift
 )
 
 target_link_swift_syntax_libraries(SwiftLexicalLookup PUBLIC

--- a/Sources/SwiftLexicalLookup/TypeLookup/UnqualifiedTypeLookup.swift
+++ b/Sources/SwiftLexicalLookup/TypeLookup/UnqualifiedTypeLookup.swift
@@ -1,0 +1,304 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftIfConfig
+import SwiftSyntax
+
+@_spi(_QualifiedLookupTests)
+public enum GenericUnqualifiedTypeLookupResult<Scope: Sendable> {
+  /// Resolve the given type decl, collecting redeclarations and
+  /// the parent 'with-statements' scope containing these declarations.
+  case nonNestedTypeDecl(
+    decl: Attached<TypeDeclSyntax>,
+    redeclarations: [Attached<TypeDeclSyntax>],
+    parentScope: Scope
+  )
+
+  /// Parameters are guaranteed to be nonempty.
+  case genericParameters(
+    firstMatch: Attached<GenericParameterSyntax>,
+    redeclarations: [Attached<GenericParameterSyntax>],
+    genericClause: Attached<GenericParameterClauseSyntax>
+  )
+
+  /// Search for the given type declaration as a member of `declGroupParent`.
+  /// If `lookForSelf==true`, then we're not looking for the identifier `Self`,
+  /// but for implicit `Self` instead.
+  case lookForMember(declGroupParent: Attached<DeclGroupSyntaxType>, lookForSelf: Bool)
+
+  /// E.g.
+  /// ```swift
+  /// extension Array {
+  ///   func f(_: Element) {} // <- Element refers to a generic parameter
+  /// }
+  /// ```
+  case lookForGenericParameters(extensionDecl: Attached<ExtensionDeclSyntax>)
+  case lookInModule
+}
+
+@_spi(_QualifiedLookupTests)
+public typealias UnqualifiedTypeLookupResult = GenericUnqualifiedTypeLookupResult<Attached<CodeBlockItemListSyntax>>
+
+extension Attached /* <SyntaxNode> */ {
+  @_spi(_QualifiedLookupTests)
+  public func findUnqualifiedType(
+    _ typeName: Identifier,
+    configuredRegions: ConfiguredRegions?
+  ) -> [UnqualifiedTypeLookupResult] {
+    let results: [LookupResult] = node.lookup(
+      typeName,
+      with: LookupConfig(
+        configuredRegions: configuredRegions,
+        _lookupTopScope: true,
+        _dontFindGenericParametersForExtendedType: true
+      )
+    )
+
+    // We force unwrap because unqualified lookup just visits outer
+    // scopes in the file, so we should still have a file root
+    func castChild<S: SyntaxProtocol>(_ syntax: S) -> Attached<S> {
+      Attached<S>(syntax)!
+    }
+
+    let filteredResults = results.compactMap({ result -> UnqualifiedTypeLookupResult? in
+      switch result {
+      case .fromScope(let scope, let names):
+        // Handle generic parameters separately
+        if let genericParameterClause = scope.as(GenericParameterClauseSyntax.self) {
+          // Cast parameters to `GenericParameterSyntax`
+          let parameters = names.map({ name in
+            guard
+              case .identifier(let rawParameter, _) = name,
+              let parameter = rawParameter.as(GenericParameterSyntax.self)
+            else {
+              fatalError(
+                "[SwiftLexicalLookup] Internal error: Got unexpected name '\(name)' from a `GenericParameterClauseSyntax` scope."
+              )
+            }
+            return castChild(parameter)
+          })
+          guard let firstParameter = parameters.first else {
+            fatalError(
+              "[SwiftLexicalLookup] Internal error: Unqualified lookup unexpectedly returned empty names in `.fromScope`."
+            )
+          }
+          return UnqualifiedTypeLookupResult.genericParameters(
+            firstMatch: firstParameter,
+            redeclarations: Array(parameters[1...]),
+            genericClause: castChild(genericParameterClause)
+          )
+        }
+
+        // Note that we skip non-type declarations, even if they have the same name.
+        // For instance:
+        //   struct A {
+        //     func f() {
+        //       let A = 1
+        //       func A() {}
+        //       var hey: A  = self
+        //     }
+        //   }
+        var typeDecls = [Attached<TypeDeclSyntax>]()
+        for name: LookupName in names {
+          switch name {
+          case .implicit(.`Self`(let decl)):
+            // According to the docs, `decl` is either a protocol or extension decl.
+            guard let declGroup = decl.as(DeclGroupSyntaxType.self) else {
+              fatalError(
+                "[SwiftLexicalLookup] Internal error: Expected syntax in .implicit(.Self) to be a declaration group but got \(decl.kind) instead."
+              )
+            }
+            // Only return implicit `Self` if we don't have other matching
+            // declarations (also named `Self`).
+            guard typeDecls.isEmpty else { continue }
+
+            return UnqualifiedTypeLookupResult.lookForMember(
+              declGroupParent: castChild(declGroup),
+              lookForSelf: true
+            )
+          case .declaration(let decl):
+            // Skip non-type declarations
+            //
+            // Note: We handle extensions above
+            guard let typeDecl = TypeDeclSyntax(decl) else { continue }
+
+            typeDecls.append(castChild(typeDecl))
+          case .identifier(let identifierSyntax, accessibleAfter: _):
+            // The only `TypeDeclSyntax` "identifiers" are generic parameters.
+            guard let genericParameter = identifierSyntax.as(GenericParameterSyntax.self) else { continue }
+            typeDecls.append(castChild((TypeDeclSyntax(genericParameter))))
+
+          // `self`, `newValue`, `error`, and `oldValue` can't be type decls.
+          // Also, `equivalentNames` always refers to variable identifiers in
+          // switch cases
+          case .implicit(.`self`), .implicit(.newValue), .implicit(.oldValue),
+            .implicit(.error), .equivalentNames:
+            return nil
+          }
+        }
+
+        // Skip if we couldn't find type declarations
+        guard let firstTypeDecl = typeDecls.first else { return nil }
+        let redeclarations = Array(typeDecls[1...])
+
+        // Return based on scope: either nested (under a decl group) or
+        // non-nested (directly under a CodeBlockItemListSyntax, like a
+        // source file or function body)
+        //
+        // Note: Type decls in a `.fromScope` result should be introduced
+        // by a `WithStatementsSyntax` scope. The only non-`WithStatementsSyntax`
+        // scopes are:
+        // 1. implicit `Self` inside an `AccessorDeclSyntax` or an `ExtensionDeclSyntax`,
+        // 2. `associatedtype`s inside `protocol` declarations
+        // 3. (generic parameters inside a generic-parameter clause -- handled above)
+        // 4. (`guard` statements -- which can't introduce types)
+        //
+        // Rationale: We surface regular type decls introduced in a declaration
+        // group with `.lookForMembers`, since qualified lookup needs to handle
+        // those, e.g.:
+        // ```swift
+        // struct A {
+        //   struct B {
+        //     func f(_: B) {} // <- Look up here
+        //   }
+        // }
+        // ```
+        // We defer to qualified lookup because if we later had
+        // `extension A { typealias B = () }`, we'd need to diagnose the
+        // ambiguity.
+        if let statementScope = scope.asProtocol((any WithStatementsSyntax).self) {
+          return UnqualifiedTypeLookupResult.nonNestedTypeDecl(
+            decl: firstTypeDecl,
+            redeclarations: redeclarations,
+            parentScope: castChild(statementScope.statements)
+          )
+        } else if let protocolParent = scope.as(ProtocolDeclSyntax.self) {
+          // As described above, this happens only for associated types.
+          // We'll find all types, not just the associated types.
+          //
+          // Note `typealias`es of associated types in protocol extensions are peculiar.
+          // They don't participate in lookup; they just act like defaults for associated
+          // types, e.g.:
+          // ```swift
+          // protocol P {
+          //     associatedtype T
+          // }
+          // extension P {
+          //     typealias T = Int
+          //     func f(x: T) {
+          //         let int: Int = x
+          //         // ❌ error: cannot convert value of type 'Self.T' to specified type 'Int'
+          //     }
+          // }
+          // struct A: P { typealias T = () }
+          // // ✅ No redeclaration error
+          //
+          // struct B: P {}
+          // // ✅ `T` inferred as `Int`
+          //
+          // let _: (any P).T = 0
+          // let _: P.T = 0
+          // // ❌ error: cannot access associated type 'T' from 'any P'
+          // ```
+          return UnqualifiedTypeLookupResult.lookForMember(
+            declGroupParent: castChild(DeclGroupSyntaxType(protocolParent)),
+            lookForSelf: false
+          )
+        } else {
+          fatalError(
+            "[SwiftLexicalLookup] Internal error: Expected a `WithStatementsSyntax` or `protocol` scope but got `\(scope.kind)` for names: \(names)"
+          )
+        }
+      case .lookForMembers(let parentSyntax):
+        guard let declGroupParent = DeclGroupSyntaxType(parentSyntax) else {
+          fatalError(
+            "[SwiftLexicalLookup] Internal error; Expected .lookForMembers to have a DeclGroupSyntax but found \(parentSyntax.kind)."
+          )
+        }
+        return UnqualifiedTypeLookupResult.lookForMember(
+          declGroupParent: castChild(declGroupParent),
+          lookForSelf: false
+        )
+      case .lookForGenericParameters(let extensionDecl):
+        return UnqualifiedTypeLookupResult.lookForGenericParameters(extensionDecl: castChild(extensionDecl))
+      // Closure parameters can't be type declarations
+      case .lookForImplicitClosureParameters(_):
+        return nil
+      }
+    })
+    // TODO: Generate `lookInImports` using the file's import declarations
+    return filteredResults + [.lookInModule]
+  }
+}
+
+// MARK: Debug
+
+extension GenericUnqualifiedTypeLookupResult {
+  @_spi(_QualifiedLookupTests)
+  public func _describe(describeScope: (Scope) -> String) -> String {
+    switch self {
+    case .nonNestedTypeDecl(let decl, let redeclarations, let parentScope):
+      let declsDescription = ([decl] + redeclarations).map({ "`\($0._memberlessDescription)`" }).joined(separator: ", ")
+      return
+        ".nonNestedTypeDecl(decls: \(declsDescription), parentScope: '\(describeScope(parentScope))')"
+    case .genericParameters(let firstMatch, let redeclarations, let genericClause):
+      let params = [firstMatch] + redeclarations
+      let paramsDescription = params.map(\.node.name.trimmedDescription).joined(separator: ", ")
+      return
+        ".genericParameters(parameters: \(paramsDescription), genericClause: \(genericClause.trimmedDescription))"
+    case .lookForMember(let declGroupParent, let lookForSelf):
+      return ".lookForMember(declGroupParent: `\(declGroupParent._memberlessDescription)`, lookForSelf: \(lookForSelf))"
+    case .lookForGenericParameters(let extensionDecl):
+      return ".lookForGenericParameters(in: `\(extensionDecl._memberlessDescription)`)"
+    case .lookInModule:
+      return ".lookInModule"
+    }
+  }
+
+  /// Compact form of `debugDescription` for logging
+  private func _describeSuccinctly(lookedUpName: Identifier, describeScope: (Scope) -> String) -> String {
+    switch self {
+    case .nonNestedTypeDecl(let decl, redeclarations: _, let parentScope):
+      return "`\(decl._memberlessDescription)` [in '\(describeScope(parentScope))']"
+    case .genericParameters(let firstMatch, let redeclarations, let genericClause):
+      let params = [firstMatch] + redeclarations
+      let paramsDescription = params.map(\.node.name.trimmedDescription).joined(separator: ", ")
+      return
+        ".genericParameters(parameters: \(paramsDescription), genericClause: \(genericClause.trimmedDescription))"
+    case .lookForMember(let declGroupParent, let lookForSelf):
+      // E.g. 'extension A {}' > 'B'
+      let memberSearchDescription = " > '\(lookedUpName.name)'"
+      return "`\(declGroupParent._memberlessDescription)`\(lookForSelf ? memberSearchDescription : "")"
+    case .lookForGenericParameters(let extensionDecl):
+      return "'\(extensionDecl._memberlessDescription)' > generic parameters"
+    case .lookInModule:
+      return ".lookInModule"
+    }
+  }
+}
+
+@_spi(_QualifiedLookupTests)
+extension UnqualifiedTypeLookupResult: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    _describe(describeScope: { scope in
+      String(reflecting: scope.parent?.parent?.kind)
+    })
+  }
+  func _describeSuccinctly(lookedUpName: Identifier) -> String {
+    _describeSuccinctly(
+      lookedUpName: lookedUpName,
+      describeScope: { scope in
+        String(reflecting: scope.parent?.parent?.kind)
+      }
+    )
+  }
+}

--- a/Tests/SwiftLexicalLookupTest/DirectLookupAssertions.swift
+++ b/Tests/SwiftLexicalLookupTest/DirectLookupAssertions.swift
@@ -34,11 +34,10 @@ struct DirectLookupMatcher {
   let lookupFile: SourceFileSyntax
 }
 
-// MARK: `Reference` Conformances
+// MARK: `Definition` Conformances
 
-// Vacuous conformances (`Reference` is unihabited)
 extension DirectLookupMatcher.Definition: LexicalAnnotation, Identifiable, CustomStringConvertible {
-  typealias SyntaxReference = ValueDeclSyntax  //TypeMemberSyntax<ValueDeclSyntax>
+  typealias SyntaxReference = ValueDeclSyntax
   func findSyntaxFromToken(
     _ token: SwiftSyntax.TokenSyntax,
     verbose: Bool,
@@ -154,7 +153,7 @@ extension DirectLookupMatcher: LexicalMatcher {
 /// ``DeclGroupSyntax/findDirectMembers``. We expect lookup to return the
 /// declarations with the given markers, e.g., the declaration marked '🟥'.
 ///
-/// See ``TestDirectLookup`` for examples.
+/// See ``DirectLookupTests`` for examples.
 func assertDirectLookup(
   _ lookupSource: LexicalLookupSource<DirectLookupMatcher>,
   configuredRegions: ConfiguredRegions? = nil,

--- a/Tests/SwiftLexicalLookupTest/UnqualifiedTypeLookupAssertions.swift
+++ b/Tests/SwiftLexicalLookupTest/UnqualifiedTypeLookupAssertions.swift
@@ -1,0 +1,259 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftIfConfig
+@_spi(_QualifiedLookup) @_spi(_QualifiedLookupTests) @_spi(Experimental) import SwiftLexicalLookup
+import SwiftSyntax
+import XCTest
+
+/// Asserts the annotated `IdentifierTypeSyntax` expectation produces
+/// the expected unqualified-type-lookup results (with the right
+/// `CodeBlockItemListSyntax` scopes).
+struct UnqualifiedTypeLookupMatcher {
+  /// Marks a given 'CodeBlockItemListSyntax' in source.
+  struct Definition {
+    let typeDeclMarker: Character
+  }
+
+  /// Annotates an `IdentifierTypeSyntax` with the expected
+  /// unqualified type lookup results (at that position).
+  struct Expectation {
+    let results: [GenericUnqualifiedTypeLookupResult<Character?>]
+  }
+
+  let lookupFile: SourceFileSyntax
+  let configuredRegions: ConfiguredRegions?
+}
+
+// MARK: `Definition` Conformances
+
+extension UnqualifiedTypeLookupMatcher.Definition: LexicalAnnotation, Identifiable, CustomStringConvertible {
+  typealias SyntaxReference = CodeBlockItemListSyntax
+  func findSyntaxFromToken(
+    _ token: SwiftSyntax.TokenSyntax,
+    verbose: Bool,
+    file: StaticString,
+    line: UInt
+  ) -> CodeBlockItemListSyntax? {
+    // Get the code block, then the statements
+    LexicalAssertionUtilities.findDirectParent(
+      from: token,
+      ofType: CodeBlockSyntax.self,
+      file: file,
+      line: line
+    )?.statements
+  }
+
+  var id: Character {
+    typeDeclMarker
+  }
+
+  var description: String {
+    typeDeclMarker.description
+  }
+}
+
+// MARK: `Expectation` Conformances
+
+extension UnqualifiedTypeLookupMatcher.Expectation: LexicalAnnotation {
+  typealias SyntaxReference = IdentifierTypeSyntax
+
+  func findSyntaxFromToken(
+    _ token: TokenSyntax,
+    verbose: Bool,
+    file: StaticString,
+    line: UInt
+  ) -> IdentifierTypeSyntax? {
+    LexicalAssertionUtilities.findDirectParent(
+      from: token,
+      ofType: IdentifierTypeSyntax.self,
+      file: file,
+      line: line
+    )
+  }
+}
+
+// MARK: `LexicalMatcher` Conformance
+
+extension UnqualifiedTypeLookupMatcher: LexicalMatcher {
+  func describeContextualizedExpectation(_ expectation: ContextualizedAnnotation<Expectation>) -> String {
+    expectation.syntax.trimmedDescription
+  }
+
+  func assertExpectation(
+    expectation: ContextualizedAnnotation<Expectation>,
+    markersToDefinitions: [Character: ContextualizedAnnotation<Definition>],
+    syntaxToDefinitions: [CodeBlockItemListSyntax: ContextualizedAnnotation<Definition>],
+    verbose: Bool
+  ) -> [ExpectationFailure] {
+    var failures = [ExpectationFailure]()
+
+    // File scope is has a `nil` marker
+    let defaultFileName = "MyFile.swift"
+
+    // Map the decls to their definitions
+    //
+    // Force unwrap because the syntax was parsed from a source file, so it
+    // should be 'Attached'.
+    let expectationSyntax = Attached(expectation.syntax)!
+    let typeNameToken = TokenSyntax.identifier(expectation.syntax.trimmedDescription)
+    let actualResults: [String] = expectationSyntax.findUnqualifiedType(
+      Identifier(validating: typeNameToken)!,
+      configuredRegions: configuredRegions
+    )
+    .compactMap({ lookupResult -> String? in
+      let lookupResultDescription: String = lookupResult._describe(describeScope: { scopeSyntax -> String in
+        // A file scope doesn't have a marker; return the file name instead
+        if scopeSyntax.node.parent?.is(SourceFileSyntax.self) == true {
+          return defaultFileName
+        }
+
+        // Get the scope's marker, or report the error
+        guard let definition = syntaxToDefinitions[scopeSyntax.node] else {
+          // Most CodeBlockItemListSyntax are part of an actual `With[Optional]CodeBlockSyntax`
+          // scope; we get the latter for nicer diagnostics.
+          let actualScope = scopeSyntax.node.parent?.parent
+          let scopeDescription: String
+          if let withCodeBlock = actualScope?.asProtocol((any WithCodeBlockSyntax).self) {
+            scopeDescription = withCodeBlock.with(\.body, CodeBlockSyntax(statements: [])).trimmedDescription
+          } else if let withCodeBlock = actualScope?.asProtocol((any WithOptionalCodeBlockSyntax).self) {
+            scopeDescription = withCodeBlock.with(\.body, CodeBlockSyntax(statements: [])).trimmedDescription
+          } else {
+            // Fallback descriptions
+            scopeDescription = actualScope?.trimmedDescription ?? "<no CodeBlockItemListSyntax grandparent>"
+          }
+          failures.append(
+            ExpectationFailure.resultReferencesUnmarkedSyntax(
+              syntaxDescription: "'\(lookupResult)' references `\(scopeDescription)`"
+            )
+          )
+          return ""
+        }
+        return definition.annotation.typeDeclMarker.description
+      })
+      return lookupResultDescription
+    })
+
+    // Map the expectations to definitions
+    let expectedResults: [String] = expectation.annotation.results
+      .compactMap({ result -> String? in
+        result._describe(describeScope: { scopeMarker in
+          // `nil` marker indicates file scope
+          guard let scopeMarker else { return defaultFileName }
+
+          // Report invalid markers
+          if markersToDefinitions[scopeMarker] == nil {
+            failures.append(ExpectationFailure.referencesUndefinedMarker(scopeMarker))
+          }
+          return scopeMarker.description
+        })
+      })
+
+    // If there are undefined markers / syntax nodes (i.e. failures isn't empty),
+    // the comparison will be inaccurate, so give up now.
+    guard failures.isEmpty else { return failures }
+
+    // Diff results
+    if actualResults != expectedResults {
+      let expectedDescription = expectedResults.map({ "    \($0),\n" }).joined(separator: "")
+      let actualDescription = actualResults.map({ "    \($0),\n" }).joined(separator: "")
+      failures.append(
+        .other(
+          failure:
+            "Invalid unqualified type-lookup results. Expected: [\n\(expectedDescription)]\nBut got:  [\n\(actualDescription)]"
+        )
+      )
+    }
+
+    return failures
+  }
+}
+
+// MARK: Assert Function
+
+/// A lookup source is an annotated string parsed as a `SourceFileSyntax`. Using
+/// string interpolation, you can annotate `IdentifierTypeSyntax` nodes with
+/// the expected `GenericUnqualifiedTypeLookupResult<Character?>` results.
+/// These results use `Character?` markers as scopes; these markers should be
+/// attached to `CodeBlockItemListSyntax` scopes.
+///
+/// See ``UnqualifiedTypeLookupTests`` for examples.
+func assertUnqualifiedTypeLookup(
+  _ lookupSource: LexicalLookupSource<UnqualifiedTypeLookupMatcher>,
+  configuredRegions: ConfiguredRegions? = nil,
+  file: StaticString = #file,
+  line: UInt = #line,
+  verbose: Bool = false
+) {
+  _assertLexicalLookup(
+    ["MyFile": lookupSource],
+    matcher: UnqualifiedTypeLookupMatcher(lookupFile: lookupSource.fileSyntax, configuredRegions: configuredRegions),
+    file: file,
+    line: line,
+    verbose: verbose
+  )
+}
+
+extension LexicalLookupSource.Interpolation where Matcher == UnqualifiedTypeLookupMatcher {
+  /// Defines a `CodeBlockItemListSyntax`.
+  mutating func appendInterpolation(
+    _ marker: Character,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    append(definition: UnqualifiedTypeLookupMatcher.Definition(typeDeclMarker: marker), file: file, line: line)
+  }
+
+  /// Adds an expectation to a `DeclGroupSyntax` that the `findDirectMembers`
+  /// with the parameters in `TestLookup` will return the value declarations
+  /// with the given markers.
+  mutating func appendInterpolation(
+    results: [GenericUnqualifiedTypeLookupResult<Character?>],
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    appendInterpolation(
+      expects: [UnqualifiedTypeLookupMatcher.Expectation(results: results)],
+      file: file,
+      line: line
+    )
+  }
+}
+
+// MARK: Convenience Constructors
+
+extension GenericUnqualifiedTypeLookupResult where Scope == Character? {
+  /// Creates a `GenericUnqualifiedTypeLookupResult.nonNestedTypeDecl`
+  /// Parameters:
+  /// - parent: The parent scope's marker, or `nil` for top-level (file scope).
+  static func decls(
+    _ decls: [Attached<TypeDeclSyntax>],
+    inScope parentScope: Character?
+  ) -> GenericUnqualifiedTypeLookupResult<Character?> {
+    GenericUnqualifiedTypeLookupResult.nonNestedTypeDecl(
+      decl: decls[0],
+      redeclarations: Array(decls[1...]),
+      parentScope: parentScope
+    )
+  }
+
+  static func genericParameters(
+    _ params: [Attached<GenericParameterSyntax>],
+    inClause genericClause: Attached<GenericParameterClauseSyntax>
+  ) -> GenericUnqualifiedTypeLookupResult<Character?> {
+    GenericUnqualifiedTypeLookupResult.genericParameters(
+      firstMatch: params[0],
+      redeclarations: Array(params[1...]),
+      genericClause: genericClause
+    )
+  }
+}

--- a/Tests/SwiftLexicalLookupTest/UnqualifiedTypeLookupTests.swift
+++ b/Tests/SwiftLexicalLookupTest/UnqualifiedTypeLookupTests.swift
@@ -1,0 +1,276 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftIfConfig
+@_spi(_QualifiedLookup) @_spi(_QualifiedLookupTests) import SwiftLexicalLookup
+import SwiftSyntax
+import XCTest
+
+final class UnqualifiedTypeLookupTests: XCTestCase {
+  func testTopScopeDecls() {
+    assertUnqualifiedTypeLookup(
+      """
+      struct A {}
+      typealias A
+
+      let _: \(results: [
+        .decls(["struct A {}", "typealias A"], inScope: nil),
+        .lookInModule,
+      ])A
+
+      func f() \("🟩"){
+        struct B {}
+        typealias B
+
+        // A is still accessible from function scope
+        let _: \(results: [
+          .decls(["struct A {}", "typealias A"], inScope: nil),
+          .lookInModule,
+        ])A
+
+        let _: \(results: [
+          .decls(["struct B {}", "typealias B"], inScope: "🟩"),
+          .lookInModule,
+        ])B
+
+        while \("🟪"){
+          // Shadowing
+          struct A {}
+
+          let a: \(results: [
+            .decls(["struct A {}"], inScope: "🟪"),
+            .decls(["struct A {}", "typealias A"], inScope: nil),
+            .lookInModule,
+          ])A
+        }
+      }
+      """
+    )
+  }
+
+  func testTypeMembers() {
+    // Nominals at top and local scope; doubly nested nominals; in extensions;
+    // in doubly nested within extensions
+
+    assertUnqualifiedTypeLookup(
+      """
+      // Test simple member type at top level
+      struct A {
+        let _: \(results: [
+          .lookForMember(declGroupParent: "struct A {}", lookForSelf: false),
+          .lookInModule
+        ])B
+
+        struct B {
+          let _: \(results: [
+            .lookForMember(declGroupParent: "struct B {}", lookForSelf: false),
+            .lookForMember(declGroupParent: "struct A {}", lookForSelf: false),
+            .lookInModule
+          ])B
+        }
+      }
+
+      // Test nested member types in local scopes
+      func f() \("🟩"){
+        struct C {
+          let _: \(results: [
+            .lookForMember(declGroupParent: "struct C {}", lookForSelf: false),
+            .decls(["struct C {}"], inScope: "🟩"),
+            .lookInModule
+          ])C
+
+          func g() {
+            struct D {
+              struct C {
+                let _: \(results: [
+                  .lookForMember(declGroupParent: "struct C {}", lookForSelf: false),
+                  .lookForMember(declGroupParent: "struct D {}", lookForSelf: false),
+                  .lookForMember(declGroupParent: "struct C {}", lookForSelf: false),
+                  .decls(["struct C {}"], inScope: "🟩"),
+                  .lookInModule
+                ])C
+              }
+            }
+          }
+        }
+      }
+
+      // Test nested member types in an extension
+      extension T {
+        struct C {
+          let _: \(results: [
+            .lookForMember(declGroupParent: "struct C {}", lookForSelf: false),
+            .lookForGenericParameters(extensionDecl: "extension T {}"),
+            .lookForMember(declGroupParent: "extension T {}", lookForSelf: false),
+            .lookInModule
+          ])D
+
+          struct D {
+            let _: \(results: [
+              .lookForMember(declGroupParent: "struct D {}", lookForSelf: false),
+              .lookForMember(declGroupParent: "struct C {}", lookForSelf: false),
+              .lookForGenericParameters(extensionDecl: "extension T {}"),
+              .lookForMember(declGroupParent: "extension T {}", lookForSelf: false),
+              .lookInModule
+            ])D
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testGenericParameters() {
+    assertUnqualifiedTypeLookup(
+      """
+      extension MyType {
+        let _: \(results: [
+          .lookForGenericParameters(extensionDecl: "extension MyType {}"),
+          .lookForMember(declGroupParent: "extension MyType {}", lookForSelf: false),
+          .lookInModule,
+        ])A
+
+        struct Nested<A, Random1> {
+          let _: \(results: [
+            .genericParameters(["A"], inClause: "<A, Random1>"),
+            .lookForMember(declGroupParent: "struct Nested<A, Random1> {}", lookForSelf: false),
+            .lookForGenericParameters(extensionDecl: "extension MyType {}"),
+            .lookForMember(declGroupParent: "extension MyType {}", lookForSelf: false),
+            .lookInModule,
+          ])A
+
+          func f<A, B, Random2>() {
+            let _: \(results: [
+              .genericParameters(["A"], inClause: "<A, B, Random2>"),
+              .genericParameters(["A"], inClause: "<A, Random1>"),
+              .lookForMember(declGroupParent: "struct Nested<A, Random1> {}", lookForSelf: false),
+              .lookForGenericParameters(extensionDecl: "extension MyType {}"),
+              .lookForMember(declGroupParent: "extension MyType {}", lookForSelf: false),
+              .lookInModule,
+            ])A
+
+            do { // nested sequential scope
+              let _: \(results: [
+                .genericParameters(["B"], inClause: "<A, B, Random2>"),
+                .lookForMember(declGroupParent: "struct Nested<A, Random1> {}", lookForSelf: false),
+                .lookForGenericParameters(extensionDecl: "extension MyType {}"),
+                .lookForMember(declGroupParent: "extension MyType {}", lookForSelf: false),
+                .lookInModule,
+              ])B
+            }
+          }
+        }
+      }
+      """
+    )
+  }
+  func testNestedProtocol() {
+    assertUnqualifiedTypeLookup(
+      """
+      // Simple case
+      protocol ProtoA {
+        associatedtype A
+        associatedtype B
+
+        func f() -> \(results: [
+          .lookForMember(declGroupParent: "protocol ProtoA {}", lookForSelf: false),
+          .lookInModule,
+        ])A
+      }
+
+      // Protocol inside a struct
+      struct B<B> {
+        typealias B
+        associatedtype B
+
+        // Protocols can only be declared in non generic structs, but
+        // we don't diagnose here
+        protocol B {
+          associatedtype B
+
+          func f() -> \(results: [
+            .lookForMember(declGroupParent: "protocol B {}", lookForSelf: false),
+            .genericParameters(["B"], inClause: "<B>"),
+            .lookForMember(declGroupParent: "struct B<B> {}", lookForSelf: false),
+            .decls(["struct B<B> {}"], inScope: nil),
+            .lookInModule,
+          ])B
+
+        }
+      }
+      """
+    )
+  }
+
+  func testImplicitSelf() {
+    // Protocols, extensions; note limitation (link to issue?)
+
+    // Implicit `Self` only appears in extensions and protocols
+    // https://github.com/swiftlang/swift-syntax/pull/2852#discussion_r1775049671
+    //
+    // Note: In the protocol case, implicit `Self` trumps other `Self` declarations, e.g.:
+    // ```swift
+    // protocol P {
+    //     typealias `Self` = Int
+    //     func f() -> Self
+    // }
+    //
+    // func g(x: some P) -> some P { x.f() } // ✅
+    // ```
+    //
+    // However, extension exhibit a different behavior:
+    // ```swift
+    // struct A {
+    //     typealias `Self` = Int
+    // }
+    // extension A {
+    //     func f() -> `Self` { Int() }
+    // }
+    // ```
+    // The difference with extensions might be explained by the aforementioned
+    // GitHub issue.
+    assertUnqualifiedTypeLookup(
+      """
+      // Protocol
+      protocol P {
+        func f() -> \(results: [
+          // Implicit `Self`
+          .lookForMember(declGroupParent: "protocol P {}", lookForSelf: true),
+          .lookForMember(declGroupParent: "protocol P {}", lookForSelf: false),
+          .lookInModule
+        ])Self
+      }
+
+      // Extension
+      extension A {
+        func f() {
+          let _: \(results: [
+            .lookForMember(declGroupParent: "extension A {}", lookForSelf: true),
+            .lookForGenericParameters(extensionDecl: "extension A {}"),
+            .lookForMember(declGroupParent: "extension A {}", lookForSelf: false),
+            .lookInModule
+          ])Self
+
+          func g() {
+            let _: \(results: [
+              .lookForMember(declGroupParent: "extension A {}", lookForSelf: true),
+              .lookForGenericParameters(extensionDecl: "extension A {}"),
+              .lookForMember(declGroupParent: "extension A {}", lookForSelf: false),
+              .lookInModule
+            ])Self
+          }
+        }
+      }
+      """
+    )
+  }
+}


### PR DESCRIPTION
With the setup from https://github.com/swiftlang/swift-syntax/pull/3401, we can now add unqualified type lookup. Eventually, this will give us type resolution as desired for the qualified name-lookup [GSoC 2026](https://summerofcode.withgoogle.com/programs/2026/projects/eRaEOB44) project.

This new lookup facility calls into standard unqualified lookup and simplifies results down to type declarations and the qualified-lookup requests we may need to issue.