### PR TITLE
Preserve child lookahead ranges for reused nodes

### DIFF
--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -24,7 +24,6 @@ extension Parser {
 
     let currentOffset = self.lexemes.offsetToStart(self.currentToken)
     if let node = parseLookup!.lookUp(AbsolutePosition(utf8Offset: currentOffset), kind: kind) {
-      parseLookup!.preserveLookaheadRanges(in: node, to: &lookaheadRanges)
       self.lexemes.advance(by: node.totalLength.utf8Length, currentToken: &self.currentToken)
       return node
     }
@@ -63,6 +62,10 @@ public final class IncrementalParseTransition {
   fileprivate let previousIncrementalParseResult: IncrementalParseResult
   fileprivate let edits: ConcurrentEdits
   fileprivate let reusedNodeCallback: ReusedNodeCallback?
+
+  var previousLookaheadRanges: LookaheadRanges {
+    return previousIncrementalParseResult.lookaheadRanges
+  }
 
   /// When the previous tree retains at least this many arenas, the next
   /// incremental parse is replaced by a full reparse that collapses the result
@@ -149,16 +152,6 @@ struct IncrementalParseLookup {
 
   fileprivate var reusedCallback: ReusedNodeCallback? {
     return transition.reusedNodeCallback
-  }
-
-  fileprivate func preserveLookaheadRanges(in node: Syntax, to lookaheadRanges: inout LookaheadRanges) {
-    var nodesToVisit = [node]
-    while let node = nodesToVisit.popLast() {
-      if let lookaheadLength = transition.previousIncrementalParseResult.lookaheadRanges.lookaheadRanges[node.raw.id] {
-        lookaheadRanges.registerNodeForIncrementalParse(node: node.raw, lookaheadLength: lookaheadLength)
-      }
-      nodesToVisit.append(contentsOf: node.children(viewMode: .sourceAccurate))
-    }
   }
 
   /// Does a lookup to see if the current source `offset` should be associated

--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -24,6 +24,7 @@ extension Parser {
 
     let currentOffset = self.lexemes.offsetToStart(self.currentToken)
     if let node = parseLookup!.lookUp(AbsolutePosition(utf8Offset: currentOffset), kind: kind) {
+      parseLookup!.preserveLookaheadRanges(in: node, to: &lookaheadRanges)
       self.lexemes.advance(by: node.totalLength.utf8Length, currentToken: &self.currentToken)
       return node
     }
@@ -148,6 +149,16 @@ struct IncrementalParseLookup {
 
   fileprivate var reusedCallback: ReusedNodeCallback? {
     return transition.reusedNodeCallback
+  }
+
+  fileprivate func preserveLookaheadRanges(in node: Syntax, to lookaheadRanges: inout LookaheadRanges) {
+    var nodesToVisit = [node]
+    while let node = nodesToVisit.popLast() {
+      if let lookaheadLength = transition.previousIncrementalParseResult.lookaheadRanges.lookaheadRanges[node.raw.id] {
+        lookaheadRanges.registerNodeForIncrementalParse(node: node.raw, lookaheadLength: lookaheadLength)
+      }
+      nodesToVisit.append(contentsOf: node.children(viewMode: .sourceAccurate))
+    }
   }
 
   /// Does a lookup to see if the current source `offset` should be associated

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -1043,6 +1043,9 @@ public struct LookaheadRanges: Sendable {
   public init() {}
 
   mutating func registerNodeForIncrementalParse(node: RawSyntax, lookaheadLength: Int) {
-    self.lookaheadRanges[node.id] = lookaheadLength
+    // Reused nodes may already have a lookahead range from the previous parse.
+    // Keep the larger range so registering the node after advancing the lexer
+    // cannot discard lookahead that was recorded before the node was reused.
+    self.lookaheadRanges[node.id] = max(self.lookaheadRanges[node.id] ?? 0, lookaheadLength)
   }
 }

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -280,6 +280,7 @@ public struct Parser {
     self.currentToken = self.lexemes.advance()
     if let parseTransition {
       self.parseLookup = IncrementalParseLookup(transition: parseTransition)
+      self.lookaheadRanges = parseTransition.previousLookaheadRanges
     } else {
       self.parseLookup = nil
     }

--- a/Tests/SwiftParserTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftParserTest/IncrementalParsingTests.swift
@@ -16,6 +16,30 @@ import XCTest
 import _SwiftSyntaxTestSupport
 
 class IncrementalParsingTests: ParserTestCase {
+  private func replacing(
+    _ oldText: String,
+    with newText: String,
+    in source: String
+  ) -> (String, SourceEdit) {
+    let range = source.range(of: oldText)!
+    let lowerBound = source.utf8.distance(
+      from: source.utf8.startIndex,
+      to: range.lowerBound.samePosition(in: source.utf8)!
+    )
+    let upperBound = source.utf8.distance(
+      from: source.utf8.startIndex,
+      to: range.upperBound.samePosition(in: source.utf8)!
+    )
+    var editedSource = source
+    editedSource.replaceSubrange(range, with: newText)
+    return (
+      editedSource,
+      SourceEdit(
+        range: AbsolutePosition(utf8Offset: lowerBound)..<AbsolutePosition(utf8Offset: upperBound),
+        replacement: newText
+      )
+    )
+  }
 
   public func testBrokenMemberFunction() {
     assertIncrementalParse(
@@ -38,6 +62,48 @@ class IncrementalParsingTests: ParserTestCase {
         ReusedNodeSpec("struct B {}", kind: .codeBlockItem)
       ]
     )
+  }
+
+  public func testLookaheadRangesForChildrenOfReusedNodeArePreserved() {
+    let originalSource = """
+      struct A {
+        func f() {}
+        func abc() {}
+        let value = 1
+      }
+      struct B {}
+      struct D {}
+      """
+    let originalResult = Parser.parseIncrementally(source: originalSource, parseTransition: nil)
+
+    // Reuse `struct A` while applying an unrelated edit. Because reusing the
+    // struct skips parsing its members, their lookahead ranges must be preserved.
+    let (intermediateSource, unrelatedEdit) = replacing("struct D", with: "struct E", in: originalSource)
+    var initiallyReusedNodes: [Syntax] = []
+    let intermediateResult = Parser.parseIncrementally(
+      source: intermediateSource,
+      parseTransition: IncrementalParseTransition(
+        previousIncrementalParseResult: originalResult,
+        edits: ConcurrentEdits(unrelatedEdit),
+        reusedNodeCallback: { initiallyReusedNodes.append($0) }
+      )
+    )
+    XCTAssertTrue(initiallyReusedNodes.contains(where: { $0.trimmedDescription.hasPrefix("struct A") }))
+
+    // This invalidates the reused struct item. The unchanged function precedes
+    // the edit, so reusing it requires preserving the skipped child's range.
+    let (finalSource, memberEdit) = replacing("let value = 1", with: "let value = 2", in: intermediateSource)
+    var reusedNodes: [Syntax] = []
+    _ = Parser.parseIncrementally(
+      source: finalSource,
+      parseTransition: IncrementalParseTransition(
+        previousIncrementalParseResult: intermediateResult,
+        edits: ConcurrentEdits(memberEdit),
+        reusedNodeCallback: { reusedNodes.append($0) }
+      )
+    )
+
+    XCTAssertTrue(reusedNodes.contains(where: { $0.trimmedDescription == "func f() {}" }))
   }
 
   public func testAddElse() {

--- a/Tests/SwiftParserTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftParserTest/IncrementalParsingTests.swift
@@ -64,6 +64,54 @@ class IncrementalParsingTests: ParserTestCase {
     )
   }
 
+  public func testLookaheadRangeDoesNotShrinkWhenNodeIsReused() {
+    let originalSource = """
+      foo() {}
+      label: switch x {
+        default: break
+      }
+      bar() {}
+      """
+    let originalResult = Parser.parseIncrementally(source: originalSource, parseTransition: nil)
+
+    // Reuse `foo() {}` while applying an unrelated edit. Its original parse
+    // looked through `label: switch` to rule out a labeled trailing closure.
+    let (intermediateSource, unrelatedEdit) = replacing("bar", with: "baz", in: originalSource)
+    var initiallyReusedNodes: [Syntax] = []
+    let intermediateResult = Parser.parseIncrementally(
+      source: intermediateSource,
+      parseTransition: IncrementalParseTransition(
+        previousIncrementalParseResult: originalResult,
+        edits: ConcurrentEdits(unrelatedEdit),
+        reusedNodeCallback: { initiallyReusedNodes.append($0) }
+      )
+    )
+    XCTAssertTrue(initiallyReusedNodes.contains(where: { $0.trimmedDescription == "foo() {}" }))
+
+    // Changing `switch ...` to a closure makes `label: {}` a labeled trailing
+    // closure of `foo()`. The reused node must therefore be invalidated.
+    let (finalSource, lookaheadEdit) = replacing(
+      "switch x {\n  default: break\n}",
+      with: "{}",
+      in: intermediateSource
+    )
+    let incrementalTree = Parser.parseIncrementally(
+      source: finalSource,
+      parseTransition: IncrementalParseTransition(
+        previousIncrementalParseResult: intermediateResult,
+        edits: ConcurrentEdits(lookaheadEdit)
+      )
+    ).tree
+    let fullyParsedTree = Parser.parse(source: finalSource)
+
+    let subtreeMatcher = SubtreeMatcher(incrementalTree, markers: [:])
+    do {
+      try subtreeMatcher.assertSameStructure(fullyParsedTree, includeTrivia: true)
+    } catch {
+      XCTFail("Matching for a subtree failed with error: \(error)")
+    }
+  }
+
   public func testLookaheadRangesForChildrenOfReusedNodeArePreserved() {
     let originalSource = """
       struct A {


### PR DESCRIPTION
## Summary

- Preserve lookahead ranges across incremental parses by carrying the previous `LookaheadRanges` into the next `Parser`.
- Keep the largest lookahead range when a node is registered more than once.
- Add regression tests covering both the original #3397 scenario and lookahead ranges for children of reused nodes.

Fixes #3397.

## Why this fixes the issue

When an incrementally parsed subtree is reused, the parser skips parsing that subtree and therefore does not re-register its nodes' lookahead ranges. The next parser now starts with the previous parse's complete `LookaheadRanges`, so lookahead information for reused nodes and their descendants is retained.

`registerNodeForIncrementalParse` keeps the maximum range for a node, preventing a later registration with a shorter range from discarding previously recorded lookahead information.

This also avoids walking every reused subtree during incremental parsing.

## Verification

- `swift test --filter IncrementalParsingTests`
- `SKIP_LONG_TESTS=1 swift test --filter SwiftParserTest`
- `swift format lint --strict --parallel --recursive ...`
- `./swift-syntax-dev-utils local-pr-precheck`

All checks passed.

--
I use codex write description