### PR TITLE
[SwiftSyntaxMacroExpansion] Expand attached macros with module-qualified names

### DIFF
--- a/Release Notes/605.md
+++ b/Release Notes/605.md
@@ -2,7 +2,14 @@
 
 ## New APIs
 
+- `MacroSpec` now accepts an optional `moduleName`
+  - Description: `assertMacroExpansion` can specify the module that declared a macro so that `@MyModule.MyMacro`, `@MyModule::MyMacro`, and `#MyModule::MyMacro` only expand when the module names match.
+  - Issue: https://github.com/swiftlang/swift-syntax/issues/2874
+  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/3411
+
 ## API Behavior Changes
+
+- Module-qualified macro expansions now require a matching `MacroSpec.moduleName`. Without a module name, only unqualified uses expand.
 
 ## Deprecations
 

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
@@ -20,10 +20,12 @@ import SwiftSyntaxMacros
 
 /// The information of a macro declaration, to be used with `assertMacroExpansion`.
 ///
-/// In addition to specifying the macro’s type, this allows the specification of conformances that will be passed to the macro’s `expansion` function.
+/// Specifies the macro type and module, plus conformances passed to its `expansion` function.
 public struct MacroSpec: Sendable {
   /// The type of macro.
   let type: Macro.Type
+  /// The module that declared the macro, if specified.
+  let moduleName: String?
   /// The list of types for which the macro needs to add conformances.
   let conformances: [TypeSyntax]
 
@@ -36,14 +38,16 @@ public struct MacroSpec: Sendable {
     }
   }
 
-  /// Creates a new specification from provided macro type
-  /// and optional list of generated conformances.
+  /// Creates a macro specification.
   ///
   /// - Parameters:
   ///   - type: The type of macro.
+  ///   - moduleName: The module that declared the macro. Module-qualified uses must match this name.
+  ///     If `nil`, only unqualified uses expand.
   ///   - conformances: The list of types that will be passed to the macro’s `expansion` function.
-  public init(type: Macro.Type, conformances: [TypeSyntax] = []) {
+  public init(type: Macro.Type, moduleName: String? = nil, conformances: [TypeSyntax] = []) {
     self.type = type
+    self.moduleName = moduleName
     self.conformances = conformances
   }
 }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -512,9 +512,15 @@ struct MacroSystem {
     macros[name] = macroSpec
   }
 
-  /// Look for a macro specification with the given name.
-  func lookup(_ macroName: String) -> MacroSpec? {
-    return macros[macroName]
+  /// Looks up a macro by name, matching the module when specified.
+  func lookup(_ macroName: String, moduleName: String? = nil) -> MacroSpec? {
+    guard let spec = macros[macroName] else {
+      return nil
+    }
+    if let moduleName, spec.moduleName != moduleName {
+      return nil
+    }
+    return spec
   }
 }
 
@@ -1081,15 +1087,30 @@ extension MacroApplication {
 
     return attributedNode.attributes.compactMap {
       guard case let .attribute(attribute) = $0,
-        let attributeName = attribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text
-          ?? attribute.attributeName.as(MemberTypeSyntax.self)?.name.text,
-        let macroSpec = macroSystem.lookup(attributeName)
+        let (attributeName, moduleName) = attachedMacroReference(attribute.attributeName),
+        let macroSpec = macroSystem.lookup(attributeName, moduleName: moduleName)
       else {
         return nil
       }
 
       return (attribute, macroSpec)
     }
+  }
+
+  /// Extracts the macro and module names from `@Name`, `@Module.Name`, or `@Module::Name`.
+  private func attachedMacroReference(_ attributeName: TypeSyntax) -> (name: String, moduleName: String?)? {
+    if let identifierType = attributeName.as(IdentifierTypeSyntax.self) {
+      return (identifierType.name.text, identifierType.moduleSelector?.moduleName.identifier?.name)
+    }
+    if let memberType = attributeName.as(MemberTypeSyntax.self),
+      memberType.moduleSelector == nil,
+      let module = memberType.baseType.as(IdentifierTypeSyntax.self),
+      module.moduleSelector == nil,
+      module.genericArgumentClause == nil
+    {
+      return (memberType.name.text, module.name.identifier?.name)
+    }
+    return nil
   }
 
   /// Get a list of the macro attribute, the macro definition and the conformance
@@ -1375,7 +1396,10 @@ extension MacroApplication {
     expandMacro: (_ macro: any Macro.Type, _ node: any FreestandingMacroExpansionSyntax) throws -> ExpandedMacroType?
   ) -> MacroExpansionResult<ExpandedMacroType> {
     guard let node,
-      let macro = macroSystem.lookup(node.macroName.text)?.type
+      let macro = macroSystem.lookup(
+        node.macroName.text,
+        moduleName: node.moduleSelector?.moduleName.identifier?.name
+      )?.type
     else {
       return .notAMacro
     }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -1081,7 +1081,8 @@ extension MacroApplication {
 
     return attributedNode.attributes.compactMap {
       guard case let .attribute(attribute) = $0,
-        let attributeName = attribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text,
+        let attributeName = attribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+          ?? attribute.attributeName.as(MemberTypeSyntax.self)?.name.text,
         let macroSpec = macroSystem.lookup(attributeName)
       else {
         return nil

--- a/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift
@@ -482,8 +482,8 @@ public func assertDiagnostic(
 ///   - diagnostics: The diagnostics when expanding any macro
 ///   - macroSpecs: The macros that should be expanded, provided as a dictionary
 ///     mapping macro names (e.g., `"CodableMacro"`) to specification with macro type
-///     (e.g., `CodableMacro.self`) and a list of conformances macro provides
-///     (e.g., `["Decodable", "Encodable"]`).
+///     (e.g., `CodableMacro.self`), optional module name, and a list of conformances
+///     the macro provides (e.g., `["Decodable", "Encodable"]`).
 ///   - applyFixIts: If specified, filters the Fix-Its that are applied to generate `fixedSource` to only those whose message occurs in this array. If `nil`, all Fix-Its from the diagnostics are applied.
 ///   - fixedSource: If specified, asserts that the source code after applying Fix-Its matches this string.
 ///   - testModuleName: The name of the test module to use.

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -99,8 +99,8 @@ public func assertMacroExpansion(
 ///   - diagnostics: The diagnostics when expanding any macro
 ///   - macroSpecs: The macros that should be expanded, provided as a dictionary
 ///     mapping macro names (e.g., `"CodableMacro"`) to specification with macro type
-///     (e.g., `CodableMacro.self`) and a list of conformances macro provides
-///     (e.g., `["Decodable", "Encodable"]`).
+///     (e.g., `CodableMacro.self`), optional module name, and a list of conformances
+///     the macro provides (e.g., `["Decodable", "Encodable"]`).
 ///   - applyFixIts: If specified, filters the Fix-Its that are applied to generate `fixedSource` to only those whose message occurs in this array. If `nil`, all Fix-Its from the diagnostics are applied.
 ///   - fixedSource: If specified, asserts that the source code after applying Fix-Its matches this string.
 ///   - testModuleName: The name of the test module to use.

--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -565,4 +565,38 @@ final class AccessorMacroTests: XCTestCase {
       macros: ["TestWrapper": PropertyWrapperMacro.self]
     )
   }
+
+  func testQualifiedAccessorMacroName() {
+    assertMacroExpansion(
+      """
+      @MyModule.constantOne
+      var x: Int
+      """,
+      expandedSource: """
+        var x: Int {
+          get {
+            return 1
+          }
+        }
+        """,
+      macros: ["constantOne": ConstantOneGetter.self],
+      indentationWidth: indentationWidth
+    )
+
+    assertMacroExpansion(
+      """
+      @MyModule::constantOne
+      var x: Int
+      """,
+      expandedSource: """
+        var x: Int {
+          get {
+            return 1
+          }
+        }
+        """,
+      macros: ["constantOne": ConstantOneGetter.self],
+      indentationWidth: indentationWidth
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -567,36 +567,74 @@ final class AccessorMacroTests: XCTestCase {
   }
 
   func testQualifiedAccessorMacroName() {
-    assertMacroExpansion(
-      """
-      @MyModule.constantOne
-      var x: Int
-      """,
-      expandedSource: """
-        var x: Int {
-          get {
-            return 1
-          }
+    let specs = ["constantOne": MacroSpec(type: ConstantOneGetter.self, moduleName: "MyModule")]
+    let expandedSource = """
+      var x: Int {
+        get {
+          return 1
         }
-        """,
-      macros: ["constantOne": ConstantOneGetter.self],
-      indentationWidth: indentationWidth
-    )
+      }
+      """
 
-    assertMacroExpansion(
-      """
-      @MyModule::constantOne
-      var x: Int
-      """,
-      expandedSource: """
-        var x: Int {
-          get {
-            return 1
-          }
-        }
+    for name in [
+      "MyModule.constantOne", "MyModule::constantOne", "constantOne",
+      "`MyModule`.constantOne", "`MyModule`::constantOne",
+    ] {
+      assertMacroExpansion(
+        """
+        @\(name)
+        var x: Int
         """,
-      macros: ["constantOne": ConstantOneGetter.self],
-      indentationWidth: indentationWidth
-    )
+        expandedSource: expandedSource,
+        macroSpecs: specs,
+        indentationWidth: indentationWidth
+      )
+    }
+
+    for name in ["OtherModule.constantOne", "OtherModule::constantOne"] {
+      let source = """
+        @\(name)
+        var x: Int
+        """
+      assertMacroExpansion(
+        source,
+        expandedSource: source,
+        macroSpecs: specs,
+        indentationWidth: indentationWidth
+      )
+    }
+
+    for name in ["MyModule.constantOne", "MyModule::constantOne"] {
+      let source = """
+        @\(name)
+        var x: Int
+        """
+      assertMacroExpansion(
+        source,
+        expandedSource: source,
+        macros: ["constantOne": ConstantOneGetter.self],
+        indentationWidth: indentationWidth
+      )
+    }
+  }
+
+  func testNestedAttributeDoesNotMatchTopLevelMacro() {
+    for name in [
+      "MyModule.Nested.constantOne",
+      "OtherModule::MyModule.constantOne",
+      "Nested.MyModule::constantOne",
+      "MyModule<Int>.constantOne",
+    ] {
+      let source = """
+        @\(name)
+        var x: Int
+        """
+      assertMacroExpansion(
+        source,
+        expandedSource: source,
+        macroSpecs: ["constantOne": MacroSpec(type: ConstantOneGetter.self, moduleName: "MyModule")],
+        indentationWidth: indentationWidth
+      )
+    }
   }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
@@ -333,6 +333,44 @@ final class ExpressionMacroTests: XCTestCase {
     )
   }
 
+  func testQualifiedExpressionMacroName() {
+    let specs = ["stringify": MacroSpec(type: StringifyMacro.self, moduleName: "MyModule")]
+
+    for name in ["MyModule::stringify", "stringify", "`MyModule`::stringify"] {
+      assertMacroExpansion(
+        """
+        let b = #\(name)(x + y)
+        """,
+        expandedSource: """
+          let b = (x + y, "x + y")
+          """,
+        macroSpecs: specs,
+        indentationWidth: indentationWidth
+      )
+    }
+
+    assertMacroExpansion(
+      """
+      let b = #OtherModule::stringify(x + y)
+      """,
+      expandedSource: """
+        let b = #OtherModule::stringify(x + y)
+        """,
+      macroSpecs: specs,
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testQualifiedExpressionMacroWithoutModuleName() {
+    let source = "let b = #MyModule::stringify(x + y)"
+    assertMacroExpansion(
+      source,
+      expandedSource: source,
+      macros: ["stringify": StringifyMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
   func testDetectCircularExpansion() {
     assertMacroExpansion(
       "#nested1",


### PR DESCRIPTION
I was able to reproduce #2874 on main.

Writing an attached macro with its module name, `@MyModule.MyMacro var hello = "world"`, makes `assertMacroExpansion` return the input unchanged, with no diagnostic.

Registering the macro as `"MyMacro"` or `"MyModule.MyMacro"` makes no difference.

`MacroSystem` only accepts attribute names that are a plain identifier (`IdentifierTypeSyntax`). `@MyModule.MyMacro` parses as `MemberTypeSyntax`, so the attribute is dropped before lookup runs.

This PR changes it to accept `MemberTypeSyntax` too and looks up the last name component, so `@MyModule.MyMacro` finds the macro registered as `"MyMacro"`. Same as what `@MyModule::MyMacro` already does, and the dictionary keys stay plain macro names as documented.

I've also added a test for both spellings.

Fixes #2874
rdar://137364509
