### PR TITLE
[Perf][SwiftParser] Scan identifier continuation bytes over the buffer

### DIFF
--- a/Sources/SwiftParser/CharacterInfo.swift
+++ b/Sources/SwiftParser/CharacterInfo.swift
@@ -64,41 +64,55 @@ extension Unicode.Scalar {
   }
 }
 
-extension Unicode.Scalar {
-  private func testCharacterInfo(
+extension UInt8 {
+  /// A Boolean value indicating whether this byte is an ASCII character which is
+  /// recommended to be allowed to appear in a non-starting position in a
+  /// programming language identifier.
+  var isAsciiIdentifierContinue: Bool {
+    self.testCharacterInfo(.IDENT_CONT)
+  }
+
+  /// The classification of a byte, which is what a scalar's classification
+  /// reduces to: a scalar outside ASCII belongs to none of these sets, and one
+  /// inside it is this byte.
+  fileprivate func testCharacterInfo(
     _ match: Character.Info
   ) -> Bool {
     let info: Character.Info
-    switch self.value {
-    case  // '0'-'9'
-    48, 49, 50, 51, 52, 53, 54, 55, 56, 57:
+    switch self {
+    case UInt8(ascii: "0")...UInt8(ascii: "9"):
       info = [.IDENT_CONT, .DECIMAL, .HEX]
 
-    case  // 'A'-'F'
-    65, 66, 67, 68, 69, 70,
-      // 'a'-'f'
-      97, 98, 99, 100, 101, 102:
+    case UInt8(ascii: "A")...UInt8(ascii: "F"),
+      UInt8(ascii: "a")...UInt8(ascii: "f"):
       info = [.IDENT_START, .IDENT_CONT, .HEX, .LETTER]
 
-    case  // 'G'-'Z'
-    71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88,
-      89, 90,
-      // 'g'-'z'
-      103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
-      118, 119, 120, 121, 122:
+    case UInt8(ascii: "G")...UInt8(ascii: "Z"),
+      UInt8(ascii: "g")...UInt8(ascii: "z"):
       info = [.IDENT_START, .IDENT_CONT, .LETTER]
 
-    case  // '_'
-    95:
+    case UInt8(ascii: "_"):
       info = [.IDENT_START, .IDENT_CONT]
 
-    case  // '$'
-    36:
+    case UInt8(ascii: "$"):
       info = [.IDENT_CONT]
 
     default:
       info = []
     }
     return info.contains(match)
+  }
+}
+
+extension Unicode.Scalar {
+  private func testCharacterInfo(
+    _ match: Character.Info
+  ) -> Bool {
+    guard self.isASCII else {
+      return false
+    }
+    // `isASCII` has established the range, so the conversion need not check it
+    // again.
+    return UInt8(truncatingIfNeeded: self.value).testCharacterInfo(match)
   }
 }

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -657,12 +657,20 @@ extension Lexer.Cursor.Position {
   }
 
   /// Advance the cursor position by `n` bytes. The offset must be valid.
+  ///
+  /// - Important: `@inline(__always)` because
+  ///   `advanceOverIdentifierContinuationCharacters` calls this once per
+  ///   identifier, where left out of line it costs more than the bytes it moves
+  ///   over.
+  @inline(__always)
   func advanced(by n: Int) -> Self {
     precondition(n > 0)
     precondition(n <= self.input.count)
-    var input = self.input.dropFirst(n - 1)
-    let c = input.removeFirst()
-    return .init(input: UnsafeBufferPointer(rebasing: input), previous: c)
+    let base = self.input.baseAddress!
+    return .init(
+      input: UnsafeBufferPointer(start: base + n, count: self.input.count - n),
+      previous: base[n - 1]
+    )
   }
 }
 
@@ -730,6 +738,34 @@ extension Lexer.Cursor {
   /// Advance the cursor while `predicate` is satisfied.
   mutating func advance(while predicate: (Unicode.Scalar) -> Bool) {
     while self.advance(if: predicate) {}
+  }
+
+  /// Advance the cursor past every character that can continue an identifier.
+  ///
+  /// Roughly half the bytes of a source file pass through here, so the run is
+  /// counted over the buffer and the position moved once at the end of it.
+  /// Taking the bytes one at a time means a bounds check to look at each and,
+  /// to consume it, a second one plus storing `previous` and rebasing the
+  /// buffer, none of which anything needs until the run ends.
+  mutating func advanceOverIdentifierContinuationCharacters() {
+    while true {
+      let bytes = self.input
+      var count = 0
+      while count < bytes.count, bytes[count].isAsciiIdentifierContinue {
+        count += 1
+      }
+      if count > 0 {
+        self.position = self.position.advanced(by: count)
+      }
+
+      // Whatever stopped the run either ends the identifier or begins a scalar
+      // outside ASCII, which has to be decoded to find out which.
+      guard let byte = self.peek(), byte >= 0x80,
+        self.advance(if: { $0.isValidIdentifierContinuationCodePoint })
+      else {
+        return
+      }
+    }
   }
 
   /// Advance the cursor to the end of the current line.
@@ -2066,7 +2102,7 @@ extension Lexer.Cursor {
     precondition(didStart, "Unexpected start")
 
     // Lex [a-zA-Z_$0-9[[:XID_Continue:]]]*
-    self.advance(while: { $0.isValidIdentifierContinuationCodePoint })
+    self.advanceOverIdentifierContinuationCharacters()
 
     let text = tokStart.text(upTo: self)
     if let keyword = Keyword(text), keyword.isLexerClassified {


### PR DESCRIPTION
Roughly half the bytes of a source file are identifier characters, and each one went through `advance(if:)`: a bounds check to peek at it, UTF-8 decoding to a `Unicode.Scalar`, a second bounds check to consume it, then storing `previous` and rebasing the buffer. None of that is needed until the run of identifier characters ends.

- Count the run over the raw buffer, classifying each byte directly, and move the cursor position once when it stops. A byte that stops the run either ends the identifier or begins a scalar outside ASCII, so the loop falls back to decoding a single scalar and resumes.
- Move the classification to `UInt8.isAsciiIdentifierContinue`, backed by a `testCharacterInfo` on `UInt8` that switches over ranges rather than sixty enumerated scalar values. `Unicode.Scalar.testCharacterInfo` delegates to it behind an `isASCII` guard, so the two share one implementation: a scalar outside ASCII belongs to none of the classification sets.
- Build `Position.advanced(by:)`'s buffer from the base address rather than `dropFirst`/`removeFirst`, and mark it `@inline(__always)` — it is called once per identifier, where out of line it costs more than the bytes it moves over.

Parsing a 177 KB source file is 10.3% faster and a 317 KB declaration-heavy one 9.3%, measured against `main` over two independent builds per side and sixteen interleaved rounds. Verified by parsing all 749 Swift files in the repository and comparing tree fingerprints including trivia, error status and round-trip fidelity, plus the 46 trivia and 26 UTF-8 raw-byte cases; `swift test` passes with 10,403 tests and exit code 0.
