### PR TITLE
Feat(SwiftRefactor): Implement InvertIfCondition refactoring

### DIFF
--- a/Sources/SwiftRefactor/CMakeLists.txt
+++ b/Sources/SwiftRefactor/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_syntax_library(SwiftRefactor
   CallLikeSyntax.swift
   CallToTrailingClosures.swift
   ExpandEditorPlaceholder.swift
+  InvertIfCondition.swift
   RefactoringProvider.swift
   SyntaxUtils.swift
 

--- a/Sources/SwiftRefactor/InvertIfCondition.swift
+++ b/Sources/SwiftRefactor/InvertIfCondition.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+public import SwiftSyntax
+#else
+import SwiftSyntax
+#endif
+
+/// Inverts a negated `if` condition and swaps the branches.
+///
+/// ## Before
+///
+/// ```swift
+/// if !x {
+///   foo()
+/// } else {
+///   bar()
+/// }
+/// ```
+///
+/// ## After
+///
+/// ```swift
+/// if x {
+///   bar()
+/// } else {
+///   foo()
+/// }
+/// ```
+public struct InvertIfCondition: SyntaxRefactoringProvider {
+  public typealias Input = IfExprSyntax
+  public typealias Output = IfExprSyntax
+
+  public static func refactor(syntax ifExpr: IfExprSyntax, in context: Void = ()) throws -> IfExprSyntax {
+    guard let elseBody = ifExpr.elseBody, case .codeBlock(let elseBlock) = elseBody else {
+      throw RefactoringNotApplicableError("missing else block")
+    }
+
+    guard ifExpr.conditions.count == 1, let condition = ifExpr.conditions.first else {
+      throw RefactoringNotApplicableError("conditions count must be 1")
+    }
+
+    guard case .expression(let expr) = condition.condition else {
+      throw RefactoringNotApplicableError("condition is not an expression")
+    }
+
+    guard let prefixOpExpr = expr.as(PrefixOperatorExprSyntax.self), prefixOpExpr.operator.text == "!" else {
+      throw RefactoringNotApplicableError("condition is not negated with '!'")
+    }
+
+    let innerExpr = prefixOpExpr.expression.with(
+      \.leadingTrivia,
+      prefixOpExpr.leadingTrivia
+        .merging(triviaOf: prefixOpExpr.operator)
+        .merging(prefixOpExpr.expression.leadingTrivia)
+    )
+
+    let newConditions = ifExpr.conditions.with(
+      \.[ifExpr.conditions.startIndex].condition,
+      .expression(innerExpr)
+    )
+
+    let oldBody = ifExpr.body
+    let oldElseBlock = elseBlock
+
+    let newBody =
+      oldElseBlock
+      .with(\.leadingTrivia, oldBody.leadingTrivia)
+      .with(\.trailingTrivia, oldBody.trailingTrivia)
+
+    let newElseBody =
+      oldBody
+      .with(\.leadingTrivia, oldElseBlock.leadingTrivia)
+      .with(\.trailingTrivia, oldElseBlock.trailingTrivia)
+
+    return
+      ifExpr
+      .with(\.conditions, newConditions)
+      .with(\.body, newBody)
+      .with(\.elseBody, .codeBlock(newElseBody))
+  }
+}

--- a/Tests/SwiftRefactorTest/InvertIfConditionTest.swift
+++ b/Tests/SwiftRefactorTest/InvertIfConditionTest.swift
@@ -1,0 +1,198 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftBasicFormat
+import SwiftRefactor
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import XCTest
+import _SwiftSyntaxTestSupport
+
+final class InvertIfConditionTest: XCTestCase {
+  func testInvertIfCondition() throws {
+    let tests: [(ExprSyntax, ExprSyntax)] = [
+      (
+        """
+        if !x {
+          foo()
+        } else {
+          bar()
+        }
+        """,
+        """
+        if x {
+          bar()
+        } else {
+          foo()
+        }
+        """
+      ),
+      (
+        """
+        if !(x == y) {
+          return
+        } else {
+          continue
+        }
+        """,
+        """
+        if (x == y) {
+          continue
+        } else {
+          return
+        }
+        """
+      ),
+      (
+        """
+        if /* comment */ !x {
+          a
+        } else {
+          b
+        }
+        """,
+        """
+        if /* comment */ x {
+          b
+        } else {
+          a
+        }
+        """
+      ),
+      (
+        """
+        if !x /* comment */ {
+          a
+        } else {
+          b
+        }
+        """,
+        """
+        if x /* comment */ {
+          b
+        } else {
+          a
+        }
+        """
+      ),
+      (
+        """
+        if !(/* comment */ x == y) {
+          return
+        } else {
+          continue
+        }
+        """,
+        """
+        if (/* comment */ x == y) {
+          continue
+        } else {
+          return
+        }
+        """
+      ),
+      (
+        """
+        if !x {
+          // body comment
+          foo()
+        } else {
+          // else comment
+          bar()
+        }
+        """,
+        """
+        if x {
+          // else comment
+          bar()
+        } else {
+          // body comment
+          foo()
+        }
+        """
+      ),
+    ]
+
+    for (input, expected) in tests {
+      try assertInvertIfCondition(input, expected: expected)
+    }
+  }
+
+  func testInvertIfConditionFails() throws {
+    let tests: [ExprSyntax] = [
+      // Not negated
+      """
+      if x {
+        a
+      } else {
+        b
+      }
+      """,
+      // No else
+      """
+      if !x {
+        a
+      }
+      """,
+      // Else if (not a CodeBlock)
+      """
+      if !x {
+        a
+      } else if y {
+        b
+      }
+      """,
+      // Multiple conditions
+      """
+      if !x, !y {
+        a
+      } else {
+        b
+      }
+      """,
+      // Binding
+      """
+      if let x = y {
+        a
+      } else {
+        b
+      }
+      """,
+    ]
+
+    for input in tests {
+      try assertInvertIfCondition(input, expected: nil)
+    }
+  }
+
+  private func assertInvertIfCondition(
+    _ input: ExprSyntax,
+    expected: ExprSyntax?,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws {
+    let inputSyntax = try XCTUnwrap(input.as(IfExprSyntax.self), "Not an IfExpr: \(input)", file: file, line: line)
+    do {
+      let result = try InvertIfCondition.refactor(syntax: inputSyntax)
+      if let expected {
+        let expectedSyntax = try XCTUnwrap(expected.as(IfExprSyntax.self), "Not an IfExpr: \(expected)", file: file, line: line)
+        assertStringsEqualWithDiff(result.description, expectedSyntax.description, file: file, line: line)
+      } else {
+        XCTFail("Expected failure, but refactoring succeeded: \(result.description)", file: file, line: line)
+      }
+    } catch {
+      if expected != nil {
+        XCTFail("Refactoring threw error '\(error)' for input:\n\(input)", file: file, line: line)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
This PR implements the `InvertIfCondition` refactoring action in `SwiftRefactor`, which supersedes stale PR #3263 and addresses maintainer review feedback for swiftlang/sourcekit-lsp#2408.

Transformation:
```swift
// Before
if !x {
  foo()
} else {
  bar()
}

// After
if x {
  bar()
} else {
  foo()
}
