### PR TITLE
[Perf][SwiftSyntax] Tail allocate a node's fields after a one-word header

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -36,14 +36,25 @@ struct RecursiveRawSyntaxFlags: OptionSet, Sendable {
   static let hasMaximumNestingLevelOverflow = RecursiveRawSyntaxFlags(rawValue: 1 << 3)
 }
 
-/// Node data for RawSyntax tree. Tagged union plus common data.
-internal struct RawSyntaxData: Sendable {
-  internal enum Payload: Sendable {
-    /// - Important: A raw syntax node for a parsed token must always be allocated in a `ParsingRawSyntaxArena` so we can
-    ///   parse the trivia in the token.
-    case parsedToken(ParsedToken)
-    case materializedToken(MaterializedToken)
-    case layout(Layout)
+/// Which shape a node's fields have, and the arena those fields live in.
+///
+/// One word wide: a class reference has spare bits, so the shape rides along
+/// inside the reference rather than beside it. A node is this header followed by
+/// the fields of whichever shape it names, so a node takes room for its own
+/// shape instead of for the largest one.
+enum RawSyntaxData: Sendable {
+  /// - Important: A raw syntax node for a parsed token must always be allocated
+  ///   in a `ParsingRawSyntaxArena` so we can parse the trivia in the token.
+  case parsedToken(RawSyntaxArenaRef)
+  case materializedToken(RawSyntaxArenaRef)
+  case layout(RawSyntaxArenaRef)
+
+  @inline(__always)
+  var arenaReference: RawSyntaxArenaRef {
+    switch self {
+    case .parsedToken(let arenaRef), .materializedToken(let arenaRef), .layout(let arenaRef):
+      return arenaRef
+    }
   }
 
   /// Token with lazy trivia parsing.
@@ -167,9 +178,6 @@ internal struct RawSyntaxData: Sendable {
     var descendantCount: Int
     var recursiveFlags: RecursiveRawSyntaxFlags
   }
-
-  var payload: Payload
-  var arenaReference: RawSyntaxArenaRef
 }
 
 extension RawSyntaxData.ParsedToken {
@@ -199,23 +207,106 @@ extension RawSyntaxData.MaterializedToken {
 @_spi(RawSyntax)
 public struct RawSyntax: Sendable {
 
-  /// Pointer to the actual data which resides in a RawSyntaxArena.
+  /// Pointer to the node, which resides in a RawSyntaxArena: a one-word header
+  /// followed by the fields of the shape it names.
   var pointer: ArenaAllocatedPointer<RawSyntaxData>
   init(pointer: ArenaAllocatedPointer<RawSyntaxData>) {
     self.pointer = pointer
   }
 
-  init(arena: __shared RawSyntaxArena, payload: RawSyntaxData.Payload) {
-    let arenaRef = RawSyntaxArenaRef(arena)
-    let data = RawSyntaxData(
-      payload: payload,
-      arenaReference: arenaRef
-    )
-    self.init(pointer: ArenaAllocatedPointer(arena.intern(data)))
+  /// Where a node's tail begins: immediately past its one-word header.
+  @inline(__always)
+  static var tailOffset: Int { MemoryLayout<RawSyntaxData>.stride }
+
+  @inline(__always)
+  private var tail: UnsafeRawPointer {
+    UnsafeRawPointer(pointer.pointer).advanced(by: Self.tailOffset)
   }
 
-  var rawData: RawSyntaxData {
-    @_transparent unsafeAddress { pointer.pointer }
+  /// Takes room for a header and `tailByteCount` bytes after it, writes the
+  /// header, and hands back the node together with where its tail begins.
+  @inline(__always)
+  private static func allocate(
+    _ header: RawSyntaxData,
+    tailByteCount: Int,
+    arena: __shared RawSyntaxArena
+  ) -> (node: RawSyntax, tail: UnsafeMutableRawPointer) {
+    let base = arena.allocateNode(byteCount: Self.tailOffset + tailByteCount)
+    let headerPointer = base.assumingMemoryBound(to: RawSyntaxData.self)
+    headerPointer.initialize(to: header)
+    return (
+      RawSyntax(pointer: ArenaAllocatedPointer(UnsafePointer(headerPointer))),
+      base.advanced(by: Self.tailOffset)
+    )
+  }
+
+  init(arena: __shared RawSyntaxArena, parsedToken fields: RawSyntaxData.ParsedToken) {
+    let (node, tail) = Self.allocate(
+      .parsedToken(RawSyntaxArenaRef(arena)),
+      tailByteCount: MemoryLayout<RawSyntaxData.ParsedToken>.stride,
+      arena: arena
+    )
+    tail.bindMemory(to: RawSyntaxData.ParsedToken.self, capacity: 1).initialize(to: fields)
+    self = node
+  }
+
+  init(arena: __shared RawSyntaxArena, materializedToken fields: RawSyntaxData.MaterializedToken) {
+    let (node, tail) = Self.allocate(
+      .materializedToken(RawSyntaxArenaRef(arena)),
+      tailByteCount: MemoryLayout<RawSyntaxData.MaterializedToken>.stride,
+      arena: arena
+    )
+    tail.bindMemory(to: RawSyntaxData.MaterializedToken.self, capacity: 1).initialize(to: fields)
+    self = node
+  }
+
+  init(arena: __shared RawSyntaxArena, layout fields: RawSyntaxData.Layout) {
+    let (node, tail) = Self.allocate(
+      .layout(RawSyntaxArenaRef(arena)),
+      tailByteCount: MemoryLayout<RawSyntaxData.Layout>.stride,
+      arena: arena
+    )
+    tail.bindMemory(to: RawSyntaxData.Layout.self, capacity: 1).initialize(to: fields)
+    self = node
+  }
+
+  /// Which of the three shapes this node has, and the arena that owns it.
+  @inline(__always)
+  var header: RawSyntaxData {
+    pointer.pointer.pointee
+  }
+
+  /// - Precondition: this is a parsed token.
+  @inline(__always)
+  var asParsedToken: UnsafePointer<RawSyntaxData.ParsedToken> {
+    switch self.header {
+    case .parsedToken:
+      return tail.assumingMemoryBound(to: RawSyntaxData.ParsedToken.self)
+    case .materializedToken, .layout:
+      preconditionFailure("not a parsed token")
+    }
+  }
+
+  /// - Precondition: this is a materialized token.
+  @inline(__always)
+  var asMaterializedToken: UnsafePointer<RawSyntaxData.MaterializedToken> {
+    switch self.header {
+    case .materializedToken:
+      return tail.assumingMemoryBound(to: RawSyntaxData.MaterializedToken.self)
+    case .parsedToken, .layout:
+      preconditionFailure("not a materialized token")
+    }
+  }
+
+  /// - Precondition: this is a layout node or a collection.
+  @inline(__always)
+  var asLayout: UnsafePointer<RawSyntaxData.Layout> {
+    switch self.header {
+    case .layout:
+      return tail.assumingMemoryBound(to: RawSyntaxData.Layout.self)
+    case .parsedToken, .materializedToken:
+      preconditionFailure("not a layout node")
+    }
   }
 
   public var arena: RetainedRawSyntaxArena {
@@ -223,11 +314,7 @@ public struct RawSyntax: Sendable {
   }
 
   internal var arenaReference: RawSyntaxArenaRef {
-    rawData.arenaReference
-  }
-
-  internal var payload: RawSyntaxData.Payload {
-    rawData.payload
+    header.arenaReference
   }
 }
 
@@ -237,10 +324,10 @@ extension RawSyntax {
   /// The syntax kind of this raw syntax.
   @_spi(RawSyntax)
   public var kind: SyntaxKind {
-    switch rawData.payload {
-    case .parsedToken(_): return .token
-    case .materializedToken(_): return .token
-    case .layout(let dat): return dat.kind
+    switch header {
+    case .parsedToken: return .token
+    case .materializedToken: return .token
+    case .layout: return asLayout.pointee.kind
     }
   }
 
@@ -273,12 +360,12 @@ extension RawSyntax {
 
   /// Total number of nodes in this sub-tree, including `self` node.
   var totalNodes: Int {
-    switch rawData.payload {
-    case .parsedToken(_),
+    switch header {
+    case .parsedToken,
       .materializedToken(_):
       return 1
-    case .layout(let dat):
-      return dat.descendantCount + 1
+    case .layout:
+      return asLayout.pointee.descendantCount + 1
     }
   }
 
@@ -287,21 +374,21 @@ extension RawSyntax {
   /// Sum of text byte lengths of all present descendant token nodes.
   @_spi(RawSyntax)
   public var byteLength: Int {
-    switch rawData.payload {
-    case .parsedToken(let dat):
-      if dat.presence == .present {
-        return dat.wholeText.count
+    switch header {
+    case .parsedToken:
+      if asParsedToken.pointee.presence == .present {
+        return asParsedToken.pointee.wholeText.count
       } else {
         return 0
       }
-    case .materializedToken(let dat):
-      if dat.presence == .present {
-        return Int(dat.byteLength)
+    case .materializedToken:
+      if asMaterializedToken.pointee.presence == .present {
+        return Int(asMaterializedToken.pointee.byteLength)
       } else {
         return 0
       }
-    case .layout(let dat):
-      return dat.byteLength
+    case .layout:
+      return asLayout.pointee.byteLength
     }
   }
 
@@ -397,23 +484,23 @@ extension RawSyntax {
   /// visitor are only guaranteed to be valid within that call. Otherwise, they
   /// are valid as long as the raw syntax is alive.
   public func withEachSyntaxText(body: (SyntaxText, _ isEphemeral: Bool) throws -> Void) rethrows {
-    switch rawData.payload {
-    case .parsedToken(let dat):
-      if dat.presence == .present {
-        try body(dat.wholeText, /*isEphemeral*/ false)
+    switch header {
+    case .parsedToken:
+      if asParsedToken.pointee.presence == .present {
+        try body(asParsedToken.pointee.wholeText, /*isEphemeral*/ false)
       }
-    case .materializedToken(let dat):
-      if dat.presence == .present {
-        for p in dat.leadingTrivia {
+    case .materializedToken:
+      if asMaterializedToken.pointee.presence == .present {
+        for p in asMaterializedToken.pointee.leadingTrivia {
           try p.withSyntaxText(body: body)
         }
-        try body(dat.tokenText, /*isEphemeral*/ false)
-        for p in dat.trailingTrivia {
+        try body(asMaterializedToken.pointee.tokenText, /*isEphemeral*/ false)
+        for p in asMaterializedToken.pointee.trailingTrivia {
           try p.withSyntaxText(body: body)
         }
       }
-    case .layout(let dat):
-      for case let child? in dat.layout {
+    case .layout:
+      for case let child? in asLayout.pointee.layout {
         try child.withEachSyntaxText(body: body)
       }
     }
@@ -446,19 +533,19 @@ extension RawSyntax: TextOutputStreamable, CustomStringConvertible {
   /// stream. This implementation must be source-accurate.
   /// - Parameter stream: The stream on which to output this node.
   public func write<Target: TextOutputStream>(to target: inout Target) {
-    switch rawData.payload {
-    case .parsedToken(let dat):
-      if dat.presence == .present {
-        String(syntaxText: dat.wholeText).write(to: &target)
+    switch header {
+    case .parsedToken:
+      if asParsedToken.pointee.presence == .present {
+        String(syntaxText: asParsedToken.pointee.wholeText).write(to: &target)
       }
-    case .materializedToken(let dat):
-      if dat.presence == .present {
-        for p in dat.leadingTrivia { p.write(to: &target) }
-        String(syntaxText: dat.tokenText).write(to: &target)
-        for p in dat.trailingTrivia { p.write(to: &target) }
+    case .materializedToken:
+      if asMaterializedToken.pointee.presence == .present {
+        for p in asMaterializedToken.pointee.leadingTrivia { p.write(to: &target) }
+        String(syntaxText: asMaterializedToken.pointee.tokenText).write(to: &target)
+        for p in asMaterializedToken.pointee.trailingTrivia { p.write(to: &target) }
       }
-    case .layout(let dat):
-      for case let child? in dat.layout {
+    case .layout:
+      for case let child? in asLayout.pointee.layout {
         child.write(to: &target)
       }
     }
@@ -592,7 +679,7 @@ extension RawSyntax {
       kind != .keyword || Keyword(payload.tokenText) != nil,
       "If kind is keyword, the text must be a known token kind"
     )
-    return RawSyntax(arena: arena, payload: .parsedToken(payload))
+    return RawSyntax(arena: arena, parsedToken: payload)
   }
 
   /// "Designated" factory method to create a materialized token node.
@@ -637,7 +724,7 @@ extension RawSyntax {
       tokenDiagnostic: tokenDiagnostic
     )
     precondition(kind != .keyword || Keyword(text) != nil, "If kind is keyword, the text must be a known token kind")
-    return RawSyntax(arena: arena, payload: .materializedToken(payload))
+    return RawSyntax(arena: arena, materializedToken: payload)
   }
 
   /// Factory method to create a materialized token node.
@@ -777,7 +864,7 @@ extension RawSyntax {
       descendantCount: descendantCount,
       recursiveFlags: recursiveFlags
     )
-    return RawSyntax(arena: arena, payload: .layout(payload))
+    return RawSyntax(arena: arena, layout: payload)
   }
 
   /// Factory method to create a layout node.
@@ -887,26 +974,26 @@ extension RawSyntax: CustomDebugStringConvertible {
 
   private func debugWrite(to target: inout some TextOutputStream, indent: Int, withChildren: Bool = false) {
     let childIndent = indent + 2
-    switch rawData.payload {
-    case .parsedToken(let dat):
+    switch header {
+    case .parsedToken:
       target.write(".parsedToken(")
-      target.write(String(describing: dat.tokenKind))
-      target.write(" wholeText=\(dat.wholeText.debugDescription)")
-      target.write(" textRange=\(dat.textRange.description)")
-    case .materializedToken(let dat):
+      target.write(String(describing: asParsedToken.pointee.tokenKind))
+      target.write(" wholeText=\(asParsedToken.pointee.wholeText.debugDescription)")
+      target.write(" textRange=\(asParsedToken.pointee.textRange.description)")
+    case .materializedToken:
       target.write(".materializedToken(")
-      target.write(String(describing: dat.tokenKind))
-      target.write(" text=\(dat.tokenText.debugDescription)")
-      target.write(" numLeadingTrivia=\(dat.numLeadingTrivia)")
-      target.write(" byteLength=\(dat.byteLength)")
+      target.write(String(describing: asMaterializedToken.pointee.tokenKind))
+      target.write(" text=\(asMaterializedToken.pointee.tokenText.debugDescription)")
+      target.write(" numLeadingTrivia=\(asMaterializedToken.pointee.numLeadingTrivia)")
+      target.write(" byteLength=\(asMaterializedToken.pointee.byteLength)")
       break
-    case .layout(let dat):
+    case .layout:
       target.write(".layout(")
       target.write(String(describing: kind))
-      target.write(" byteLength=\(dat.byteLength)")
-      target.write(" descendantCount=\(dat.descendantCount)")
+      target.write(" byteLength=\(asLayout.pointee.byteLength)")
+      target.write(" descendantCount=\(asLayout.pointee.descendantCount)")
       if withChildren {
-        for (num, child) in dat.layout.enumerated() {
+        for (num, child) in asLayout.pointee.layout.enumerated() {
           target.write("\n")
           target.write(String(repeating: " ", count: childIndent))
           target.write("\(num): ")
@@ -954,7 +1041,7 @@ enum RawSyntaxView {
 
 extension RawSyntax {
   var view: RawSyntaxView {
-    switch raw.payload {
+    switch header {
     case .parsedToken, .materializedToken:
       return .token(tokenView!)
     case .layout:

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -341,36 +341,6 @@ public struct RawSyntax: Sendable {
     )
   }
 
-  init(arena: __shared RawSyntaxArena, parsedToken fields: RawSyntaxData.ParsedToken) {
-    let (node, tail) = Self.allocate(
-      .parsedToken(RawSyntaxArenaRef(arena)),
-      tailByteCount: MemoryLayout<RawSyntaxData.ParsedToken>.stride,
-      arena: arena
-    )
-    tail.bindMemory(to: RawSyntaxData.ParsedToken.self, capacity: 1).initialize(to: fields)
-    self = node
-  }
-
-  init(arena: __shared RawSyntaxArena, materializedToken fields: RawSyntaxData.MaterializedToken) {
-    let (node, tail) = Self.allocate(
-      .materializedToken(RawSyntaxArenaRef(arena)),
-      tailByteCount: MemoryLayout<RawSyntaxData.MaterializedToken>.stride,
-      arena: arena
-    )
-    tail.bindMemory(to: RawSyntaxData.MaterializedToken.self, capacity: 1).initialize(to: fields)
-    self = node
-  }
-
-  init(arena: __shared RawSyntaxArena, layout fields: RawSyntaxData.Layout) {
-    let (node, tail) = Self.allocate(
-      .layout(RawSyntaxArenaRef(arena)),
-      tailByteCount: MemoryLayout<RawSyntaxData.Layout>.stride,
-      arena: arena
-    )
-    tail.bindMemory(to: RawSyntaxData.Layout.self, capacity: 1).initialize(to: fields)
-    self = node
-  }
-
   /// Which of the three shapes this node has, and the arena that owns it.
   @inline(__always)
   var header: RawSyntaxData {
@@ -780,7 +750,20 @@ extension RawSyntax {
       kind != .keyword || Keyword(SyntaxText(rebasing: wholeText[textRange])) != nil,
       "If kind is keyword, the text must be a known token kind"
     )
-    return RawSyntax(arena: arena, parsedToken: payload)
+    return RawSyntax.allocateParsedToken(payload, arena: arena)
+  }
+
+  static func allocateParsedToken(
+    _ fields: RawSyntaxData.ParsedToken,
+    arena: __shared RawSyntaxArena
+  ) -> RawSyntax {
+    let (node, tail) = Self.allocate(
+      .parsedToken(RawSyntaxArenaRef(arena)),
+      tailByteCount: MemoryLayout<RawSyntaxData.ParsedToken>.stride,
+      arena: arena
+    )
+    tail.bindMemory(to: RawSyntaxData.ParsedToken.self, capacity: 1).initialize(to: fields)
+    return node
   }
 
   /// "Designated" factory method to create a materialized token node.
@@ -825,7 +808,20 @@ extension RawSyntax {
       tokenDiagnostic: tokenDiagnostic
     )
     precondition(kind != .keyword || Keyword(text) != nil, "If kind is keyword, the text must be a known token kind")
-    return RawSyntax(arena: arena, materializedToken: payload)
+    return RawSyntax.allocateMaterializedToken(payload, arena: arena)
+  }
+
+  static func allocateMaterializedToken(
+    _ fields: RawSyntaxData.MaterializedToken,
+    arena: __shared RawSyntaxArena
+  ) -> RawSyntax {
+    let (node, tail) = Self.allocate(
+      .materializedToken(RawSyntaxArenaRef(arena)),
+      tailByteCount: MemoryLayout<RawSyntaxData.MaterializedToken>.stride,
+      arena: arena
+    )
+    tail.bindMemory(to: RawSyntaxData.MaterializedToken.self, capacity: 1).initialize(to: fields)
+    return node
   }
 
   /// Factory method to create a materialized token node.
@@ -965,7 +961,20 @@ extension RawSyntax {
       descendantCount: descendantCount,
       recursiveFlags: recursiveFlags
     )
-    return RawSyntax(arena: arena, layout: payload)
+    return RawSyntax.allocateLayout(payload, arena: arena)
+  }
+
+  private static func allocateLayout(
+    _ fields: RawSyntaxData.Layout,
+    arena: __shared RawSyntaxArena
+  ) -> RawSyntax {
+    let (node, tail) = Self.allocate(
+      .layout(RawSyntaxArenaRef(arena)),
+      tailByteCount: MemoryLayout<RawSyntaxData.Layout>.stride,
+      arena: arena
+    )
+    tail.bindMemory(to: RawSyntaxData.Layout.self, capacity: 1).initialize(to: fields)
+    return node
   }
 
   /// Factory method to create a layout node.

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -181,23 +181,124 @@ enum RawSyntaxData: Sendable {
 }
 
 extension RawSyntaxData.ParsedToken {
-  var tokenText: SyntaxText {
-    SyntaxText(rebasing: wholeText[textRange])
-  }
-  var leadingTriviaText: SyntaxText {
-    SyntaxText(rebasing: wholeText[..<textRange.lowerBound])
-  }
-  var trailingTriviaText: SyntaxText {
-    SyntaxText(rebasing: wholeText[textRange.upperBound...])
+  /// A parsed token's fields in a node's tail.
+  ///
+  /// - Important: The arena that owns the node must outlive this.
+  struct Ref: Sendable {
+    typealias Fields = RawSyntaxData.ParsedToken
+
+    private let pointer: ArenaAllocatedPointer<Fields>
+
+    @inline(__always)
+    init(_ pointer: UnsafePointer<Fields>) {
+      self.pointer = ArenaAllocatedPointer(pointer)
+    }
+
+    /// The fields themselves, to make a token that differs from this one in a
+    /// field or two.
+    @inline(__always)
+    var fields: Fields { pointer.pointee }
+
+    @inline(__always)
+    var tokenKind: RawTokenKind { pointer.pointee.tokenKind }
+    @inline(__always)
+    var wholeText: SyntaxText { pointer.pointee.wholeText }
+    @inline(__always)
+    var textRange: Range<SyntaxText.Index> { pointer.pointee.textRange }
+    @inline(__always)
+    var presence: SourcePresence { pointer.pointee.presence }
+    @inline(__always)
+    var tokenDiagnostic: TokenDiagnostic? { pointer.pointee.tokenDiagnostic }
+
+    /// The token's own text, without its trivia.
+    @inline(__always)
+    var tokenText: SyntaxText {
+      SyntaxText(rebasing: self.wholeText[self.textRange])
+    }
+    @inline(__always)
+    var leadingTriviaText: SyntaxText {
+      SyntaxText(rebasing: self.wholeText[..<self.textRange.lowerBound])
+    }
+    @inline(__always)
+    var trailingTriviaText: SyntaxText {
+      SyntaxText(rebasing: self.wholeText[self.textRange.upperBound...])
+    }
   }
 }
 
 extension RawSyntaxData.MaterializedToken {
-  var leadingTrivia: RawTriviaPieceBuffer {
-    RawTriviaPieceBuffer(rebasing: triviaPieces[..<Int(numLeadingTrivia)])
+  /// A materialized token's fields in a node's tail.
+  ///
+  /// - Important: The arena that owns the node must outlive this.
+  struct Ref: Sendable {
+    typealias Fields = RawSyntaxData.MaterializedToken
+
+    private let pointer: ArenaAllocatedPointer<Fields>
+
+    @inline(__always)
+    init(_ pointer: UnsafePointer<Fields>) {
+      self.pointer = ArenaAllocatedPointer(pointer)
+    }
+
+    /// The fields themselves, to make a token that differs from this one in a
+    /// field or two.
+    @inline(__always)
+    var fields: Fields { pointer.pointee }
+
+    @inline(__always)
+    var tokenKind: RawTokenKind { pointer.pointee.tokenKind }
+    @inline(__always)
+    var tokenText: SyntaxText { pointer.pointee.tokenText }
+    @inline(__always)
+    var byteLength: UInt32 { pointer.pointee.byteLength }
+    @inline(__always)
+    var numLeadingTrivia: UInt32 { pointer.pointee.numLeadingTrivia }
+    @inline(__always)
+    var triviaPieces: RawTriviaPieceBuffer { pointer.pointee.triviaPieces }
+    @inline(__always)
+    var presence: SourcePresence { pointer.pointee.presence }
+    @inline(__always)
+    var tokenDiagnostic: TokenDiagnostic? { pointer.pointee.tokenDiagnostic }
+
+    @inline(__always)
+    var leadingTrivia: RawTriviaPieceBuffer {
+      RawTriviaPieceBuffer(rebasing: self.triviaPieces[..<Int(self.numLeadingTrivia)])
+    }
+    @inline(__always)
+    var trailingTrivia: RawTriviaPieceBuffer {
+      RawTriviaPieceBuffer(rebasing: self.triviaPieces[Int(self.numLeadingTrivia)...])
+    }
   }
-  var trailingTrivia: RawTriviaPieceBuffer {
-    RawTriviaPieceBuffer(rebasing: triviaPieces[Int(numLeadingTrivia)...])
+}
+
+extension RawSyntaxData.Layout {
+  /// A layout node's fields in a node's tail.
+  ///
+  /// - Important: The arena that owns the node must outlive this.
+  struct Ref: Sendable {
+    typealias Fields = RawSyntaxData.Layout
+
+    private let pointer: ArenaAllocatedPointer<Fields>
+
+    @inline(__always)
+    init(_ pointer: UnsafePointer<Fields>) {
+      self.pointer = ArenaAllocatedPointer(pointer)
+    }
+
+    /// The fields themselves, for a caller that wants them as a value.
+    @inline(__always)
+    var fields: Fields { pointer.pointee }
+
+    @inline(__always)
+    var kind: SyntaxKind { pointer.pointee.kind }
+    @inline(__always)
+    var layout: RawSyntaxBuffer { pointer.pointee.layout }
+    @inline(__always)
+    var byteLength: Int { pointer.pointee.byteLength }
+    @inline(__always)
+    var descendantCount: Int { pointer.pointee.descendantCount }
+    @inline(__always)
+    var recursiveFlags: RecursiveRawSyntaxFlags { pointer.pointee.recursiveFlags }
   }
 }
 
@@ -278,10 +379,10 @@ public struct RawSyntax: Sendable {
 
   /// - Precondition: this is a parsed token.
   @inline(__always)
-  var asParsedToken: UnsafePointer<RawSyntaxData.ParsedToken> {
+  var asParsedToken: RawSyntaxData.ParsedToken.Ref {
     switch self.header {
     case .parsedToken:
-      return tail.assumingMemoryBound(to: RawSyntaxData.ParsedToken.self)
+      return RawSyntaxData.ParsedToken.Ref(tail.assumingMemoryBound(to: RawSyntaxData.ParsedToken.self))
     case .materializedToken, .layout:
       preconditionFailure("not a parsed token")
     }
@@ -289,10 +390,10 @@ public struct RawSyntax: Sendable {
 
   /// - Precondition: this is a materialized token.
   @inline(__always)
-  var asMaterializedToken: UnsafePointer<RawSyntaxData.MaterializedToken> {
+  var asMaterializedToken: RawSyntaxData.MaterializedToken.Ref {
     switch self.header {
     case .materializedToken:
-      return tail.assumingMemoryBound(to: RawSyntaxData.MaterializedToken.self)
+      return RawSyntaxData.MaterializedToken.Ref(tail.assumingMemoryBound(to: RawSyntaxData.MaterializedToken.self))
     case .parsedToken, .layout:
       preconditionFailure("not a materialized token")
     }
@@ -300,10 +401,10 @@ public struct RawSyntax: Sendable {
 
   /// - Precondition: this is a layout node or a collection.
   @inline(__always)
-  var asLayout: UnsafePointer<RawSyntaxData.Layout> {
+  var asLayout: RawSyntaxData.Layout.Ref {
     switch self.header {
     case .layout:
-      return tail.assumingMemoryBound(to: RawSyntaxData.Layout.self)
+      return RawSyntaxData.Layout.Ref(tail.assumingMemoryBound(to: RawSyntaxData.Layout.self))
     case .parsedToken, .materializedToken:
       preconditionFailure("not a layout node")
     }
@@ -327,7 +428,7 @@ extension RawSyntax {
     switch header {
     case .parsedToken: return .token
     case .materializedToken: return .token
-    case .layout: return asLayout.pointee.kind
+    case .layout: return asLayout.kind
     }
   }
 
@@ -365,7 +466,7 @@ extension RawSyntax {
       .materializedToken(_):
       return 1
     case .layout:
-      return asLayout.pointee.descendantCount + 1
+      return asLayout.descendantCount + 1
     }
   }
 
@@ -376,19 +477,19 @@ extension RawSyntax {
   public var byteLength: Int {
     switch header {
     case .parsedToken:
-      if asParsedToken.pointee.presence == .present {
-        return asParsedToken.pointee.wholeText.count
+      if asParsedToken.presence == .present {
+        return asParsedToken.wholeText.count
       } else {
         return 0
       }
     case .materializedToken:
-      if asMaterializedToken.pointee.presence == .present {
-        return Int(asMaterializedToken.pointee.byteLength)
+      if asMaterializedToken.presence == .present {
+        return Int(asMaterializedToken.byteLength)
       } else {
         return 0
       }
     case .layout:
-      return asLayout.pointee.byteLength
+      return asLayout.byteLength
     }
   }
 
@@ -486,21 +587,21 @@ extension RawSyntax {
   public func withEachSyntaxText(body: (SyntaxText, _ isEphemeral: Bool) throws -> Void) rethrows {
     switch header {
     case .parsedToken:
-      if asParsedToken.pointee.presence == .present {
-        try body(asParsedToken.pointee.wholeText, /*isEphemeral*/ false)
+      if asParsedToken.presence == .present {
+        try body(asParsedToken.wholeText, /*isEphemeral*/ false)
       }
     case .materializedToken:
-      if asMaterializedToken.pointee.presence == .present {
-        for p in asMaterializedToken.pointee.leadingTrivia {
+      if asMaterializedToken.presence == .present {
+        for p in asMaterializedToken.leadingTrivia {
           try p.withSyntaxText(body: body)
         }
-        try body(asMaterializedToken.pointee.tokenText, /*isEphemeral*/ false)
-        for p in asMaterializedToken.pointee.trailingTrivia {
+        try body(asMaterializedToken.tokenText, /*isEphemeral*/ false)
+        for p in asMaterializedToken.trailingTrivia {
           try p.withSyntaxText(body: body)
         }
       }
     case .layout:
-      for case let child? in asLayout.pointee.layout {
+      for case let child? in asLayout.layout {
         try child.withEachSyntaxText(body: body)
       }
     }
@@ -535,17 +636,17 @@ extension RawSyntax: TextOutputStreamable, CustomStringConvertible {
   public func write<Target: TextOutputStream>(to target: inout Target) {
     switch header {
     case .parsedToken:
-      if asParsedToken.pointee.presence == .present {
-        String(syntaxText: asParsedToken.pointee.wholeText).write(to: &target)
+      if asParsedToken.presence == .present {
+        String(syntaxText: asParsedToken.wholeText).write(to: &target)
       }
     case .materializedToken:
-      if asMaterializedToken.pointee.presence == .present {
-        for p in asMaterializedToken.pointee.leadingTrivia { p.write(to: &target) }
-        String(syntaxText: asMaterializedToken.pointee.tokenText).write(to: &target)
-        for p in asMaterializedToken.pointee.trailingTrivia { p.write(to: &target) }
+      if asMaterializedToken.presence == .present {
+        for p in asMaterializedToken.leadingTrivia { p.write(to: &target) }
+        String(syntaxText: asMaterializedToken.tokenText).write(to: &target)
+        for p in asMaterializedToken.trailingTrivia { p.write(to: &target) }
       }
     case .layout:
-      for case let child? in asLayout.pointee.layout {
+      for case let child? in asLayout.layout {
         child.write(to: &target)
       }
     }
@@ -676,7 +777,7 @@ extension RawSyntax {
       tokenDiagnostic: tokenDiagnostic
     )
     precondition(
-      kind != .keyword || Keyword(payload.tokenText) != nil,
+      kind != .keyword || Keyword(SyntaxText(rebasing: wholeText[textRange])) != nil,
       "If kind is keyword, the text must be a known token kind"
     )
     return RawSyntax(arena: arena, parsedToken: payload)
@@ -977,23 +1078,23 @@ extension RawSyntax: CustomDebugStringConvertible {
     switch header {
     case .parsedToken:
       target.write(".parsedToken(")
-      target.write(String(describing: asParsedToken.pointee.tokenKind))
-      target.write(" wholeText=\(asParsedToken.pointee.wholeText.debugDescription)")
-      target.write(" textRange=\(asParsedToken.pointee.textRange.description)")
+      target.write(String(describing: asParsedToken.tokenKind))
+      target.write(" wholeText=\(asParsedToken.wholeText.debugDescription)")
+      target.write(" textRange=\(asParsedToken.textRange.description)")
     case .materializedToken:
       target.write(".materializedToken(")
-      target.write(String(describing: asMaterializedToken.pointee.tokenKind))
-      target.write(" text=\(asMaterializedToken.pointee.tokenText.debugDescription)")
-      target.write(" numLeadingTrivia=\(asMaterializedToken.pointee.numLeadingTrivia)")
-      target.write(" byteLength=\(asMaterializedToken.pointee.byteLength)")
+      target.write(String(describing: asMaterializedToken.tokenKind))
+      target.write(" text=\(asMaterializedToken.tokenText.debugDescription)")
+      target.write(" numLeadingTrivia=\(asMaterializedToken.numLeadingTrivia)")
+      target.write(" byteLength=\(asMaterializedToken.byteLength)")
       break
     case .layout:
       target.write(".layout(")
       target.write(String(describing: kind))
-      target.write(" byteLength=\(asLayout.pointee.byteLength)")
-      target.write(" descendantCount=\(asLayout.pointee.descendantCount)")
+      target.write(" byteLength=\(asLayout.byteLength)")
+      target.write(" descendantCount=\(asLayout.descendantCount)")
       if withChildren {
-        for (num, child) in asLayout.pointee.layout.enumerated() {
+        for (num, child) in asLayout.layout.enumerated() {
           target.write("\n")
           target.write(String(repeating: " ", count: childIndent))
           target.write("\(num): ")

--- a/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxArena.swift
@@ -137,12 +137,13 @@ public class RawSyntaxArena {
     }
   }
 
-  /// Copies a `RawSyntaxData` to the memory this arena manages, and returns the
-  /// pointer to the destination.
-  func intern(_ value: RawSyntaxData) -> UnsafePointer<RawSyntaxData> {
-    let allocated = allocator.allocate(RawSyntaxData.self, count: 1).baseAddress!
-    allocated.initialize(to: value)
-    return UnsafePointer(allocated)
+  /// Allocates `byteCount` bytes for one node, aligned for a node's header and
+  /// for anything its tail can hold, and returns the uninitialized memory.
+  ///
+  /// A node is a header followed by a tail whose shape and size depend on which
+  /// of the three kinds of node it is, so its size is not a type's size.
+  func allocateNode(byteCount: Int) -> UnsafeMutableRawPointer {
+    return allocator.allocate(byteCount: byteCount, alignment: 8).baseAddress!
   }
 
   /// Adds an ``RawSyntaxArena`` to this arena as a "child". Do nothing if `arenaRef`

--- a/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
@@ -15,7 +15,7 @@ extension RawSyntax {
   /// The token's payload must be a layout, otherwise this traps.
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView? {
-    switch raw.payload {
+    switch header {
     case .parsedToken, .materializedToken:
       return nil
     case .layout:
@@ -31,21 +31,21 @@ public struct RawSyntaxLayoutView {
 
   fileprivate init(raw: RawSyntax) {
     self.raw = raw
-    switch raw.payload {
+    switch raw.header {
     case .parsedToken, .materializedToken:
       preconditionFailure("RawSyntax must be a layout")
-    case .layout(_):
+    case .layout:
       break
     }
   }
 
   private var layoutData: RawSyntaxData.Layout {
-    switch raw.rawData.payload {
-    case .parsedToken(_),
+    switch raw.header {
+    case .parsedToken,
       .materializedToken(_):
       preconditionFailure("RawSyntax must be a layout")
-    case .layout(let dat):
-      return dat
+    case .layout:
+      return raw.asLayout.pointee
     }
   }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
@@ -45,7 +45,7 @@ public struct RawSyntaxLayoutView {
       .materializedToken(_):
       preconditionFailure("RawSyntax must be a layout")
     case .layout:
-      return raw.asLayout.pointee
+      return raw.asLayout.fields
     }
   }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -15,10 +15,10 @@ extension RawSyntax {
   /// The token's payload must be a token, otherwise this traps.
   @_spi(RawSyntax)
   public var tokenView: RawSyntaxTokenView? {
-    switch raw.payload {
+    switch header {
     case .parsedToken, .materializedToken:
       return RawSyntaxTokenView(raw: self)
-    case .layout(_):
+    case .layout:
       return nil
     }
   }
@@ -31,10 +31,10 @@ public struct RawSyntaxTokenView: Sendable {
 
   fileprivate init(raw: RawSyntax) {
     self.raw = raw
-    switch raw.payload {
+    switch raw.header {
     case .parsedToken, .materializedToken:
       break
-    case .layout(_):
+    case .layout:
       preconditionFailure("RawSyntax must be a token")
     }
   }
@@ -42,12 +42,12 @@ public struct RawSyntaxTokenView: Sendable {
   /// Token kind of this node.
   @_spi(RawSyntax)
   public var rawKind: RawTokenKind {
-    switch raw.rawData.payload {
-    case .materializedToken(let dat):
-      return dat.tokenKind
-    case .parsedToken(let dat):
-      return dat.tokenKind
-    case .layout(_):
+    switch raw.header {
+    case .materializedToken:
+      return raw.asMaterializedToken.pointee.tokenKind
+    case .parsedToken:
+      return raw.asParsedToken.pointee.tokenKind
+    case .layout:
       preconditionFailure("'tokenKind' is not available for non-token node")
     }
   }
@@ -55,12 +55,12 @@ public struct RawSyntaxTokenView: Sendable {
   /// Token text of this node.
   @_spi(RawSyntax)
   public var rawText: SyntaxText {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return dat.tokenText
-    case .materializedToken(let dat):
-      return dat.tokenText
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.asParsedToken.pointee.tokenText
+    case .materializedToken:
+      return raw.asMaterializedToken.pointee.tokenText
+    case .layout:
       preconditionFailure("'rawText' is not available for non-token node")
     }
   }
@@ -68,12 +68,12 @@ public struct RawSyntaxTokenView: Sendable {
   /// The UTF-8 byte length of the leading trivia.
   @_spi(RawSyntax)
   public var leadingTriviaByteLength: Int {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return dat.leadingTriviaText.count
-    case .materializedToken(let dat):
-      return dat.leadingTrivia.reduce(0) { $0 + $1.byteLength }
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.asParsedToken.pointee.leadingTriviaText.count
+    case .materializedToken:
+      return raw.asMaterializedToken.pointee.leadingTrivia.reduce(0) { $0 + $1.byteLength }
+    case .layout:
       preconditionFailure("'leadingTriviaByteLength' is not available for non-token node")
     }
   }
@@ -81,36 +81,36 @@ public struct RawSyntaxTokenView: Sendable {
   /// The UTF-8 byte length of the trailing trivia.
   @_spi(RawSyntax)
   public var trailingTriviaByteLength: Int {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return dat.trailingTriviaText.count
-    case .materializedToken(let dat):
-      return dat.trailingTrivia.reduce(0) { $0 + $1.byteLength }
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.asParsedToken.pointee.trailingTriviaText.count
+    case .materializedToken:
+      return raw.asMaterializedToken.pointee.trailingTrivia.reduce(0) { $0 + $1.byteLength }
+    case .layout:
       preconditionFailure("'trailingTriviaByteLength' is not available for non-token node")
     }
   }
 
   @_spi(RawSyntax)
   public var leadingRawTriviaPieces: [RawTriviaPiece] {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return raw.arenaReference.parseTrivia(source: dat.leadingTriviaText, position: .leading)
-    case .materializedToken(let dat):
-      return Array(dat.leadingTrivia)
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.arenaReference.parseTrivia(source: raw.asParsedToken.pointee.leadingTriviaText, position: .leading)
+    case .materializedToken:
+      return Array(raw.asMaterializedToken.pointee.leadingTrivia)
+    case .layout:
       preconditionFailure("'leadingRawTriviaPieces' is called on non-token raw syntax")
     }
   }
 
   @_spi(RawSyntax)
   public var trailingRawTriviaPieces: [RawTriviaPiece] {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return raw.arenaReference.parseTrivia(source: dat.trailingTriviaText, position: .trailing)
-    case .materializedToken(let dat):
-      return Array(dat.trailingTrivia)
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.arenaReference.parseTrivia(source: raw.asParsedToken.pointee.trailingTriviaText, position: .trailing)
+    case .materializedToken:
+      return Array(raw.asMaterializedToken.pointee.trailingTrivia)
+    case .layout:
       preconditionFailure("'trailingRawTriviaPieces' is called on non-token raw syntax")
     }
   }
@@ -130,13 +130,14 @@ public struct RawSyntaxTokenView: Sendable {
   /// Run `body` with text of the leading trivia and return its result.
   @_spi(RawSyntax)
   public func leadingTrivia<T>(_ body: (SyntaxText) -> T) -> T {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return body(dat.leadingTriviaText)
-    case .materializedToken(let dat):
-      var leadingTriviaStr = Trivia(pieces: dat.leadingTrivia.map(TriviaPiece.init)).description
+    switch raw.header {
+    case .parsedToken:
+      return body(raw.asParsedToken.pointee.leadingTriviaText)
+    case .materializedToken:
+      var leadingTriviaStr = Trivia(pieces: raw.asMaterializedToken.pointee.leadingTrivia.map(TriviaPiece.init))
+        .description
       return leadingTriviaStr.withSyntaxText(body)
-    case .layout(_):
+    case .layout:
       preconditionFailure("'leadingTrivia' is called on non-token raw syntax")
     }
   }
@@ -144,13 +145,14 @@ public struct RawSyntaxTokenView: Sendable {
   /// Run `body` with text of the leading trivia and return its result.
   @_spi(RawSyntax)
   public func trailingTrivia<T>(_ body: (SyntaxText) -> T) -> T {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return body(dat.trailingTriviaText)
-    case .materializedToken(let dat):
-      var trailingTriviaStr = Trivia(pieces: dat.trailingTrivia.map(TriviaPiece.init)).description
+    switch raw.header {
+    case .parsedToken:
+      return body(raw.asParsedToken.pointee.trailingTriviaText)
+    case .materializedToken:
+      var trailingTriviaStr = Trivia(pieces: raw.asMaterializedToken.pointee.trailingTrivia.map(TriviaPiece.init))
+        .description
       return trailingTriviaStr.withSyntaxText(body)
-    case .layout(_):
+    case .layout:
       preconditionFailure("'trailingTrivia' is called on non-token raw syntax")
     }
   }
@@ -173,8 +175,8 @@ public struct RawSyntaxTokenView: Sendable {
   @_spi(RawSyntax)
   public func withKind(_ newValue: TokenKind, arena: RawSyntaxArena) -> RawSyntax {
     arena.addChild(self.raw.arenaReference)
-    switch raw.rawData.payload {
-    case .parsedToken(_):
+    switch raw.header {
+    case .parsedToken:
       // The wholeText can't be continuous anymore. Make a materialized token.
       return .makeMaterializedToken(
         kind: newValue,
@@ -184,13 +186,14 @@ public struct RawSyntaxTokenView: Sendable {
         tokenDiagnostic: tokenDiagnostic,
         arena: arena
       )
-    case .materializedToken(var payload):
+    case .materializedToken:
+      var payload = raw.asMaterializedToken.pointee
       let decomposed = newValue.decomposeToRaw()
       let rawKind = decomposed.rawKind
       let text: SyntaxText = (decomposed.string.map({ arena.intern($0) }) ?? decomposed.rawKind.defaultText ?? "")
       payload.tokenKind = rawKind
       payload.tokenText = text
-      return RawSyntax(arena: arena, payload: .materializedToken(payload))
+      return RawSyntax(arena: arena, materializedToken: payload)
     default:
       preconditionFailure("'withKind()' is called on non-token raw syntax")
     }
@@ -200,11 +203,12 @@ public struct RawSyntaxTokenView: Sendable {
   @_spi(RawSyntax)
   public func withPresence(_ newValue: SourcePresence, arena: RawSyntaxArena) -> RawSyntax {
     arena.addChild(self.raw.arenaReference)
-    switch raw.rawData.payload {
-    case .parsedToken(var payload):
+    switch raw.header {
+    case .parsedToken:
+      var payload = raw.asParsedToken.pointee
       if arena == self.raw.arenaReference {
         payload.presence = newValue
-        return RawSyntax(arena: arena, payload: .parsedToken(payload))
+        return RawSyntax(arena: arena, parsedToken: payload)
       }
       // If the modified token is allocated in a different arena, it might have
       // a different or no `parseTrivia` function. We thus cannot use a
@@ -217,9 +221,10 @@ public struct RawSyntaxTokenView: Sendable {
         tokenDiagnostic: tokenDiagnostic,
         arena: arena
       )
-    case .materializedToken(var payload):
+    case .materializedToken:
+      var payload = raw.asMaterializedToken.pointee
       payload.presence = newValue
-      return RawSyntax(arena: arena, payload: .materializedToken(payload))
+      return RawSyntax(arena: arena, materializedToken: payload)
     default:
       preconditionFailure("'withKind()' is called on non-token raw syntax")
     }
@@ -229,12 +234,12 @@ public struct RawSyntaxTokenView: Sendable {
   /// is a token node.
   @_spi(RawSyntax)
   public var textByteLength: Int {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return dat.tokenText.count
-    case .materializedToken(let dat):
-      return dat.tokenText.count
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.asParsedToken.pointee.tokenText.count
+    case .materializedToken:
+      return raw.asMaterializedToken.pointee.tokenText.count
+    case .layout:
       preconditionFailure("'textByteLength' is not available for non-token node")
     }
   }
@@ -246,36 +251,42 @@ public struct RawSyntaxTokenView: Sendable {
 
   @_spi(RawSyntax)
   public func formKind() -> TokenKind {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return TokenKind.fromRaw(kind: dat.tokenKind, text: String(syntaxText: dat.tokenText))
-    case .materializedToken(let dat):
-      return TokenKind.fromRaw(kind: dat.tokenKind, text: String(syntaxText: dat.tokenText))
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return TokenKind.fromRaw(
+        kind: raw.asParsedToken.pointee.tokenKind,
+        text: String(syntaxText: raw.asParsedToken.pointee.tokenText)
+      )
+    case .materializedToken:
+      return TokenKind.fromRaw(
+        kind: raw.asMaterializedToken.pointee.tokenKind,
+        text: String(syntaxText: raw.asMaterializedToken.pointee.tokenText)
+      )
+    case .layout:
       preconditionFailure("'formKind' is not available for non-token node")
     }
   }
 
   @_spi(RawSyntax)
   public var presence: SourcePresence {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return dat.presence
-    case .materializedToken(let dat):
-      return dat.presence
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.asParsedToken.pointee.presence
+    case .materializedToken:
+      return raw.asMaterializedToken.pointee.presence
+    case .layout:
       preconditionFailure("'presence' is not available for non-token node")
     }
   }
 
   @_spi(RawSyntax)
   public var tokenDiagnostic: TokenDiagnostic? {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return dat.tokenDiagnostic
-    case .materializedToken(let dat):
-      return dat.tokenDiagnostic
-    case .layout(_):
+    switch raw.header {
+    case .parsedToken:
+      return raw.asParsedToken.pointee.tokenDiagnostic
+    case .materializedToken:
+      return raw.asMaterializedToken.pointee.tokenDiagnostic
+    case .layout:
       preconditionFailure("'tokenDiagnostic' is not available for non-token node")
     }
   }
@@ -283,11 +294,12 @@ public struct RawSyntaxTokenView: Sendable {
   @_spi(RawSyntax)
   public func withTokenDiagnostic(tokenDiagnostic: TokenDiagnostic?, arena: RawSyntaxArena) -> RawTokenSyntax {
     arena.addChild(self.raw.arenaReference)
-    switch raw.rawData.payload {
-    case .parsedToken(var dat):
+    switch raw.header {
+    case .parsedToken:
+      var dat = raw.asParsedToken.pointee
       if arena == self.raw.arenaReference {
         dat.tokenDiagnostic = tokenDiagnostic
-        return RawSyntax(arena: arena, payload: .parsedToken(dat)).cast(RawTokenSyntax.self)
+        return RawSyntax(arena: arena, parsedToken: dat).cast(RawTokenSyntax.self)
       }
       // If the modified token is allocated in a different arena, it might have
       // a different or no `parseTrivia` function. We thus cannot use a
@@ -300,9 +312,10 @@ public struct RawSyntaxTokenView: Sendable {
         tokenDiagnostic: tokenDiagnostic,
         arena: arena
       ).cast(RawTokenSyntax.self)
-    case .materializedToken(var dat):
+    case .materializedToken:
+      var dat = raw.asMaterializedToken.pointee
       dat.tokenDiagnostic = tokenDiagnostic
-      return RawSyntax(arena: arena, payload: .materializedToken(dat)).cast(RawTokenSyntax.self)
+      return RawSyntax(arena: arena, materializedToken: dat).cast(RawTokenSyntax.self)
     default:
       preconditionFailure("'withTokenDiagnostic' is not available for non-token node")
     }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -44,9 +44,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var rawKind: RawTokenKind {
     switch raw.header {
     case .materializedToken:
-      return raw.asMaterializedToken.pointee.tokenKind
+      return raw.asMaterializedToken.tokenKind
     case .parsedToken:
-      return raw.asParsedToken.pointee.tokenKind
+      return raw.asParsedToken.tokenKind
     case .layout:
       preconditionFailure("'tokenKind' is not available for non-token node")
     }
@@ -57,9 +57,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var rawText: SyntaxText {
     switch raw.header {
     case .parsedToken:
-      return raw.asParsedToken.pointee.tokenText
+      return raw.asParsedToken.tokenText
     case .materializedToken:
-      return raw.asMaterializedToken.pointee.tokenText
+      return raw.asMaterializedToken.tokenText
     case .layout:
       preconditionFailure("'rawText' is not available for non-token node")
     }
@@ -70,9 +70,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var leadingTriviaByteLength: Int {
     switch raw.header {
     case .parsedToken:
-      return raw.asParsedToken.pointee.leadingTriviaText.count
+      return raw.asParsedToken.leadingTriviaText.count
     case .materializedToken:
-      return raw.asMaterializedToken.pointee.leadingTrivia.reduce(0) { $0 + $1.byteLength }
+      return raw.asMaterializedToken.leadingTrivia.reduce(0) { $0 + $1.byteLength }
     case .layout:
       preconditionFailure("'leadingTriviaByteLength' is not available for non-token node")
     }
@@ -83,9 +83,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var trailingTriviaByteLength: Int {
     switch raw.header {
     case .parsedToken:
-      return raw.asParsedToken.pointee.trailingTriviaText.count
+      return raw.asParsedToken.trailingTriviaText.count
     case .materializedToken:
-      return raw.asMaterializedToken.pointee.trailingTrivia.reduce(0) { $0 + $1.byteLength }
+      return raw.asMaterializedToken.trailingTrivia.reduce(0) { $0 + $1.byteLength }
     case .layout:
       preconditionFailure("'trailingTriviaByteLength' is not available for non-token node")
     }
@@ -95,9 +95,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var leadingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.header {
     case .parsedToken:
-      return raw.arenaReference.parseTrivia(source: raw.asParsedToken.pointee.leadingTriviaText, position: .leading)
+      return raw.arenaReference.parseTrivia(source: raw.asParsedToken.leadingTriviaText, position: .leading)
     case .materializedToken:
-      return Array(raw.asMaterializedToken.pointee.leadingTrivia)
+      return Array(raw.asMaterializedToken.leadingTrivia)
     case .layout:
       preconditionFailure("'leadingRawTriviaPieces' is called on non-token raw syntax")
     }
@@ -107,9 +107,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var trailingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.header {
     case .parsedToken:
-      return raw.arenaReference.parseTrivia(source: raw.asParsedToken.pointee.trailingTriviaText, position: .trailing)
+      return raw.arenaReference.parseTrivia(source: raw.asParsedToken.trailingTriviaText, position: .trailing)
     case .materializedToken:
-      return Array(raw.asMaterializedToken.pointee.trailingTrivia)
+      return Array(raw.asMaterializedToken.trailingTrivia)
     case .layout:
       preconditionFailure("'trailingRawTriviaPieces' is called on non-token raw syntax")
     }
@@ -132,9 +132,9 @@ public struct RawSyntaxTokenView: Sendable {
   public func leadingTrivia<T>(_ body: (SyntaxText) -> T) -> T {
     switch raw.header {
     case .parsedToken:
-      return body(raw.asParsedToken.pointee.leadingTriviaText)
+      return body(raw.asParsedToken.leadingTriviaText)
     case .materializedToken:
-      var leadingTriviaStr = Trivia(pieces: raw.asMaterializedToken.pointee.leadingTrivia.map(TriviaPiece.init))
+      var leadingTriviaStr = Trivia(pieces: raw.asMaterializedToken.leadingTrivia.map(TriviaPiece.init))
         .description
       return leadingTriviaStr.withSyntaxText(body)
     case .layout:
@@ -147,9 +147,9 @@ public struct RawSyntaxTokenView: Sendable {
   public func trailingTrivia<T>(_ body: (SyntaxText) -> T) -> T {
     switch raw.header {
     case .parsedToken:
-      return body(raw.asParsedToken.pointee.trailingTriviaText)
+      return body(raw.asParsedToken.trailingTriviaText)
     case .materializedToken:
-      var trailingTriviaStr = Trivia(pieces: raw.asMaterializedToken.pointee.trailingTrivia.map(TriviaPiece.init))
+      var trailingTriviaStr = Trivia(pieces: raw.asMaterializedToken.trailingTrivia.map(TriviaPiece.init))
         .description
       return trailingTriviaStr.withSyntaxText(body)
     case .layout:
@@ -187,7 +187,7 @@ public struct RawSyntaxTokenView: Sendable {
         arena: arena
       )
     case .materializedToken:
-      var payload = raw.asMaterializedToken.pointee
+      var payload = raw.asMaterializedToken.fields
       let decomposed = newValue.decomposeToRaw()
       let rawKind = decomposed.rawKind
       let text: SyntaxText = (decomposed.string.map({ arena.intern($0) }) ?? decomposed.rawKind.defaultText ?? "")
@@ -205,7 +205,7 @@ public struct RawSyntaxTokenView: Sendable {
     arena.addChild(self.raw.arenaReference)
     switch raw.header {
     case .parsedToken:
-      var payload = raw.asParsedToken.pointee
+      var payload = raw.asParsedToken.fields
       if arena == self.raw.arenaReference {
         payload.presence = newValue
         return RawSyntax(arena: arena, parsedToken: payload)
@@ -222,7 +222,7 @@ public struct RawSyntaxTokenView: Sendable {
         arena: arena
       )
     case .materializedToken:
-      var payload = raw.asMaterializedToken.pointee
+      var payload = raw.asMaterializedToken.fields
       payload.presence = newValue
       return RawSyntax(arena: arena, materializedToken: payload)
     default:
@@ -236,9 +236,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var textByteLength: Int {
     switch raw.header {
     case .parsedToken:
-      return raw.asParsedToken.pointee.tokenText.count
+      return raw.asParsedToken.tokenText.count
     case .materializedToken:
-      return raw.asMaterializedToken.pointee.tokenText.count
+      return raw.asMaterializedToken.tokenText.count
     case .layout:
       preconditionFailure("'textByteLength' is not available for non-token node")
     }
@@ -254,13 +254,13 @@ public struct RawSyntaxTokenView: Sendable {
     switch raw.header {
     case .parsedToken:
       return TokenKind.fromRaw(
-        kind: raw.asParsedToken.pointee.tokenKind,
-        text: String(syntaxText: raw.asParsedToken.pointee.tokenText)
+        kind: raw.asParsedToken.tokenKind,
+        text: String(syntaxText: raw.asParsedToken.tokenText)
       )
     case .materializedToken:
       return TokenKind.fromRaw(
-        kind: raw.asMaterializedToken.pointee.tokenKind,
-        text: String(syntaxText: raw.asMaterializedToken.pointee.tokenText)
+        kind: raw.asMaterializedToken.tokenKind,
+        text: String(syntaxText: raw.asMaterializedToken.tokenText)
       )
     case .layout:
       preconditionFailure("'formKind' is not available for non-token node")
@@ -271,9 +271,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var presence: SourcePresence {
     switch raw.header {
     case .parsedToken:
-      return raw.asParsedToken.pointee.presence
+      return raw.asParsedToken.presence
     case .materializedToken:
-      return raw.asMaterializedToken.pointee.presence
+      return raw.asMaterializedToken.presence
     case .layout:
       preconditionFailure("'presence' is not available for non-token node")
     }
@@ -283,9 +283,9 @@ public struct RawSyntaxTokenView: Sendable {
   public var tokenDiagnostic: TokenDiagnostic? {
     switch raw.header {
     case .parsedToken:
-      return raw.asParsedToken.pointee.tokenDiagnostic
+      return raw.asParsedToken.tokenDiagnostic
     case .materializedToken:
-      return raw.asMaterializedToken.pointee.tokenDiagnostic
+      return raw.asMaterializedToken.tokenDiagnostic
     case .layout:
       preconditionFailure("'tokenDiagnostic' is not available for non-token node")
     }
@@ -296,7 +296,7 @@ public struct RawSyntaxTokenView: Sendable {
     arena.addChild(self.raw.arenaReference)
     switch raw.header {
     case .parsedToken:
-      var dat = raw.asParsedToken.pointee
+      var dat = raw.asParsedToken.fields
       if arena == self.raw.arenaReference {
         dat.tokenDiagnostic = tokenDiagnostic
         return RawSyntax(arena: arena, parsedToken: dat).cast(RawTokenSyntax.self)
@@ -313,7 +313,7 @@ public struct RawSyntaxTokenView: Sendable {
         arena: arena
       ).cast(RawTokenSyntax.self)
     case .materializedToken:
-      var dat = raw.asMaterializedToken.pointee
+      var dat = raw.asMaterializedToken.fields
       dat.tokenDiagnostic = tokenDiagnostic
       return RawSyntax(arena: arena, materializedToken: dat).cast(RawTokenSyntax.self)
     default:

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -193,7 +193,7 @@ public struct RawSyntaxTokenView: Sendable {
       let text: SyntaxText = (decomposed.string.map({ arena.intern($0) }) ?? decomposed.rawKind.defaultText ?? "")
       payload.tokenKind = rawKind
       payload.tokenText = text
-      return RawSyntax(arena: arena, materializedToken: payload)
+      return RawSyntax.allocateMaterializedToken(payload, arena: arena)
     default:
       preconditionFailure("'withKind()' is called on non-token raw syntax")
     }
@@ -208,7 +208,7 @@ public struct RawSyntaxTokenView: Sendable {
       var payload = raw.asParsedToken.fields
       if arena == self.raw.arenaReference {
         payload.presence = newValue
-        return RawSyntax(arena: arena, parsedToken: payload)
+        return RawSyntax.allocateParsedToken(payload, arena: arena)
       }
       // If the modified token is allocated in a different arena, it might have
       // a different or no `parseTrivia` function. We thus cannot use a
@@ -224,7 +224,7 @@ public struct RawSyntaxTokenView: Sendable {
     case .materializedToken:
       var payload = raw.asMaterializedToken.fields
       payload.presence = newValue
-      return RawSyntax(arena: arena, materializedToken: payload)
+      return RawSyntax.allocateMaterializedToken(payload, arena: arena)
     default:
       preconditionFailure("'withKind()' is called on non-token raw syntax")
     }
@@ -299,7 +299,7 @@ public struct RawSyntaxTokenView: Sendable {
       var dat = raw.asParsedToken.fields
       if arena == self.raw.arenaReference {
         dat.tokenDiagnostic = tokenDiagnostic
-        return RawSyntax(arena: arena, parsedToken: dat).cast(RawTokenSyntax.self)
+        return RawSyntax.allocateParsedToken(dat, arena: arena).cast(RawTokenSyntax.self)
       }
       // If the modified token is allocated in a different arena, it might have
       // a different or no `parseTrivia` function. We thus cannot use a
@@ -315,7 +315,7 @@ public struct RawSyntaxTokenView: Sendable {
     case .materializedToken:
       var dat = raw.asMaterializedToken.fields
       dat.tokenDiagnostic = tokenDiagnostic
-      return RawSyntax(arena: arena, materializedToken: dat).cast(RawTokenSyntax.self)
+      return RawSyntax.allocateMaterializedToken(dat, arena: arena).cast(RawTokenSyntax.self)
     default:
       preconditionFailure("'withTokenDiagnostic' is not available for non-token node")
     }

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -814,22 +814,23 @@ fileprivate extension RawSyntax {
     handleSourceLocationDirective: (_ position: AbsolutePosition, _ rawSyntax: RawSyntax) -> Void
   ) -> AbsolutePosition {
     var position = position
-    switch self.rawData.payload {
-    case .parsedToken(let dat):
-      position = dat.wholeText.forEachEndOfLine(position: position, body: body)
-    case .materializedToken(let dat):
-      position = dat.leadingTrivia.forEachEndOfLine(position: position, body: body)
-      position = dat.tokenText.forEachEndOfLine(position: position, body: body)
-      position = dat.trailingTrivia.forEachEndOfLine(position: position, body: body)
-    case .layout(let dat):
+    switch self.header {
+    case .parsedToken:
+      position = self.asParsedToken.pointee.wholeText.forEachEndOfLine(position: position, body: body)
+    case .materializedToken:
+      position = self.asMaterializedToken.pointee.leadingTrivia.forEachEndOfLine(position: position, body: body)
+      position = self.asMaterializedToken.pointee.tokenText.forEachEndOfLine(position: position, body: body)
+      position = self.asMaterializedToken.pointee.trailingTrivia.forEachEndOfLine(position: position, body: body)
+    case .layout:
       // Handle '#sourceLocation' directive.
-      if dat.kind == .poundSourceLocation {
+      if self.asLayout.pointee.kind == .poundSourceLocation {
         // Do this before `node.forEachEndOfLine` call below so the caller can
         // know the exact position of the directive.
         handleSourceLocationDirective(position, self)
       }
 
-      for case let node? in dat.layout where SyntaxTreeViewMode.sourceAccurate.shouldTraverse(node: node) {
+      for case let node? in self.asLayout.pointee.layout
+      where SyntaxTreeViewMode.sourceAccurate.shouldTraverse(node: node) {
         position = node.forEachEndOfLine(
           position: position,
           body: body,

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -816,20 +816,20 @@ fileprivate extension RawSyntax {
     var position = position
     switch self.header {
     case .parsedToken:
-      position = self.asParsedToken.pointee.wholeText.forEachEndOfLine(position: position, body: body)
+      position = self.asParsedToken.wholeText.forEachEndOfLine(position: position, body: body)
     case .materializedToken:
-      position = self.asMaterializedToken.pointee.leadingTrivia.forEachEndOfLine(position: position, body: body)
-      position = self.asMaterializedToken.pointee.tokenText.forEachEndOfLine(position: position, body: body)
-      position = self.asMaterializedToken.pointee.trailingTrivia.forEachEndOfLine(position: position, body: body)
+      position = self.asMaterializedToken.leadingTrivia.forEachEndOfLine(position: position, body: body)
+      position = self.asMaterializedToken.tokenText.forEachEndOfLine(position: position, body: body)
+      position = self.asMaterializedToken.trailingTrivia.forEachEndOfLine(position: position, body: body)
     case .layout:
       // Handle '#sourceLocation' directive.
-      if self.asLayout.pointee.kind == .poundSourceLocation {
+      if self.asLayout.kind == .poundSourceLocation {
         // Do this before `node.forEachEndOfLine` call below so the caller can
         // know the exact position of the directive.
         handleSourceLocationDirective(position, self)
       }
 
-      for case let node? in self.asLayout.pointee.layout
+      for case let node? in self.asLayout.layout
       where SyntaxTreeViewMode.sourceAccurate.shouldTraverse(node: node) {
         position = node.forEachEndOfLine(
           position: position,

--- a/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
@@ -25,11 +25,15 @@ final class MemoryLayoutTest: XCTestCase {
     /// numbers as low as possible, nothing should rely on them, and are not hard
     /// limits in any way.
     /// If this fails, just update the numbers.
+    ///
+    /// A node is a ``RawSyntaxData`` header followed by the fields of the shape
+    /// that header names, in one allocation, so what a node costs is the header
+    /// plus one of the three strides below rather than the largest of them.
     let expected: [String: SyntaxMemoryLayout.Value] = [
       "RawSyntaxData.Layout": .init(size: 41, stride: 48, alignment: 8),
       "RawSyntaxData.ParsedToken": .init(size: 44, stride: 48, alignment: 8),
       "RawSyntaxData.MaterializedToken": .init(size: 52, stride: 56, alignment: 8),
-      "RawSyntaxData": .init(size: 64, stride: 64, alignment: 8),
+      "RawSyntaxData": .init(size: 8, stride: 8, alignment: 8),
       "RawSyntax?": .init(size: 8, stride: 8, alignment: 8),
 
       "Syntax": .init(size: 16, stride: 16, alignment: 8),


### PR DESCRIPTION
`RawSyntaxData` was a tagged union, a `Payload` enum sized for the largest shape plus an arena reference beside it. So every node cost 64 bytes regardless of the payload. Now it is a one-word header followed by the fields of the shape that header names, in one allocation.

- Turns `RawSyntaxData` into the header: one word packing the arena reference and the discriminator.
- Tail allocate the payload immediately past the header, so a node takes room for its own shape rather than the largest one.

**8.4% less memory** over the 749-file corpus: 254,892,666 bytes of arena down to 233,488,314, and a tree from 26.45× to 24.23× its source. Slab capacity falls 7.9%; the truth is between the two, the first excluding alignment padding and the second including the last slab's unused tail.

Source-breaking for `@_spi(RawSyntax)` clients: `RawSyntaxData` becomes an enum, its nested `Payload` is gone, and `RawSyntax.rawData` is removed.

Optimizing each payload (`RawSyntaxData.Layout`, et al) is planned as follow-ups.