### PR TITLE
[Perf][SwiftParser] Shrink Lexer.Cursor, and track the lexer and parser layouts

### DIFF
--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -20,6 +20,7 @@ add_swift_syntax_library(SwiftParser
   IsValidIdentifier.swift
   Lookahead.swift
   LoopProgressCondition.swift
+  MemoryLayout.swift
   Modifiers.swift
   Names.swift
   Nominals.swift

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -75,7 +75,7 @@ extension Lexer.Cursor {
 
     /// The lexer is inside a string literal of `kind` after having lexed
     /// `delimiterLength` raw string delimiters.
-    case inStringLiteral(kind: StringLiteralKind, delimiterLength: Int)
+    case inStringLiteral(delimiterLength: Int, kind: StringLiteralKind)
 
     /// The lexer has finished lexing the contents of a string literal and is now
     /// looking for the closing quote.
@@ -96,12 +96,12 @@ extension Lexer.Cursor {
     /// `(` that opens the string interpolation.
     ///
     /// `stringInterpolationStart` points to the first character inside the interpolation.
-    case inStringInterpolation(stringLiteralKind: StringLiteralKind, parenCount: Int)
+    case inStringInterpolation(parenCount: Int, stringLiteralKind: StringLiteralKind)
 
     /// We have encountered a regex literal, and have its tokens to work
     /// through. `lexemes` is a pointer to the lexemes allocated in the state
     /// stack bump pointer allocator.
-    case inRegexLiteral(index: UInt8, lexemes: UnsafePointer<RegexLiteralLexemes>)
+    case inRegexLiteral(lexemes: UnsafePointer<RegexLiteralLexemes>, index: UInt8)
 
     /// The mode in which leading trivia should be lexed for this state or `nil`
     /// if no trivia should be lexed.
@@ -113,7 +113,7 @@ extension Lexer.Cursor {
       case .afterStringLiteral: return nil
       case .afterClosingStringQuote: return nil
       case .inStringInterpolationStart: return nil
-      case .inStringInterpolation(let stringLiteralKind, _):
+      case .inStringInterpolation(_, let stringLiteralKind):
         // Single line strings cannot span multiple lines, so we don't want to
         // consume any newline inside a string interpolation either.
         switch stringLiteralKind {
@@ -147,7 +147,7 @@ extension Lexer.Cursor {
       switch self {
       case .normal, .preferRegexOverBinaryOperator: return false
       case .afterRawStringDelimiter: return false
-      case .inStringLiteral(kind: let stringLiteralKind, delimiterLength: _): return stringLiteralKind != .multiLine
+      case .inStringLiteral(delimiterLength: _, kind: let stringLiteralKind): return stringLiteralKind != .multiLine
       case .afterStringLiteral: return false
       case .afterClosingStringQuote: return false
       case .inStringInterpolationStart: return false
@@ -193,7 +193,7 @@ extension Lexer.Cursor {
       case .pushRegexLexemes(let index, let lexemes):
         perform(
           stateTransition: .push(
-            newState: .inRegexLiteral(index: index, lexemes: lexemes.allocate(in: stateAllocator))
+            newState: .inRegexLiteral(lexemes: lexemes.allocate(in: stateAllocator), index: index)
           ),
           stateAllocator: stateAllocator
         )
@@ -255,8 +255,6 @@ extension Lexer {
     }
     var position: Position
 
-    var languageFeatures: Parser.LanguageFeatures
-
     /// If we have already lexed a token, the kind of the previously lexed token
     var previousTokenKind: RawTokenKind?
 
@@ -269,9 +267,8 @@ extension Lexer {
 
     private var stateStack: StateStack = StateStack()
 
-    init(input: UnsafeBufferPointer<UInt8>, previous: UInt8, languageFeatures: Parser.LanguageFeatures) {
+    init(input: UnsafeBufferPointer<UInt8>, previous: UInt8) {
       self.position = Position(input: input, previous: previous)
-      self.languageFeatures = languageFeatures
     }
 
     /// Returns `true` if this cursor is sufficiently different to `other` in a way that indicates that the lexer has
@@ -445,7 +442,7 @@ extension Lexer.Cursor.Position {
 // MARK: - Entry point
 
 extension Lexer.Cursor {
-  mutating func nextToken(sourceBufferStart: Lexer.Cursor, stateAllocator: BumpPtrAllocator) -> Lexer.Lexeme {
+  mutating func nextToken(sourceBufferStart: UnsafePointer<UInt8>?, stateAllocator: BumpPtrAllocator) -> Lexer.Lexeme {
     let cursor = self
     // Leading trivia.
     let leadingTriviaStart = self
@@ -472,7 +469,7 @@ extension Lexer.Cursor {
       self.stateStack.perform(stateTransition: .pop, stateAllocator: stateAllocator)
     case .afterRawStringDelimiter(let delimiterLength):
       result = lexAfterRawStringDelimiter(delimiterLength: delimiterLength)
-    case .inStringLiteral(kind: let stringLiteralKind, let delimiterLength):
+    case .inStringLiteral(let delimiterLength, let stringLiteralKind):
       result = lexInStringLiteral(stringLiteralKind: stringLiteralKind, delimiterLength: delimiterLength)
     case .afterStringLiteral(kind: let stringLiteralKind, isRawString: _):
       result = lexAfterStringLiteral(stringLiteralKind: stringLiteralKind)
@@ -480,13 +477,13 @@ extension Lexer.Cursor {
       result = lexAfterClosingStringQuote()
     case .inStringInterpolationStart(let stringLiteralKind):
       result = lexInStringInterpolationStart(stringLiteralKind: stringLiteralKind)
-    case .inStringInterpolation(let stringLiteralKind, let parenCount):
+    case .inStringInterpolation(let parenCount, let stringLiteralKind):
       result = lexInStringInterpolation(
         stringLiteralKind: stringLiteralKind,
         parenCount: parenCount,
         sourceBufferStart: sourceBufferStart
       )
-    case .inRegexLiteral(let index, let lexemes):
+    case .inRegexLiteral(let lexemes, let index):
       result = lexInRegexLiteral(lexemes.pointee[index...], existingPtr: lexemes)
     }
 
@@ -572,8 +569,8 @@ extension Lexer.Cursor {
   /// Peeks back `offset` bytes.
   /// `bufferBegin` is the start of the source file buffer to guard that we are
   /// not dereferencing a pointer that points before the source buffer.
-  func peekBack(by offset: Int, bufferBegin: Lexer.Cursor) -> UInt8? {
-    guard let bufferBaseAddress = bufferBegin.input.baseAddress,
+  func peekBack(by offset: Int, bufferBegin: UnsafePointer<UInt8>?) -> UInt8? {
+    guard let bufferBaseAddress = bufferBegin,
       let selfBaseAddress = self.input.baseAddress
     else {
       return nil
@@ -890,11 +887,11 @@ extension Lexer.Cursor {
 // MARK: - Boundness of operators
 
 extension Lexer.Cursor {
-  /// `bufferBegin` is a cursor that points to the start of the source file that
-  /// is being lexed.
-  func isLeftBound(sourceBufferStart: Lexer.Cursor) -> Bool {
+  /// `sourceBufferStart` points to the first byte of the source file that is
+  /// being lexed.
+  func isLeftBound(sourceBufferStart: UnsafePointer<UInt8>?) -> Bool {
     // The first character in the file is not left-bound.
-    if self.input.baseAddress == sourceBufferStart.input.baseAddress {
+    if self.input.baseAddress == sourceBufferStart {
       return false
     }
 
@@ -964,7 +961,7 @@ extension Lexer.Cursor {
 
 extension Lexer.Cursor {
   private mutating func lexNormal(
-    sourceBufferStart: Lexer.Cursor,
+    sourceBufferStart: UnsafePointer<UInt8>?,
     preferRegexOverBinaryOperator: Bool
   ) -> Lexer.Result {
     switch self.peek() {
@@ -1056,7 +1053,7 @@ extension Lexer.Cursor {
   }
 
   private mutating func lexNormalQuestionOrExclamation(
-    sourceBufferStart: Lexer.Cursor,
+    sourceBufferStart: UnsafePointer<UInt8>?,
     preferRegexOverBinaryOperator: Bool
   ) -> Lexer.Result {
     if let result = lexPostfixOptionalChain(sourceBufferStart: sourceBufferStart) {
@@ -1069,7 +1066,7 @@ extension Lexer.Cursor {
   }
 
   private mutating func lexNormalLeftAngle(
-    sourceBufferStart: Lexer.Cursor,
+    sourceBufferStart: UnsafePointer<UInt8>?,
     preferRegexOverBinaryOperator: Bool
   ) -> Lexer.Result {
     if self.is(offset: 1, at: "#"),
@@ -1084,7 +1081,7 @@ extension Lexer.Cursor {
   }
 
   private mutating func lexNormalMiscellaneous(
-    sourceBufferStart: Lexer.Cursor,
+    sourceBufferStart: UnsafePointer<UInt8>?,
     preferRegexOverBinaryOperator: Bool
   ) -> Lexer.Result {
     var tmp = self
@@ -1157,7 +1154,7 @@ extension Lexer.Cursor {
       _ = self.advance()
       return Lexer.Result(
         .leftParen,
-        stateTransition: .replace(newState: .inStringInterpolation(stringLiteralKind: stringLiteralKind, parenCount: 0))
+        stateTransition: .replace(newState: .inStringInterpolation(parenCount: 0, stringLiteralKind: stringLiteralKind))
       )
     case nil:
       return Lexer.Result(.endOfFile)
@@ -1169,7 +1166,7 @@ extension Lexer.Cursor {
   private mutating func lexInStringInterpolation(
     stringLiteralKind: StringLiteralKind,
     parenCount: Int,
-    sourceBufferStart: Lexer.Cursor
+    sourceBufferStart: UnsafePointer<UInt8>?
   ) -> Lexer.Result {
     // Keep track of open parentheses
     switch self.peek() {
@@ -1178,7 +1175,7 @@ extension Lexer.Cursor {
       return Lexer.Result(
         .leftParen,
         stateTransition: .replace(
-          newState: .inStringInterpolation(stringLiteralKind: stringLiteralKind, parenCount: parenCount + 1)
+          newState: .inStringInterpolation(parenCount: parenCount + 1, stringLiteralKind: stringLiteralKind)
         )
       )
     case ")":
@@ -1189,7 +1186,7 @@ extension Lexer.Cursor {
         return Lexer.Result(
           .rightParen,
           stateTransition: .replace(
-            newState: .inStringInterpolation(stringLiteralKind: stringLiteralKind, parenCount: parenCount - 1)
+            newState: .inStringInterpolation(parenCount: parenCount - 1, stringLiteralKind: stringLiteralKind)
           )
         )
       }
@@ -1882,9 +1879,9 @@ extension Lexer.Cursor {
     case .afterStringLiteral(kind: _, isRawString: false):
       return .pop
     case .afterRawStringDelimiter(let delimiterLength):
-      return .replace(newState: .inStringLiteral(kind: kind, delimiterLength: delimiterLength))
+      return .replace(newState: .inStringLiteral(delimiterLength: delimiterLength, kind: kind))
     case .normal, .preferRegexOverBinaryOperator, .inStringInterpolation:
-      return .push(newState: .inStringLiteral(kind: kind, delimiterLength: 0))
+      return .push(newState: .inStringLiteral(delimiterLength: 0, kind: kind))
     case .inRegexLiteral, .inStringLiteral, .afterClosingStringQuote, .inStringInterpolationStart:
       preconditionFailure("Unexpected currentState '\(currentState)' for 'stateTransitionAfterLexingStringQuote'")
     }
@@ -2191,7 +2188,7 @@ extension Lexer.Cursor {
   }
 
   /// Attempt to lex a postfix '!' or '?'.
-  mutating func lexPostfixOptionalChain(sourceBufferStart: Lexer.Cursor) -> Lexer.Result? {
+  mutating func lexPostfixOptionalChain(sourceBufferStart: UnsafePointer<UInt8>?) -> Lexer.Result? {
     // Must be left bound, otherwise this isn't postfix.
     guard self.isLeftBound(sourceBufferStart: sourceBufferStart) else { return nil }
 
@@ -2221,7 +2218,7 @@ extension Lexer.Cursor {
   static func classifyOperatorToken(
     operStart: Lexer.Cursor,
     operEnd: Lexer.Cursor,
-    sourceBufferStart: Lexer.Cursor
+    sourceBufferStart: UnsafePointer<UInt8>?
   ) -> (RawTokenKind, error: LexingDiagnostic?) {
     // Decide between the binary, prefix, and postfix cases.
     // It's binary if either both sides are bound or both sides are not bound.
@@ -2292,7 +2289,7 @@ extension Lexer.Cursor {
   }
 
   mutating func lexOperatorIdentifier(
-    sourceBufferStart: Lexer.Cursor,
+    sourceBufferStart: UnsafePointer<UInt8>?,
     preferRegexOverBinaryOperator: Bool
   ) -> Lexer.Result {
     let tokStart = self
@@ -2390,7 +2387,7 @@ extension Lexer.Cursor {
 // MARK: - Editor Placeholders
 
 extension Lexer.Cursor {
-  mutating func tryLexEditorPlaceholder(sourceBufferStart: Lexer.Cursor) -> Lexer.Result? {
+  mutating func tryLexEditorPlaceholder(sourceBufferStart: UnsafePointer<UInt8>?) -> Lexer.Result? {
     precondition(self.is(at: "<") && self.is(offset: 1, at: "#"))
     let start = self
     var ptr = self
@@ -2557,7 +2554,7 @@ extension Lexer.Cursor {
       return false
     }
 
-    guard let end = Self.findConflictEnd(start, markerKind: kind, languageFeatures: languageFeatures) else {
+    guard let end = Self.findConflictEnd(start, markerKind: kind) else {
       // No end of conflict marker found.
       return false
     }
@@ -2575,16 +2572,14 @@ extension Lexer.Cursor {
   /// Find the end of a version control conflict marker.
   static func findConflictEnd(
     _ curPtr: Lexer.Cursor,
-    markerKind: ConflictMarker,
-    languageFeatures: Parser.LanguageFeatures
+    markerKind: ConflictMarker
   ) -> Lexer.Cursor? {
     // Get a reference to the rest of the buffer minus the length of the start
     // of the conflict marker.
     let advanced = curPtr.input.baseAddress?.advanced(by: markerKind.introducer.count)
     var restOfBuffer = Lexer.Cursor(
       input: .init(start: advanced, count: curPtr.input.count - markerKind.introducer.count),
-      previous: curPtr.input[markerKind.introducer.count - 1],
-      languageFeatures: languageFeatures
+      previous: curPtr.input[markerKind.introducer.count - 1]
     )
     let terminator = markerKind.terminator
     let terminatorStart = terminator.first!
@@ -2605,8 +2600,7 @@ extension Lexer.Cursor {
       let advanced = restOfBuffer.input.baseAddress?.advanced(by: terminator.count)
       return Lexer.Cursor(
         input: .init(start: advanced, count: restOfBuffer.input.count - terminator.count),
-        previous: restOfBuffer.input[terminator.count - 1],
-        languageFeatures: languageFeatures
+        previous: restOfBuffer.input[terminator.count - 1]
       )
     }
     return nil

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -21,7 +21,7 @@ extension Lexer {
   /// that points into an input buffer.
   @_spi(Testing)
   public struct LexemeSequence: IteratorProtocol, Sequence, CustomDebugStringConvertible {
-    fileprivate let sourceBufferStart: Lexer.Cursor
+    fileprivate let sourceBufferStart: UnsafePointer<UInt8>?
     fileprivate var cursor: Lexer.Cursor
     fileprivate var nextToken: Lexer.Lexeme
     /// If the lexer has more than one state on its state stack, it will
@@ -49,7 +49,7 @@ extension Lexer {
     let lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>
 
     fileprivate init(
-      sourceBufferStart: Lexer.Cursor,
+      sourceBufferStart: UnsafePointer<UInt8>?,
       cursor: Lexer.Cursor,
       lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>
     ) {
@@ -85,7 +85,7 @@ extension Lexer {
 
     /// Get the offset of the leading trivia start of `token` relative to `sourceBufferStart`.
     func offsetToStart(_ token: Lexer.Lexeme) -> Int {
-      return self.sourceBufferStart.distance(to: token.cursor)
+      return self.sourceBufferStart!.distance(to: token.cursor.pointer)
     }
 
     /// Advance the the cursor by `offset` and reset `currentToken`
@@ -152,19 +152,16 @@ extension Lexer {
   public static func tokenize(
     _ input: UnsafeBufferPointer<UInt8>,
     from startIndex: Int = 0,
-    lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>,
-    languageFeatures: Parser.LanguageFeatures
+    lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>
   ) -> LexemeSequence {
     precondition(input.isEmpty || startIndex < input.endIndex)
     let startChar = startIndex == input.startIndex ? UInt8(ascii: "\0") : input[startIndex - 1]
-    let start = Cursor(input: input, previous: UInt8(ascii: "\0"), languageFeatures: languageFeatures)
     let cursor = Cursor(
       input: UnsafeBufferPointer(rebasing: input[startIndex...]),
-      previous: startChar,
-      languageFeatures: languageFeatures
+      previous: startChar
     )
     return LexemeSequence(
-      sourceBufferStart: start,
+      sourceBufferStart: input.baseAddress,
       cursor: cursor,
       lookaheadTracker: lookaheadTracker
     )

--- a/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
+++ b/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
@@ -684,7 +684,7 @@ extension Lexer.Cursor {
   fileprivate func tryScanOperatorAsRegexLiteral(
     operatorStart: Lexer.Cursor,
     operatorEnd: Lexer.Cursor,
-    sourceBufferStart: Lexer.Cursor,
+    sourceBufferStart: UnsafePointer<UInt8>?,
     preferRegexOverBinaryOperator: Bool
   ) -> RegexLiteralLexemes? {
     precondition(self.pointer >= operatorStart.pointer, "lexing before the operator?")
@@ -766,7 +766,7 @@ extension Lexer.Cursor {
     at regexStart: Lexer.Cursor,
     operatorStart: Lexer.Cursor,
     operatorEnd: Lexer.Cursor,
-    sourceBufferStart: Lexer.Cursor,
+    sourceBufferStart: UnsafePointer<UInt8>?,
     preferRegexOverBinaryOperator: Bool
   ) -> Lexer.Result? {
     guard
@@ -819,7 +819,7 @@ extension Lexer.Cursor {
     // Compute the new transition.
     let transition: Lexer.StateTransition?
     if let existingPtr {
-      transition = lexemes.isEmpty ? .pop : .replace(newState: .inRegexLiteral(index: index, lexemes: existingPtr))
+      transition = lexemes.isEmpty ? .pop : .replace(newState: .inRegexLiteral(lexemes: existingPtr, index: index))
     } else {
       transition = lexemes.isEmpty ? nil : .pushRegexLexemes(index: index, lexemes: lexemes.base)
     }

--- a/Sources/SwiftParser/MemoryLayout.swift
+++ b/Sources/SwiftParser/MemoryLayout.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+@_spi(Testing) public import SwiftSyntax
+#else
+@_spi(Testing) import SwiftSyntax
+#endif
+
+/// The memory layout of `T`, as a ``SyntaxMemoryLayout/Value``.
+///
+/// `SyntaxMemoryLayout.Value` has an initializer that takes a type, but it is
+/// internal to `SwiftSyntax`.
+func layout<T>(_: T.Type) -> SyntaxMemoryLayout.Value {
+  return SyntaxMemoryLayout.Value(
+    size: MemoryLayout<T>.size,
+    stride: MemoryLayout<T>.stride,
+    alignment: MemoryLayout<T>.alignment
+  )
+}
+
+// See `MemoryLayoutTest.swift`.
+@_spi(Testing) public enum ParserMemoryLayout: Sendable {
+  public static var values: [String: SyntaxMemoryLayout.Value] {
+    let uniq: (SyntaxMemoryLayout.Value, SyntaxMemoryLayout.Value) -> SyntaxMemoryLayout.Value = { _, _ in
+      preconditionFailure()
+    }
+
+    var result: [String: SyntaxMemoryLayout.Value] = [:]
+    result.merge(LexerMemoryLayouts, uniquingKeysWith: uniq)
+    result.merge(ParserMemoryLayouts, uniquingKeysWith: uniq)
+    return result
+  }
+
+  /// Whether a value of the type is copied without any extra work, i.e. whether
+  /// it holds nothing that has to be retained or released.
+  ///
+  /// A ``Parser/Lookahead`` is made by copying the parser's lexeme sequence, so
+  /// these staying trivial is what keeps starting and discarding a lookahead
+  /// down to a move.
+  public static var trivialTypes: [String: Bool] {
+    return [
+      "Lexer.Cursor": _isPOD(Lexer.Cursor.self),
+      "Lexer.Lexeme": _isPOD(Lexer.Lexeme.self),
+      "Lexer.LexemeSequence": _isPOD(Lexer.LexemeSequence.self),
+      "Parser.Lookahead": _isPOD(Parser.Lookahead.self),
+    ]
+  }
+}
+
+/// The lexer types. See `ParserMemoryLayout`.
+///
+/// These live here rather than beside the types they measure, because unlike
+/// their counterparts in `SwiftSyntax` none of them is file private, so keeping
+/// them here saves their files from importing the `Testing` SPI.
+let LexerMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
+  "Lexer.Cursor": layout(Lexer.Cursor.self),
+  "Lexer.Cursor.Position": layout(Lexer.Cursor.Position.self),
+  "Lexer.Cursor.State": layout(Lexer.Cursor.State.self),
+  "Lexer.Cursor.StateStack": layout(Lexer.Cursor.StateStack.self),
+  "Lexer.Lexeme": layout(Lexer.Lexeme.self),
+  "Lexer.LexemeSequence": layout(Lexer.LexemeSequence.self),
+]
+
+/// The parser types. See `ParserMemoryLayout`.
+let ParserMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
+  "Parser.Lookahead": layout(Parser.Lookahead.self),
+  "TokenSpec": layout(TokenSpec.self),
+]

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -274,8 +274,7 @@ public struct Parser {
 
     self.lexemes = Lexer.tokenize(
       input,
-      lookaheadTracker: lookaheadTrackerOwner.lookaheadTracker,
-      languageFeatures: languageFeatures
+      lookaheadTracker: lookaheadTrackerOwner.lookaheadTracker
     )
     self.currentToken = self.lexemes.advance()
     if let parseTransition {

--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -94,11 +94,11 @@ extension StringSegmentSyntax {
     let stateAllocator = BumpPtrAllocator(initialSlabSize: 256)
     withExtendedLifetime(stateAllocator) {
       rawText.withBuffer { buffer in
-        var cursor = Lexer.Cursor(input: buffer, previous: 0, languageFeatures: [])
+        var cursor = Lexer.Cursor(input: buffer, previous: 0)
 
         // Put the cursor in the string literal lexing state. This is just
         // defensive as it's currently not used by `lexCharacterInStringLiteral`.
-        let state = Lexer.Cursor.State.inStringLiteral(kind: stringLiteralKind, delimiterLength: delimiterLength)
+        let state = Lexer.Cursor.State.inStringLiteral(delimiterLength: delimiterLength, kind: stringLiteralKind)
         let transition = Lexer.StateTransition.push(newState: state)
         cursor.perform(stateTransition: transition, stateAllocator: stateAllocator)
 

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -25,9 +25,7 @@ public struct TriviaParser {
     var pieces: [RawTriviaPiece] = []
     var cursor = Lexer.Cursor(
       input: UnsafeBufferPointer(start: source.baseAddress, count: source.count),
-      previous: 0,
-      // There are currently no experimental features that affect trivia parsing.
-      languageFeatures: []
+      previous: 0
     )
 
     while true {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -190,7 +190,6 @@ private func assertTokens(
 func assertLexemes(
   _ markedSource: String,
   lexemes expectedLexemes: [LexemeSpec],
-  languageFeatures: Parser.LanguageFeatures = [],
   file: StaticString = #filePath,
   line: UInt = #line
 ) {
@@ -210,8 +209,7 @@ func assertLexemes(
     for token in Lexer.tokenize(
       buf,
       from: 0,
-      lookaheadTracker: lookaheadTracker,
-      languageFeatures: languageFeatures
+      lookaheadTracker: lookaheadTracker
     ) {
       lexemes.append(token)
 

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -22,7 +22,7 @@ private func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Void) 
   lookaheadTracker.initialize(to: LookaheadTracker())
   try sourceBytes.withUnsafeBufferPointer { (buf) in
     var lexemes = [Lexer.Lexeme]()
-    for token in Lexer.tokenize(buf, from: 0, lookaheadTracker: lookaheadTracker, languageFeatures: []) {
+    for token in Lexer.tokenize(buf, from: 0, lookaheadTracker: lookaheadTracker) {
       lexemes.append(token)
 
       if token.rawTokenKind == .endOfFile {

--- a/Tests/SwiftParserTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftParserTest/MemoryLayoutTest.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing) import SwiftParser
+@_spi(Testing) import SwiftSyntax
+import XCTest
+
+final class MemoryLayoutTest: XCTestCase {
+
+  func testMemoryLayouts() throws {
+    #if !arch(x86_64) && !arch(arm64)
+    throw XCTSkip("Only runs on x86_64 and arm64")
+    #endif
+
+    /// This test result is just for tracking the memory footprint of the lexer
+    /// and parser, and they are totally informative purpose. Although we want to
+    /// keep the numbers as low as possible, nothing should rely on them, and are
+    /// not hard limits in any way.
+    /// If this fails, just update the numbers.
+    ///
+    /// A ``Lexer/Cursor`` is stored in every ``Lexer/Lexeme``, and a
+    /// ``Lexer/LexemeSequence`` is copied to start every ``Parser/Lookahead``,
+    /// so these sizes are multiplied several times over on the hot path.
+    let expected: [String: SyntaxMemoryLayout.Value] = [
+      "Lexer.Cursor": .init(size: 81, stride: 88, alignment: 8),
+      "Lexer.Cursor.Position": .init(size: 17, stride: 24, alignment: 8),
+      "Lexer.Cursor.State": .init(size: 17, stride: 24, alignment: 8),
+      "Lexer.Cursor.StateStack": .init(size: 41, stride: 48, alignment: 8),
+      "Lexer.Lexeme": .init(size: 121, stride: 128, alignment: 8),
+      "Lexer.LexemeSequence": .init(size: 320, stride: 320, alignment: 8),
+
+      "Parser.Lookahead": .init(size: 472, stride: 472, alignment: 8),
+      "TokenSpec": .init(size: 5, stride: 5, alignment: 1),
+    ]
+
+    let values = ParserMemoryLayout.values
+    XCTAssertEqual(values.count, expected.count)
+    for exp in expected {
+      let actualValue = try XCTUnwrap(values[exp.key], "Missing '\(exp.key)'")
+      XCTAssertEqual(actualValue, exp.value, "Matching '\(exp.key)' values")
+    }
+  }
+
+  func testCopyingLookaheadTypes() throws {
+    /// Whether a copy of each type is a move, tracked the same way as the sizes
+    /// above and equally informative.
+    ///
+    /// Starting a ``Parser/Lookahead`` copies the parser's
+    /// ``Lexer/LexemeSequence``, at roughly a hundred call sites. Where the
+    /// copied type holds nothing that has to be retained, that copy is a move
+    /// and discarding the lookahead costs nothing; where it holds a reference,
+    /// both become calls out to a value witness.
+    let expected: [String: Bool] = [
+      "Lexer.Cursor": true,
+      "Lexer.Lexeme": true,
+      "Lexer.LexemeSequence": false,
+      "Parser.Lookahead": false,
+    ]
+    XCTAssertEqual(ParserMemoryLayout.trivialTypes, expected)
+  }
+}

--- a/Tests/SwiftParserTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftParserTest/MemoryLayoutTest.swift
@@ -31,14 +31,14 @@ final class MemoryLayoutTest: XCTestCase {
     /// ``Lexer/LexemeSequence`` is copied to start every ``Parser/Lookahead``,
     /// so these sizes are multiplied several times over on the hot path.
     let expected: [String: SyntaxMemoryLayout.Value] = [
-      "Lexer.Cursor": .init(size: 81, stride: 88, alignment: 8),
+      "Lexer.Cursor": .init(size: 57, stride: 64, alignment: 8),
       "Lexer.Cursor.Position": .init(size: 17, stride: 24, alignment: 8),
-      "Lexer.Cursor.State": .init(size: 17, stride: 24, alignment: 8),
-      "Lexer.Cursor.StateStack": .init(size: 41, stride: 48, alignment: 8),
-      "Lexer.Lexeme": .init(size: 121, stride: 128, alignment: 8),
-      "Lexer.LexemeSequence": .init(size: 320, stride: 320, alignment: 8),
+      "Lexer.Cursor.State": .init(size: 10, stride: 16, alignment: 8),
+      "Lexer.Cursor.StateStack": .init(size: 33, stride: 40, alignment: 8),
+      "Lexer.Lexeme": .init(size: 97, stride: 104, alignment: 8),
+      "Lexer.LexemeSequence": .init(size: 192, stride: 192, alignment: 8),
 
-      "Parser.Lookahead": .init(size: 472, stride: 472, alignment: 8),
+      "Parser.Lookahead": .init(size: 320, stride: 320, alignment: 8),
       "TokenSpec": .init(size: 5, stride: 5, alignment: 1),
     ]
 


### PR DESCRIPTION
A `Lexer.Cursor` is stored in every `Lexer.Lexeme`, and a `Lexer.LexemeSequence` is copied to start every `Parser.Lookahead` at roughly a hundred call sites, so a few bytes added to any of them are paid many times over. Shrunk them.

- Add `ParserMemoryLayout` and a test recording the size, stride and alignment of nine lexer and parser types, plus whether copying each of four of them is a move. The numbers are informative, not limits. Both dictionaries live in `MemoryLayout.swift` rather than beside the types they measure, since none of these types is file private and that keeps `Cursor.swift` and `Parser.swift` from importing the `Testing` SPI.
- Order `Lexer.Cursor.State`'s payloads by decreasing alignment, so the case's fields pack instead of padding to the widest.
- Pass the source buffer start as a pointer, not a whole `Cursor`. Only the pointer was ever read from it.
- Drop `languageFeatures` from the cursor. No lexing decision consults it.

A cursor's stride falls from 88 to 64 bytes, a lexeme's from 128 to 104, a lexeme sequence from 320 to 192, and a `Parser.Lookahead` from 472 to 320. Parsing a 177 KB source file speeds up by 11.1% and 11.7% over two independent builds, and a 317 KB declaration-heavy one by 10.9% and 10.8%, measured against `main`.

(This will conflict with #3417, I will rebase this after it lands)