### PR TITLE
[Perf][SwiftSyntax] Size a parsing arena's slabs for the source it will hold

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -236,7 +236,15 @@ public struct Parser {
     swiftVersion: SwiftVersion?,
     languageFeatures: LanguageFeatures
   ) {
-    self.arena = arena ?? ParsingRawSyntaxArena(parseTriviaFunction: TriviaParser.parseTrivia)
+    // A full parse allocates in proportion to the source, so the arena can size
+    // its slabs for it. An incremental reparse allocates for what it re-lexes,
+    // which the size of the source says nothing about.
+    self.arena =
+      arena
+      ?? ParsingRawSyntaxArena(
+        parseTriviaFunction: TriviaParser.parseTrivia,
+        sourceByteCount: parseTransition == nil ? input.count : nil
+      )
 
     var input = input
     if parseTransition == nil {

--- a/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
@@ -213,9 +213,43 @@ public class ParsingRawSyntaxArena: RawSyntaxArena {
   }
   private var sourceCopy: SourceCopy?
 
-  public init(parseTriviaFunction: @escaping ParseTriviaFunction) {
+  /// The size of slab to take when nothing is known about what will be
+  /// allocated.
+  private static let defaultSlabSize = 4096
+
+  /// The largest slab to take, so that a large file does not ask the system for
+  /// one enormous block.
+  private static let maximumSlabSize = 4 << 20
+
+  /// The size of slab to take while parsing a source file of `sourceByteCount`
+  /// bytes.
+  ///
+  /// A full parse allocates roughly 26 times the source here, in nodes, text and
+  /// trivia — measured between 19 and 28 times across the parser's own sources
+  /// and the performance test inputs. A slab the size of the source therefore
+  /// fills in about twenty allocations, where the 4 KB a parse starts with
+  /// otherwise takes hundreds of them, doubling only every 128.
+  ///
+  /// Doubled up from the default rather than computed, so that a slab is always a
+  /// power of two, and bounded at both ends: a small file is no worse off than it
+  /// was, and what a large one wastes is bounded by one slab, measured at 4.4% of
+  /// the memory a parse takes. Sizing the slab at twice the source instead saves
+  /// no measurable time and wastes twice as much.
+  private static func slabSize(forSourceOf sourceByteCount: Int) -> Int {
+    var size = Self.defaultSlabSize
+    while size < Self.maximumSlabSize, size < sourceByteCount {
+      size *= 2
+    }
+    return size
+  }
+
+  /// - Parameter sourceByteCount: The size of the source that this arena will
+  ///   hold a full parse of, if that is known, so that the slabs can be sized for
+  ///   it. `nil` for an incremental reparse, where what gets allocated bears no
+  ///   relation to the size of the source, and for any other use.
+  public init(parseTriviaFunction: @escaping ParseTriviaFunction, sourceByteCount: Int? = nil) {
     self.parseTriviaFunction = parseTriviaFunction
-    super.init(slabSize: 4096)
+    super.init(slabSize: sourceByteCount.map(Self.slabSize(forSourceOf:)) ?? Self.defaultSlabSize)
   }
 
   /// Copy the whole source buffer into this arena and return the copy, so the


### PR DESCRIPTION
A parse allocates in 4 KB slabs that double only every 128 of them, so filling the 8.5 MB that parsing a 317 KB file takes asks the system for memory 519 times. A full parse allocates roughly 26 times the source, so the source size is a good estimate of what to ask for up front.

- Add `sourceByteCount:` to `ParsingRawSyntaxArena.init`, defaulting to `nil`, and derive the initial slab size from it by doubling up from 4 KB, bounded at 4 MB. Slabs stay powers of two and a file under 4 KB is unaffected.
- Pass it from `Parser` only for a full parse. An incremental reparse allocates for what it re-lexes, which the source size says nothing about, so it keeps the default.

Slab allocations per parse fall from 412 to 18 on a 177 KB source, 519 to 17 on a 317 KB one, and 15,751 to 5,310 across 400 of the parser's own sources. The cost is the tail of the last slab: waste is bounded by one slab, 4.4% of the memory the declaration-heavy parse takes against 0.8% before. Parsing is about half a percent faster on both performance inputs against `main`.