### PR TITLE
Add a minimum deployment version query to BuildConfiguration

### DIFF
--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -305,6 +305,28 @@ public protocol BuildConfiguration {
   /// #endif
   /// ```
   var compilerVersion: VersionTuple { get }
+
+  /// The deployment target version for the given target operating system.
+  ///
+  /// - Parameters:
+  ///   - targetOS: The name of the operating system being queried, as used by
+  ///     `os(...)`, such as `macOS`, `iOS`, or `Linux`. The aliases the compiler
+  ///     accepts for `os(...)` are accepted here as well, such as `OSX` for
+  ///     macOS. `anyAppleOS` yields a version only when the deployment target
+  ///     uses the unified version numbering introduced in the 26.0 releases.
+  /// - Returns: The minimum deployment version for the given operating system,
+  ///   if any.
+  ///
+  /// A macro implementation can use this to determine the minimum operating
+  /// system version its expansion will run on, and conditionally emit code that
+  /// uses newer APIs.
+  ///
+  /// The result is `nil` when the version is unknown or does not apply: when
+  /// `targetOS` is not (an alias of) an active target operating system; when the
+  /// target has no meaningful operating system version, as with many Linux or
+  /// bare-metal triples; or when the configuration was produced by a toolchain
+  /// that predates this query.
+  func minimumDeploymentVersion(forTargetOS targetOS: String) throws -> VersionTuple?
 }
 
 /// Default implementation of BuildConfiguration, to avoid a revlock with the
@@ -313,5 +335,14 @@ extension BuildConfiguration {
   @available(*, deprecated, message: "`BuildConfiguration` conformance must implement `isActiveTargetObjectFormat`")
   public func isActiveTargetObjectFormat(name: String) throws -> Bool {
     throw BuildConfigurationError.notImplemented(name: "isActiveTargetObjectFormat")
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "`BuildConfiguration` conformance must implement `minimumDeploymentVersion(forTargetOS:)`"
+  )
+  public func minimumDeploymentVersion(forTargetOS targetOS: String) throws -> VersionTuple? {
+    throw BuildConfigurationError.notImplemented(name: "minimumDeploymentVersion(forTargetOS:)")
   }
 }

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -884,6 +884,10 @@ private struct CanImportSuppressingBuildConfiguration<Other: BuildConfiguration>
     return try other.isActiveTargetObjectFormat(name: name)
   }
 
+  func minimumDeploymentVersion(forTargetOS targetOS: String) throws -> VersionTuple? {
+    return try other.minimumDeploymentVersion(forTargetOS: targetOS)
+  }
+
   var targetPointerBitWidth: Int { return other.targetPointerBitWidth }
 
   var targetAtomicBitWidths: [Int] { return other.targetAtomicBitWidths }

--- a/Sources/SwiftIfConfig/StaticBuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/StaticBuildConfiguration.swift
@@ -39,7 +39,8 @@ public struct StaticBuildConfiguration: Codable {
     targetAtomicBitWidths: [Int] = [],
     endianness: Endianness = .little,
     languageVersion: VersionTuple,
-    compilerVersion: VersionTuple
+    compilerVersion: VersionTuple,
+    deploymentTargetVersions: [String: VersionTuple]? = nil
   ) {
     self.customConditions = customConditions
     self.features = features
@@ -55,6 +56,7 @@ public struct StaticBuildConfiguration: Codable {
     self.endianness = endianness
     self.languageMode = languageVersion
     self.compilerVersion = compilerVersion
+    self.deploymentTargetVersions = deploymentTargetVersions
   }
 
   /// The set of custom conditions that are present and can be used with `#if`.
@@ -229,6 +231,16 @@ public struct StaticBuildConfiguration: Codable {
   /// // Hooray, we can implicitly open existentials!
   /// #endif
   public var compilerVersion: VersionTuple
+
+  /// The minimum deployment version keyed by target operating system name.
+  ///
+  /// Keys are operating system names as used by `os(...)` (e.g., `macOS`,
+  /// `iOS`), including the aliases the compiler accepts for those names. This is
+  /// optional, and is distinct from an empty dictionary: a `nil` value means the
+  /// mapping is unknown (e.g., because the configuration was produced by a
+  /// toolchain that predates this information), whereas an empty dictionary means
+  /// no operating system has a known deployment version.
+  public var deploymentTargetVersions: [String: VersionTuple]?
 }
 
 extension StaticBuildConfiguration: BuildConfiguration {
@@ -416,6 +428,17 @@ extension StaticBuildConfiguration: BuildConfiguration {
   /// - Returns: Whether the target object file format matches the given name.
   public func isActiveTargetObjectFormat(name: String) -> Bool {
     targetObjectFileFormats.contains(name)
+  }
+
+  /// The deployment target version for the given target operating system.
+  ///
+  /// - Parameters:
+  ///   - targetOS: The name of the operating system being queried, as used by
+  ///     `os(...)`, such as `macOS`, `iOS`, or `Linux`.
+  /// - Returns: The minimum deployment version for the given operating system,
+  ///   if any.
+  public func minimumDeploymentVersion(forTargetOS targetOS: String) -> VersionTuple? {
+    deploymentTargetVersions?[targetOS]
   }
 
   /// Equivalent to `languageMode`, but required for conformance to the

--- a/Tests/SwiftIfConfigTest/MinimumDeploymentVersionTests.swift
+++ b/Tests/SwiftIfConfigTest/MinimumDeploymentVersionTests.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2) && canImport(Testing)
+import SwiftIfConfig
+import SwiftSyntax
+import Testing
+
+/// Tests for the deployment-version query on `BuildConfiguration` /
+/// `StaticBuildConfiguration`.
+struct `Minimum OS deployment version tests` {
+  /// A configuration for a macOS build that also targets an iOS variant (as with
+  /// a Mac Catalyst variant).
+  let variantConfig = StaticBuildConfiguration(
+    languageVersion: VersionTuple(6),
+    compilerVersion: VersionTuple(6),
+    deploymentTargetVersions: ["macOS": VersionTuple(14), "OSX": VersionTuple(14), "iOS": VersionTuple(17, 4)]
+  )
+
+  /// A configuration produced by a toolchain that predates this information: the
+  /// version map is `nil` (unknown), distinct from an empty map.
+  let unknownConfig = StaticBuildConfiguration(
+    languageVersion: VersionTuple(6),
+    compilerVersion: VersionTuple(6)
+  )
+
+  @Test(arguments: ["macOS", "OSX"])
+  func `Deployment version resolves for the active OS and its aliases`(name: String) {
+    // The compiler populates the map under every `os(...)` spelling it emits, so
+    // an alias such as `OSX` resolves to the same version as `macOS`.
+    #expect(variantConfig.minimumDeploymentVersion(forTargetOS: name) == VersionTuple(14))
+  }
+
+  @Test
+  func `Deployment version resolves for a target-variant OS`() {
+    #expect(variantConfig.minimumDeploymentVersion(forTargetOS: "iOS") == VersionTuple(17, 4))
+  }
+
+  @Test
+  func `Deployment version is nil for an inactive OS`() {
+    #expect(variantConfig.minimumDeploymentVersion(forTargetOS: "Linux") == nil)
+  }
+
+  @Test
+  func `Deployment version is nil when the mapping is unknown`() {
+    #expect(unknownConfig.deploymentTargetVersions == nil)
+    #expect(unknownConfig.minimumDeploymentVersion(forTargetOS: "macOS") == nil)
+  }
+
+  @Test
+  func `anyAppleOS carries a version only under unified numbering`() {
+    let unified = StaticBuildConfiguration(
+      languageVersion: VersionTuple(6),
+      compilerVersion: VersionTuple(6),
+      deploymentTargetVersions: ["macOS": VersionTuple(26), "anyAppleOS": VersionTuple(26)]
+    )
+    #expect(unified.minimumDeploymentVersion(forTargetOS: "anyAppleOS") == VersionTuple(26))
+
+    // The pre-unification configuration has no `anyAppleOS` entry.
+    #expect(variantConfig.minimumDeploymentVersion(forTargetOS: "anyAppleOS") == nil)
+  }
+}
+#endif

--- a/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
+++ b/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
@@ -112,4 +112,10 @@ struct TestingBuildConfiguration: BuildConfiguration {
   var languageVersion: VersionTuple { VersionTuple(5, 5) }
 
   var compilerVersion: VersionTuple { VersionTuple(5, 9, 1) }
+
+  var deploymentTargetVersions: [String: VersionTuple]? = nil
+
+  func minimumDeploymentVersion(forTargetOS targetOS: String) -> VersionTuple? {
+    deploymentTargetVersions?[targetOS]
+  }
 }


### PR DESCRIPTION
Add `minimumDeploymentVersion(forTargetOS:)` to the `BuildConfiguration` protocol so that macro implementations can query the deployment target version of the module they are expanded into, and conditionally emit code that uses newer APIs. This is especially useful for expression macros, which cannot wrap emitted code in a runtime `if #available(...)` check.

- Add the protocol requirement to `BuildConfiguration` protocol.
- Implement that method on `StaticBuildConfiguration`, backed by a new optional `deploymentTargetVersions` map keyed by `os(...)` name. The map is optional so that a configuration produced by a toolchain that predates this information decodes as `nil` (unknown).
- Add tests for the query behavior.

- [ ] Post an accompanying PR in the 'swift' repo which begins populating this field.