### PR TITLE
Allow trailing commas in parseMacroRoleArguments

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -413,7 +413,7 @@ extension Parser {
     let additionalArgs = self.parseArgumentListElements(
       pattern: .none,
       flavor: .attributeArguments,
-      allowTrailingComma: false
+      allowTrailingComma: true
     )
     return [roleElement] + additionalArgs
   }

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -909,6 +909,13 @@ final class AttributeTests: ParserTestCase {
 
     assertParse(
       """
+      @attached(extension,)
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
       @attached(extension, names: named(test))
       macro m()
       """

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -913,6 +913,20 @@ final class AttributeTests: ParserTestCase {
       macro m()
       """
     )
+
+    assertParse(
+      """
+      @attached(extension, names: named(test),)
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @attached(member, names: arbitrary,)
+      macro m()
+      """
+    )
   }
 
   func testConventionAttributeInArrayType() {


### PR DESCRIPTION
### Motivation

Fixes #3306.

Under SE-0439, list structures such as `LabeledExprListSyntax` support trailing commas. Currently, `parseMacroRoleArguments` in `Sources/SwiftParser/Attributes.swift` explicitly disabled trailing commas with `allowTrailingComma: false`, preventing macro role attributes from supporting trailing commas (e.g., `@attached(member, names: arbitrary,)`).

### Modifications

- Updated `parseMacroRoleArguments` in `Sources/SwiftParser/Attributes.swift` to pass `allowTrailingComma: true` when calling `parseArgumentListElements`.
- Added test cases in `Tests/SwiftParserTest/AttributeTests.swift` verifying that macro role attributes with trailing commas parse correctly without diagnostics.

### Result

Macro role attributes now support trailing commas as expected.