### PR TITLE
[Perf][SwiftParser] Hold the lexer's state stack as a shared linked list

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -175,65 +175,114 @@ extension Lexer.Cursor {
     }
   }
 
-  /// A data structure that holds the state stack entries in the lexer. It is
-  /// optimized for situations where there's at most one state on the stack
-  /// (in addition to the bottom `normal` mode) and to not create any ARC
-  /// traffic.
+  /// The lexer's state stack, holding the bottom `normal` state implicitly and
+  /// the states above it as a singly linked list running from the top down,
+  /// whose nodes are allocated in a bump allocator that outlives the stack.
   ///
-  /// It does this by representing the bottom `normal` state implicitly and
-  /// storing one additional state inline. If the stack needs to contain more
-  /// entries, the required memory is allocated in a bump allocator that is
-  /// expected to outlive the stack.
+  /// One pointer wide, and free of ARC traffic. Both matter because a
+  /// ``Lexer/Cursor`` is stored in every ``Lexer/Lexeme``.
   struct StateStack {
-    private var topState: State? = nil
-    private var stateStack: UnsafeBufferPointer<State>? = nil
+    /// One state, together with the states below it.
+    ///
+    /// Written once, when allocated, and shared from then on by every stack that
+    /// has it in its tail. That is what gives the stack value semantics without
+    /// copying: a transition on one ``Lexer/Cursor`` leaves the chain any copy
+    /// of it refers to untouched.
+    struct Node {
+      /// The state below `state`, or `nil` if `state` sits directly on the
+      /// implicit `normal` bottom.
+      let next: UnsafePointer<Node>?
 
-    var currentState: State {
-      return topState ?? .normal
+      let state: State
+
+      /// The number of states below `state`, held per node so that
+      /// `hasProgressed(comparedTo:)` compares it in constant time.
+      let statesBelow: UInt32
     }
 
-    mutating func perform(stateTransition: Lexer.StateTransition, stateAllocator: BumpPtrAllocator) {
+    /// The top of the stack, or `nil` if the stack holds nothing above the
+    /// implicit `normal` bottom.
+    private var top: UnsafePointer<Node>? = nil
+
+    var currentState: State {
+      guard let top else {
+        return .normal
+      }
+      return top.pointee.state
+    }
+
+    /// The number of states below ``currentState``.
+    private var statesBelowCurrent: UInt32 {
+      guard let top else {
+        return 0
+      }
+      return top.pointee.statesBelow
+    }
+
+    /// Make `state` the top of the stack, with the chain starting at `next`
+    /// below it.
+    mutating func perform(
+      stateTransition: Lexer.StateTransition,
+      stateAllocator: Unmanaged<Lexer.StateAllocator>
+    ) {
+      // Unwrapped here rather than by the caller, because a transition happens
+      // for a small fraction of the tokens that are lexed.
+      let stateAllocator = stateAllocator.takeUnretainedValue()
+
+      // Every transition but a pop amounts to putting a state on top of some
+      // suffix of the stack, so the switch works out which, and the node for it
+      // is built once below.
+      let state: State
+      let next: UnsafePointer<Node>?
       switch stateTransition {
       case .push(let newState):
-        if let topState {
-          if let stateStack = stateStack {
-            let newStateStack = stateAllocator.allocate(State.self, count: stateStack.count + 1)
-            let (_, existingStateStackEndIndex) = newStateStack.initialize(from: stateStack)
-            newStateStack[existingStateStackEndIndex] = topState
-            self.stateStack = UnsafeBufferPointer(newStateStack)
-          } else {
-            let newStateStack = stateAllocator.allocate(State.self, count: 1)
-            newStateStack[0] = topState
-            self.stateStack = UnsafeBufferPointer(newStateStack)
-          }
-        }
-        topState = newState
+        state = newState
+        next = self.top
       case .pushRegexLexemes(let index, let lexemes):
-        perform(
-          stateTransition: .push(
-            newState: .inRegexLiteral(lexemes: lexemes.allocate(in: stateAllocator), index: index)
-          ),
-          stateAllocator: stateAllocator
+        state = .inRegexLiteral(
+          lexemes: lexemes.allocate(in: stateAllocator.allocator),
+          index: index
         )
+        next = self.top
       case .replace(let newState):
-        topState = newState
+        state = newState
+        next = self.top?.pointee.next
       case .pop:
-        if let stateStack {
-          topState = stateStack.last!
-          if stateStack.count == 1 {
-            self.stateStack = nil
-          } else {
-            self.stateStack = UnsafeBufferPointer(start: stateStack.baseAddress, count: stateStack.count - 1)
-          }
-        } else {
-          topState = nil
-        }
+        self.top = self.top?.pointee.next
+        return
+      }
+
+      // A node standing on the empty stack is determined entirely by its state,
+      // so one built earlier in the parse describes this stack just as well. See
+      // `StateAllocator.nodesOnEmptyStack`.
+      let standsOnEmptyStack = next == nil
+      if standsOnEmptyStack,
+        let shared = stateAllocator.nodesOnEmptyStack.first(where: { $0.pointee.state == state })
+      {
+        self.top = shared
+        return
+      }
+
+      let node = stateAllocator.allocator.allocate(Node.self, count: 1).baseAddress!
+      node.initialize(
+        to: Node(
+          next: next,
+          state: state,
+          statesBelow: next.map { $0.pointee.statesBelow + 1 } ?? 0
+        )
+      )
+      self.top = UnsafePointer(node)
+
+      if standsOnEmptyStack,
+        stateAllocator.nodesOnEmptyStack.count < Lexer.StateAllocator.nodesOnEmptyStackLimit
+      {
+        stateAllocator.nodesOnEmptyStack.append(UnsafePointer(node))
       }
     }
 
     /// See `Lexer.Cursor.hasProgressed(comparedTo:)`.
     fileprivate func hasProgressed(comparedTo other: StateStack) -> Bool {
-      return currentState != other.currentState || stateStack?.count != other.stateStack?.count
+      return currentState != other.currentState || statesBelowCurrent != other.statesBelowCurrent
     }
   }
 
@@ -306,7 +355,7 @@ extension Lexer {
       stateStack.currentState
     }
 
-    mutating func perform(stateTransition: Lexer.StateTransition, stateAllocator: BumpPtrAllocator) {
+    mutating func perform(stateTransition: Lexer.StateTransition, stateAllocator: Unmanaged<Lexer.StateAllocator>) {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
 
@@ -460,7 +509,10 @@ extension Lexer.Cursor.Position {
 // MARK: - Entry point
 
 extension Lexer.Cursor {
-  mutating func nextToken(sourceBufferStart: UnsafePointer<UInt8>?, stateAllocator: BumpPtrAllocator) -> Lexer.Lexeme {
+  mutating func nextToken(
+    sourceBufferStart: UnsafePointer<UInt8>?,
+    stateAllocator: Unmanaged<Lexer.StateAllocator>
+  ) -> Lexer.Lexeme {
     let cursor = self
     // Leading trivia.
     let leadingTriviaStart = self

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -17,6 +17,32 @@
 #endif
 
 extension Lexer {
+  /// Owns the memory that the lexer's state stack spills into.
+  ///
+  /// Whoever creates this keeps it alive for as long as the lexeme sequence made
+  /// from it, and anything copied from that sequence.
+  @_spi(Testing)
+  public final class StateAllocator {
+    let allocator: BumpPtrAllocator
+
+    /// Nodes already built for a state pushed onto the empty stack, so that a
+    /// file entering the same state repeatedly builds one node rather than one
+    /// per occurrence. Only these are shared, being the ones that recur.
+    ///
+    /// Bounded, so that a file entering many distinct states allocates rather
+    /// than turning every transition into a long scan. Six entries suffice for
+    /// the parser's own sources.
+    var nodesOnEmptyStack: [UnsafePointer<Lexer.Cursor.StateStack.Node>] = []
+
+    static let nodesOnEmptyStackLimit = 16
+
+    @_spi(Testing)
+    public init() {
+      self.allocator = BumpPtrAllocator(initialSlabSize: 256)
+      self.nodesOnEmptyStack.reserveCapacity(Self.nodesOnEmptyStackLimit)
+    }
+  }
+
   /// A sequence of ``Lexer/Lexeme`` tokens starting from a ``Lexer/Cursor``
   /// that points into an input buffer.
   @_spi(Testing)
@@ -24,17 +50,14 @@ extension Lexer {
     fileprivate let sourceBufferStart: UnsafePointer<UInt8>?
     fileprivate var cursor: Lexer.Cursor
     fileprivate var nextToken: Lexer.Lexeme
-    /// If the lexer has more than one state on its state stack, it will
-    /// allocate a new memory region in this allocator to represent the
-    /// additional states on its stack. This is more efficient than paying the
-    /// retain/release cost of an array.
+    /// Where the lexer allocates the states above the first one on its stack,
+    /// which costs less than the retain and release an array would.
     ///
-    /// The states will be freed when the lexer is finished, i.e. when this
-    /// ``LexemeSequence`` is deallocated.
-    ///
-    /// The memory footprint of not freeing past lexer states is negligible. It's
-    /// usually less than 0.1% of the memory allocated by the syntax arena.
-    var lexerStateAllocator = BumpPtrAllocator(initialSlabSize: 256)
+    /// Unmanaged so that copying a sequence to start a ``Lookahead`` stays a
+    /// move; `unowned(unsafe)` costs a retain and release for every token, since
+    /// the allocator is passed as a parameter. Whoever creates the sequence keeps
+    /// the allocator alive for at least as long as anything copied from it.
+    let lexerStateAllocator: Unmanaged<Lexer.StateAllocator>
 
     /// The offset of the trailing trivia end of `nextToken` relative to the source buffer’s start.
     var offsetToNextTokenEnd: Int {
@@ -51,13 +74,15 @@ extension Lexer {
     fileprivate init(
       sourceBufferStart: UnsafePointer<UInt8>?,
       cursor: Lexer.Cursor,
-      lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>
+      lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>,
+      stateAllocator: Unmanaged<Lexer.StateAllocator>
     ) {
       self.sourceBufferStart = sourceBufferStart
       self.cursor = cursor
+      self.lexerStateAllocator = stateAllocator
       self.nextToken = self.cursor.nextToken(
         sourceBufferStart: self.sourceBufferStart,
-        stateAllocator: lexerStateAllocator
+        stateAllocator: stateAllocator
       )
       self.lookaheadTracker = lookaheadTracker
     }
@@ -152,7 +177,8 @@ extension Lexer {
   public static func tokenize(
     _ input: UnsafeBufferPointer<UInt8>,
     from startIndex: Int = 0,
-    lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>
+    lookaheadTracker: UnsafeMutablePointer<LookaheadTracker>,
+    stateAllocator: StateAllocator
   ) -> LexemeSequence {
     precondition(input.isEmpty || startIndex < input.endIndex)
     let startChar = startIndex == input.startIndex ? UInt8(ascii: "\0") : input[startIndex - 1]
@@ -163,7 +189,8 @@ extension Lexer {
     return LexemeSequence(
       sourceBufferStart: input.baseAddress,
       cursor: cursor,
-      lookaheadTracker: lookaheadTracker
+      lookaheadTracker: lookaheadTracker,
+      stateAllocator: .passUnretained(stateAllocator)
     )
   }
 }

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -121,6 +121,13 @@ public struct Parser {
   /// Parser should own a ``LookaheadTracker`` so that we can share one `furthestOffset` in a parse.
   private let lookaheadTrackerOwner: LookaheadTrackerOwner
 
+  /// Owns the memory that the lexer's state stack spills into.
+  ///
+  /// ``Lexer/LexemeSequence`` refers to this without owning it, so this parser,
+  /// which outlives its own ``lexemes`` and every ``Lookahead`` copied from them,
+  /// is the one to keep it alive.
+  private let lexerStateAllocator: Lexer.StateAllocator
+
   /// Owns the source buffer for the lifetime of this parser when the parser
   /// created its own arena. The source is not copied into the arena, so it is
   /// freed when this `Parser` is destroyed. `nil` when the source lives
@@ -271,10 +278,12 @@ public struct Parser {
     self.swiftVersion = swiftVersion ?? Self.defaultSwiftVersion
     self.languageFeatures = languageFeatures
     self.lookaheadTrackerOwner = LookaheadTrackerOwner()
+    self.lexerStateAllocator = Lexer.StateAllocator()
 
     self.lexemes = Lexer.tokenize(
       input,
-      lookaheadTracker: lookaheadTrackerOwner.lookaheadTracker
+      lookaheadTracker: lookaheadTrackerOwner.lookaheadTracker,
+      stateAllocator: lexerStateAllocator
     )
     self.currentToken = self.lexemes.advance()
     if let parseTransition {

--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -91,7 +91,7 @@ extension StringSegmentSyntax {
 
     // The lexer's state stack spills into this allocator, so it has to outlive
     // `cursor` below rather than be a temporary of the `perform` call.
-    let stateAllocator = BumpPtrAllocator(initialSlabSize: 256)
+    let stateAllocator = Lexer.StateAllocator()
     withExtendedLifetime(stateAllocator) {
       rawText.withBuffer { buffer in
         var cursor = Lexer.Cursor(input: buffer, previous: 0)
@@ -100,7 +100,7 @@ extension StringSegmentSyntax {
         // defensive as it's currently not used by `lexCharacterInStringLiteral`.
         let state = Lexer.Cursor.State.inStringLiteral(delimiterLength: delimiterLength, kind: stringLiteralKind)
         let transition = Lexer.StateTransition.push(newState: state)
-        cursor.perform(stateTransition: transition, stateAllocator: stateAllocator)
+        cursor.perform(stateTransition: transition, stateAllocator: .passUnretained(stateAllocator))
 
         while true {
           let lex = cursor.lexCharacterInStringLiteral(

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -204,12 +204,15 @@ func assertLexemes(
     lookaheadTracker.deallocate()
   }
   lookaheadTracker.initialize(to: LookaheadTracker())
+  // Outlives the lexeme sequence, which refers to it without owning it.
+  let stateAllocator = Lexer.StateAllocator()
   source.withUTF8 { buf in
     var lexemes = [Lexer.Lexeme]()
     for token in Lexer.tokenize(
       buf,
       from: 0,
-      lookaheadTracker: lookaheadTracker
+      lookaheadTracker: lookaheadTracker,
+      stateAllocator: stateAllocator
     ) {
       lexemes.append(token)
 

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -20,9 +20,16 @@ private func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Void) 
     lookaheadTracker.deallocate()
   }
   lookaheadTracker.initialize(to: LookaheadTracker())
+  // Outlives the lexeme sequence, which refers to it without owning it.
+  let stateAllocator = Lexer.StateAllocator()
   try sourceBytes.withUnsafeBufferPointer { (buf) in
     var lexemes = [Lexer.Lexeme]()
-    for token in Lexer.tokenize(buf, from: 0, lookaheadTracker: lookaheadTracker) {
+    for token in Lexer.tokenize(
+      buf,
+      from: 0,
+      lookaheadTracker: lookaheadTracker,
+      stateAllocator: stateAllocator
+    ) {
       lexemes.append(token)
 
       if token.rawTokenKind == .endOfFile {

--- a/Tests/SwiftParserTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftParserTest/MemoryLayoutTest.swift
@@ -31,14 +31,14 @@ final class MemoryLayoutTest: XCTestCase {
     /// ``Lexer/LexemeSequence`` is copied to start every ``Parser/Lookahead``,
     /// so these sizes are multiplied several times over on the hot path.
     let expected: [String: SyntaxMemoryLayout.Value] = [
-      "Lexer.Cursor": .init(size: 57, stride: 64, alignment: 8),
+      "Lexer.Cursor": .init(size: 32, stride: 32, alignment: 8),
       "Lexer.Cursor.Position": .init(size: 17, stride: 24, alignment: 8),
       "Lexer.Cursor.State": .init(size: 10, stride: 16, alignment: 8),
-      "Lexer.Cursor.StateStack": .init(size: 33, stride: 40, alignment: 8),
-      "Lexer.Lexeme": .init(size: 97, stride: 104, alignment: 8),
-      "Lexer.LexemeSequence": .init(size: 192, stride: 192, alignment: 8),
+      "Lexer.Cursor.StateStack": .init(size: 8, stride: 8, alignment: 8),
+      "Lexer.Lexeme": .init(size: 72, stride: 72, alignment: 8),
+      "Lexer.LexemeSequence": .init(size: 128, stride: 128, alignment: 8),
 
-      "Parser.Lookahead": .init(size: 320, stride: 320, alignment: 8),
+      "Parser.Lookahead": .init(size: 224, stride: 224, alignment: 8),
       "TokenSpec": .init(size: 5, stride: 5, alignment: 1),
     ]
 
@@ -62,8 +62,8 @@ final class MemoryLayoutTest: XCTestCase {
     let expected: [String: Bool] = [
       "Lexer.Cursor": true,
       "Lexer.Lexeme": true,
-      "Lexer.LexemeSequence": false,
-      "Parser.Lookahead": false,
+      "Lexer.LexemeSequence": true,
+      "Parser.Lookahead": true,
     ]
     XCTAssertEqual(ParserMemoryLayout.trivialTypes, expected)
   }


### PR DESCRIPTION
Use linked list to describe the lexer state stack.

* State itself immutable, so `.replace` transition stack can reuse the `next` node.
* Nodes for a state pushed onto the empty stack are reused, so we don't allocate identical `Node` many times.
* The allocator now lives in `Parser` and is passed into `LexemeSequence` as a unowned value so creating `Lookahead` which copies `lexemes` don't imply ARC traffic.

`Lexer.Cursor` 57 → 32 bytes, its `StateStack` 33 → 8, `Lexer.Lexeme` 97 → 72, and `Lexer.LexemeSequence` 192 → 128.
All four of the types a lookahead copies are now trivially copyable, which are tested in `testCopyingLookaheadTypes`.

Parsing 468 KB of declarations goes from 7.899 ms to 6.698 ms, and 389 KB of 65% non-ASCII source from 6.383 ms to 5.887 ms — 15.2% and 7.8%.
