### PR TITLE
[SwiftParser] Accept keyword-named decl references after a module selector in atStartOfExpression

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -21,6 +21,12 @@ extension TokenConsumer {
     if self.isAtModuleSelector() {
       var lookahead = self.lookahead()
       _ = lookahead.consumeModuleSelectorTokensIfPresent()
+      // After a module selector, a lexer-classified keyword is a declaration
+      // reference: 'parseDeclReferenceBase' remaps it to an identifier, so that
+      // e.g. 'Module::as(x)' parses as a function call.
+      if lookahead.currentToken.isLexerClassifiedKeyword {
+        return true
+      }
       return lookahead.atStartOfExpression()
     }
 

--- a/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
+++ b/Tests/SwiftParserTest/translated/ModuleSelectorTests.swift
@@ -2174,6 +2174,38 @@ final class ModuleSelectorTests: ParserTestCase {
     )
   }
 
+  func testModuleSelectorKeywordNameAtStartOfStatement() {
+    // https://github.com/swiftlang/swift-syntax/issues/3387
+    // A module-selected reference to a keyword-named declaration must be
+    // recognized as the start of an expression at statement level, matching
+    // 'parseDeclReferenceBase', which remaps the keyword to an identifier.
+    assertParse(
+      "Module::as(x)",
+      substructure: makeCall(
+        callee: makeDeclRef(moduleSelector: "Module", baseName: "as"),
+        arguments: [nil: ExprSyntax(makeDeclRef(baseName: "x"))]
+      )
+    )
+    assertParse(
+      "Module::is(x)",
+      substructure: makeCall(
+        callee: makeDeclRef(moduleSelector: "Module", baseName: "is"),
+        arguments: [nil: ExprSyntax(makeDeclRef(baseName: "x"))]
+      )
+    )
+    assertParse(
+      """
+      func use(_ x: Int) {
+        Module::as(x)
+      }
+      """,
+      substructure: makeCall(
+        callee: makeDeclRef(moduleSelector: "Module", baseName: "as"),
+        arguments: [nil: ExprSyntax(makeDeclRef(baseName: "x"))]
+      )
+    )
+  }
+
   func testModuleSelectorType() {
     assertParse(
       "func fn(_: Swift::Self) {}",


### PR DESCRIPTION
Fixes #3387.

### Problem

`atStartOfExpression()` consumes a module selector and then recursively tests whether the *following* token can begin an unqualified expression. Lexer-classified keywords such as `as` and `is` fail that check, so valid code the compiler accepts:

```swift
func use(_ x: Int) {
  Module::as(x)
  Module::is(x)
}
```

is parsed at statement level as unexpected code instead of a `FunctionCallExprSyntax`, with a spurious diagnostic.

### Fix

`parseDeclReferenceBase()` already accepts any lexer-classified keyword after a module selector and remaps it to an identifier. This teaches the lookahead the same rule: after consuming the module selector tokens, a lexer-classified keyword counts as the start of an expression. Six lines, no behavior change for code without module selectors.

### Testing

Added `testModuleSelectorKeywordNameAtStartOfStatement` to `ModuleSelectorTests` covering `Module::as(x)` and `Module::is(x)` as bare statements plus the issue's function-body reproducer, asserting the `FunctionCallExprSyntax` substructure with the module-selected `DeclReferenceExprSyntax` callee and no diagnostics.

- Without the fix, all three cases fail (no `FunctionCallExprSyntax`; one diagnostic each) — matching the issue.
- With the fix, the full test suite passes (`SKIP_LONG_TESTS=1`, Swift 6.3 / aarch64 Linux).