### PR TITLE
[Perf][SwiftParser] Resolve a lexeme's keyword once, in the lexer

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -345,8 +345,12 @@ extension Lexer {
     /// for this lexeme.
     let trailingTriviaLexingMode: Lexer.Cursor.TriviaLexingMode?
 
-    /// If `tokenKind` is `.keyword`, the kind of keyword produced, otherwise
-    /// `nil`.
+    /// The keyword that the lexed text spells, or `nil` if it spells none.
+    ///
+    /// Set for a `.keyword`, and for an `.identifier` whose text spells a
+    /// keyword that the lexer leaves for the parser to classify from context.
+    /// Resolved here because `lexIdentifier` has to look the text up anyway to
+    /// find out which of the two it produced.
     let keywordKind: Keyword?
     /// Indicates whether the end of the lexed token text contains a newline.
     let trailingNewlinePresence: Lexer.Cursor.NewlinePresence
@@ -400,6 +404,20 @@ extension Lexer {
         stateTransition: nil,
         trailingTriviaLexingMode: nil,
         keywordKind: kind,
+        trailingNewlinePresence: .absent
+      )
+    }
+
+    /// Produce a lexer result for an identifier whose text spells `keyword`, a
+    /// keyword the lexer leaves for the parser to classify from context.
+    static func identifier(spelling keyword: Keyword?) -> Self {
+      Self(
+        .identifier,
+        flags: [],
+        error: nil,
+        stateTransition: nil,
+        trailingTriviaLexingMode: nil,
+        keywordKind: keyword,
         trailingNewlinePresence: .absent
       )
     }
@@ -504,6 +522,7 @@ extension Lexer.Cursor {
       tokenKind: result.tokenKind,
       flags: flags,
       diagnostic: diagnostic,
+      keyword: result.keywordKind,
       start: leadingTriviaStart.pointer,
       leadingTriviaLength: leadingTriviaStart.distance(to: textStart),
       textLength: textStart.distance(to: trailingTriviaStart),
@@ -511,7 +530,9 @@ extension Lexer.Cursor {
       cursor: cursor
     )
     self.previousTokenKind = result.tokenKind
-    self.previousKeyword = result.keywordKind
+    // `keywordKind` is also set for an identifier that spells a keyword, which
+    // this is not about: see the property's doc comment.
+    self.previousKeyword = result.tokenKind == .keyword ? result.keywordKind : nil
 
     return lexeme
   }
@@ -2069,12 +2090,16 @@ extension Lexer.Cursor {
     self.advance(while: { $0.isValidIdentifierContinuationCodePoint })
 
     let text = tokStart.text(upTo: self)
-    if let keyword = Keyword(text), keyword.isLexerClassified {
+    let keyword = Keyword(text)
+    if let keyword, keyword.isLexerClassified {
       return Lexer.Result.keyword(keyword)
     } else if text == "_" {
       return Lexer.Result(.wildcard)
     } else {
-      return Lexer.Result(.identifier)
+      // A keyword the lexer does not classify is an identifier that the parser
+      // matches against a `TokenSpec` by keyword, so hand the lookup on rather
+      // than have the text looked up a second time.
+      return Lexer.Result.identifier(spelling: keyword)
     }
   }
 

--- a/Sources/SwiftParser/Lexer/Lexeme.swift
+++ b/Sources/SwiftParser/Lexer/Lexeme.swift
@@ -56,6 +56,11 @@ extension Lexer {
     @_spi(Testing)
     public var diagnostic: TokenDiagnostic?
 
+    /// If this lexeme's text is spelled like a keyword, that keyword, otherwise
+    /// `nil`. Resolved once by the lexer so that matching a lexeme against
+    /// several ``TokenSpec`` does not recompute it from the text each time.
+    var keyword: Keyword?
+
     var start: UnsafePointer<UInt8>
 
     var leadingTriviaByteLength: Int
@@ -80,6 +85,7 @@ extension Lexer {
       tokenKind: RawTokenKind,
       flags: Flags,
       diagnostic: TokenDiagnostic?,
+      keyword: Keyword?,
       start: UnsafePointer<UInt8>,
       leadingTriviaLength: Int,
       textLength: Int,
@@ -89,6 +95,7 @@ extension Lexer {
       self.rawTokenKind = tokenKind
       self.flags = flags
       self.diagnostic = diagnostic
+      self.keyword = keyword
       self.start = start
       self.leadingTriviaByteLength = leadingTriviaLength
       self.textByteLength = textLength

--- a/Sources/SwiftParser/TokenSpec.swift
+++ b/Sources/SwiftParser/TokenSpec.swift
@@ -32,12 +32,7 @@ struct PrepareForKeywordMatch {
   @inline(__always)
   init(_ lexeme: Lexer.Lexeme) {
     self.rawTokenKind = lexeme.rawTokenKind
-    switch lexeme.rawTokenKind {
-    case .keyword, .identifier:
-      keyword = Keyword(lexeme.tokenText)
-    default:
-      keyword = nil
-    }
+    self.keyword = lexeme.keyword
     self.isAtStartOfLine = lexeme.isAtStartOfLine
   }
 }
@@ -137,7 +132,7 @@ public struct TokenSpec: Sendable {
   static func ~= (kind: TokenSpec, lexeme: Lexer.Lexeme) -> Bool {
     return kind.matches(
       rawTokenKind: lexeme.rawTokenKind,
-      keyword: Keyword(lexeme.tokenText),
+      keyword: lexeme.keyword,
       atStartOfLine: lexeme.isAtStartOfLine
     )
   }


### PR DESCRIPTION
`TokenSpec` comparisons re-derived a lexeme's keyword from its text on every match, and a parser decision tries one token against many specs.

- Resolve the keyword once in the lexer, where `lexIdentifier` already looks it up and discards it, and store it on the lexeme. The field lands in existing padding — `Lexeme` size is not changed.
- Thread it out of `lexIdentifier` via `Result.identifier(spelling:)` so the text isn't looked up a second time in `nextToken`.
- `previousKeyword` now tests the token kind, since `keywordKind` no longer implies the token was classified as a keyword.

**Parsing is 6.5% faster** on both inputs. Verified against the full corpus, plus a token-level check that kind, keyword and text are unchanged for every token, plus targeted files for each of the eight paths that produce an identifier.
