### PR TITLE
[Namespaces] Add experimental namespace syntax and parsing

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -1663,6 +1663,48 @@ public let DECL_NODES: [Node] = [
   ),
 
   Node(
+    kind: .namespaceDecl,
+    base: .decl,
+    experimentalFeature: .namespaces,
+    nameForDiagnostics: "namespace",
+    documentation: "A declaration that introduces a namespace.",
+    traits: [
+      "NamedDecl",
+      "WithAttributes",
+      "WithModifiers",
+    ],
+    children: [
+      Child(
+        name: "attributes",
+        kind: .collection(kind: .attributeList, collectionElementName: "Attribute", defaultsToEmpty: true),
+        nameForDiagnostics: "attributes",
+        documentation: "Attributes written before the namespace declaration. These are retained for diagnostics."
+      ),
+      Child(
+        name: "modifiers",
+        kind: .collection(kind: .declModifierList, collectionElementName: "Modifier", defaultsToEmpty: true),
+        nameForDiagnostics: "modifiers",
+        documentation: "Modifiers written before the namespace declaration. These are retained for diagnostics."
+      ),
+      Child(
+        name: "namespaceKeyword",
+        kind: .token(choices: [.keyword(.namespace)]),
+        documentation: "The `namespace` keyword for this declaration."
+      ),
+      Child(
+        name: "name",
+        kind: .token(choices: [.token(.identifier)]),
+        documentation: "The name of the namespace."
+      ),
+      Child(
+        name: "memberBlock",
+        kind: .node(kind: .memberBlock),
+        documentation: "The declarations contained in the namespace."
+      ),
+    ]
+  ),
+
+  Node(
     kind: .declModifierList,
     base: .syntaxCollection,
     nameForDiagnostics: nil,

--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -25,6 +25,7 @@ public enum ExperimentalFeature: String, CaseIterable {
   case borrowAndMutateAccessors
   case literalExpressions
   case calledAttribute
+  case namespaces
   case _test_EverythingUnexpected
 
   /// The name of the feature as it is written in the compiler's `Features.def` file.
@@ -54,6 +55,8 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "LiteralExpressions"
     case .calledAttribute:
       return "CalledAttribute"
+    case .namespaces:
+      return "Namespaces"
     case ._test_EverythingUnexpected:
       return "_test_EverythingUnexpected"
     }
@@ -86,6 +89,8 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "constant-foldable literal expressions"
     case .calledAttribute:
       return "`@called(...)` attribute on function types"
+    case .namespaces:
+      return "namespace declarations"
     case ._test_EverythingUnexpected:
       return "a test feature that parses everything as unexpected"
     }

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -205,6 +205,7 @@ public enum Keyword: CaseIterable {
   case mutableAddressWithNativeOwner
   case mutableAddressWithOwner
   case mutating
+  case namespace
   case `nil`
   case noasync
   case noDerivative
@@ -549,6 +550,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("mutableAddressWithOwner")
     case .mutating:
       return KeywordSpec("mutating")
+    case .namespace:
+      return KeywordSpec("namespace", experimentalFeature: .namespaces)
     case .nil:
       return KeywordSpec("nil", isLexerClassified: true)
     case .noasync:

--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -210,6 +210,7 @@ public enum SyntaxNodeKind: String, CaseIterable, IdentifierConvertible, TypeCon
   case multipleTrailingClosureElement
   case multipleTrailingClosureElementList
   case namedOpaqueReturnType
+  case namespaceDecl
   case nilLiteralExpr
   case nonisolatedSpecifierArgument
   case nonisolatedSpecifierArgumentList

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -80,6 +80,12 @@ extension TokenConsumer {
       }
     }
 
+    if subparser.atStartOfNamespaceDeclaration(
+      allowRecovery: hasAttribute || hasModifier || requiresDecl
+    ) {
+      return true
+    }
+
     switch subparser.at(anyIn: DeclarationKeyword.self)?.0 {
     case .lhs(.actor):
       // actor Foo {}
@@ -145,7 +151,129 @@ extension TokenConsumer {
   }
 }
 
+extension TokenConsumer {
+  /// Returns whether the current token begins a namespace declaration.
+  ///
+  /// `namespace` is intentionally contextual. In mixed declaration and
+  /// expression contexts, require a complete declaration-shaped header and
+  /// body opener so ordinary identifier uses continue to parse as expressions.
+  /// In declaration-only contexts, or after attributes or modifiers have
+  /// established declaration intent, also accept missing syntax for recovery.
+  fileprivate mutating func atStartOfNamespaceDeclaration(allowRecovery: Bool) -> Bool {
+    guard languageFeatures.contains(.namespaces), self.at(.keyword(.namespace)) else {
+      return false
+    }
+
+    var lookahead = self.lookahead()
+    lookahead.consumeAnyToken()
+    if lookahead.at(.identifier) {
+      lookahead.consumeAnyToken()
+      if lookahead.at(.leftBrace) {
+        return true
+      }
+      if lookahead.atStartOfMalformedNamespaceHeaderEndingInMemberBlock() {
+        return true
+      }
+      return allowRecovery
+    }
+
+    if allowRecovery && lookahead.at(.leftBrace, .rightBrace, .endOfFile) {
+      return true
+    }
+
+    // A malformed name immediately followed by a body is unambiguous enough
+    // to recover as a namespace declaration even in a mixed declaration and
+    // expression context.
+    if lookahead.currentToken.isLexerClassifiedKeyword
+      || lookahead.at(.integerLiteral, .floatLiteral, .dollarIdentifier)
+      || lookahead.at(.wildcard, .unknown)
+    {
+      lookahead.consumeAnyToken()
+      return lookahead.at(.leftBrace)
+    }
+
+    return false
+  }
+}
+
 extension Parser.Lookahead {
+  /// Recognizes the unsupported namespace-head forms that the parser retains
+  /// as structured unexpected syntax. Requiring the eventual left brace keeps
+  /// this recovery from claiming ordinary identifier-shaped expressions.
+  fileprivate mutating func atStartOfMalformedNamespaceHeaderEndingInMemberBlock() -> Bool {
+    var consumedMalformedSyntax = false
+
+    while self.consume(if: .period) != nil {
+      guard self.consume(if: .identifier) != nil else {
+        return false
+      }
+      consumedMalformedSyntax = true
+    }
+
+    if self.at(prefix: "<") {
+      guard self.consumeNamespaceGenericParameterClause() else {
+        return false
+      }
+      consumedMalformedSyntax = true
+    }
+
+    if self.consume(if: .colon) != nil {
+      guard self.canParseType() else {
+        return false
+      }
+      while self.consume(if: .comma) != nil {
+        guard self.canParseType() else {
+          return false
+        }
+      }
+      consumedMalformedSyntax = true
+    }
+
+    if self.consume(if: .keyword(.where)) != nil {
+      repeat {
+        guard self.canParseType() || self.canParseIntegerLiteral() else {
+          return false
+        }
+        if self.consume(if: .colon) == nil {
+          guard self.currentToken.tokenText == "==" else {
+            return false
+          }
+          self.consumeAnyToken()
+        }
+        guard self.canParseType() || self.canParseIntegerLiteral() else {
+          return false
+        }
+      } while self.consume(if: .comma) != nil
+      consumedMalformedSyntax = true
+    }
+
+    return consumedMalformedSyntax && self.at(.leftBrace)
+  }
+
+  /// Consumes a balanced angle-bracket clause without assigning it semantic
+  /// meaning. The real parser subsequently builds a generic-parameter node and
+  /// retains it as unexpected syntax on the namespace declaration.
+  private mutating func consumeNamespaceGenericParameterClause() -> Bool {
+    guard self.consume(ifPrefix: "<", as: .leftAngle) != nil else {
+      return false
+    }
+
+    var depth = 1
+    while !self.at(.endOfFile, .leftBrace, .rightBrace) {
+      if self.consume(ifPrefix: "<", as: .leftAngle) != nil {
+        depth += 1
+      } else if self.consume(ifPrefix: ">", as: .rightAngle) != nil {
+        depth -= 1
+        if depth == 0 {
+          return true
+        }
+      } else {
+        self.consumeAnyToken()
+      }
+    }
+    return false
+  }
+
   fileprivate mutating func skipAttributesAndModifiers() -> (hasAttribute: Bool, hasModifier: Bool) {
     var hasAttribute = false
     var attributeProgress = LoopProgressCondition()
@@ -290,6 +418,14 @@ extension Parser {
       modifiers: self.parseDeclModifierList()
     )
 
+    if self.atStartOfNamespaceDeclaration(
+      allowRecovery: context.requiresDecl || !attrs.attributes.isEmpty || !attrs.modifiers.isEmpty
+    ) {
+      return RawDeclSyntax(
+        self.parseNamespaceDeclaration(attrs, .constant(.keyword(.namespace)))
+      )
+    }
+
     let recoveryResult: (match: DeclarationKeyword, handle: RecoveryConsumptionHandle)?
     if let atResult = self.at(anyIn: DeclarationKeyword.self) {
       // We are at a keyword that starts a declaration. Parse that declaration.
@@ -383,6 +519,55 @@ extension Parser {
         modifiers: attrs.modifiers,
         arena: self.arena
       )
+    )
+  }
+}
+
+extension Parser {
+  mutating func parseNamespaceDeclaration(
+    _ attrs: DeclAttributes,
+    _ namespaceHandle: RecoveryConsumptionHandle
+  ) -> RawNamespaceDeclSyntax {
+    let (unexpectedBeforeNamespaceKeyword, namespaceKeyword) = self.eat(namespaceHandle)
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
+
+    var unexpectedAfterName: [RawSyntax] = []
+
+    // Namespace names are a single identifier. Preserve dotted components as
+    // structured unexpected syntax for targeted diagnostics downstream.
+    while let period = self.consume(if: .period) {
+      unexpectedAfterName.append(period.raw)
+      let (unexpectedBeforeComponent, component) = self.expectIdentifier(keywordRecovery: true)
+      if let unexpectedBeforeComponent {
+        unexpectedAfterName.append(contentsOf: unexpectedBeforeComponent.elements)
+      }
+      unexpectedAfterName.append(component.raw)
+    }
+
+    // These clauses aren't part of a namespace head, but parsing them into
+    // their normal syntax nodes retains enough structure for precise parser or
+    // compiler diagnostics instead of flattening them into skipped tokens.
+    if self.at(prefix: "<") {
+      unexpectedAfterName.append(self.parseGenericParameters().raw)
+    }
+    if self.at(.colon) {
+      unexpectedAfterName.append(self.parseInheritance().raw)
+    }
+    if self.at(.keyword(.where)) {
+      unexpectedAfterName.append(self.parseGenericWhereClause().raw)
+    }
+
+    let memberBlock = self.parseMemberBlock(introducer: namespaceKeyword)
+    return RawNamespaceDeclSyntax(
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeNamespaceKeyword,
+      namespaceKeyword: namespaceKeyword,
+      unexpectedBeforeName,
+      name: name,
+      RawUnexpectedNodesSyntax(unexpectedAfterName, arena: self.arena),
+      memberBlock: memberBlock,
+      arena: self.arena
     )
   }
 }

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -159,7 +159,7 @@ extension TokenConsumer {
   /// body opener so ordinary identifier uses continue to parse as expressions.
   /// In declaration-only contexts, or after attributes or modifiers have
   /// established declaration intent, also accept missing syntax for recovery.
-  fileprivate mutating func atStartOfNamespaceDeclaration(allowRecovery: Bool) -> Bool {
+  mutating func atStartOfNamespaceDeclaration(allowRecovery: Bool) -> Bool {
     guard languageFeatures.contains(.namespaces), self.at(.keyword(.namespace)) else {
       return false
     }

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -21,6 +21,14 @@ extension Parser {
     var elements = [RawDeclModifierSyntax]()
     var modifierLoopProgress = LoopProgressCondition()
     MODIFIER_LOOP: while self.hasProgressed(&modifierLoopProgress) {
+      // `namespace` is contextual and intentionally absent from
+      // `DeclarationStart`. Once a declaration-shaped spelling is at the
+      // current token, do not let modifier recovery skip across it to a
+      // modifier on a later declaration.
+      if self.atStartOfNamespaceDeclaration(allowRecovery: false) {
+        break
+      }
+
       switch self.canRecoverTo(anyIn: DeclarationStart.self) {
       case (.declarationModifier(.private), _)?,
         (.declarationModifier(.fileprivate), _)?,

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -220,7 +220,7 @@ enum TokenPrecedence: Comparable {
 
     // MARK: Decl keywords
     case  // Types
-    .associatedtype, .class, .enum, .extension, .protocol, .struct, .typealias, .actor, .macro,
+    .associatedtype, .class, .enum, .extension, .protocol, .struct, .typealias, .actor, .macro, .namespace,
       // Access modifiers
       .fileprivate, .internal, .private, .public, .static,
       // Functions

--- a/Sources/SwiftParser/generated/LanguageFeatures.swift
+++ b/Sources/SwiftParser/generated/LanguageFeatures.swift
@@ -76,9 +76,13 @@ extension Parser.LanguageFeatures {
   @_spi(ExperimentalLanguageFeatures)
   public static let calledAttribute = Self (rawValue: 1 << 11)
 
+  /// Whether to enable the parsing of namespace declarations.
+  @_spi(ExperimentalLanguageFeatures)
+  public static let namespaces = Self (rawValue: 1 << 12)
+
   /// Whether to enable the parsing of a test feature that parses everything as unexpected.
   @_spi(ExperimentalLanguageFeatures)
-  public static let _test_EverythingUnexpected = Self (rawValue: 1 << 12)
+  public static let _test_EverythingUnexpected = Self (rawValue: 1 << 13)
 
   /// Creates a new value representing the experimental feature with the
   /// given name, or returns nil if the name is not recognized.
@@ -109,6 +113,8 @@ extension Parser.LanguageFeatures {
       self = .literalExpressions
     case "CalledAttribute":
       self = .calledAttribute
+    case "Namespaces":
+      self = .namespaces
     case "_test_EverythingUnexpected":
       self = ._test_EverythingUnexpected
     default:

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -269,6 +269,10 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "'::' operator"
   case \MultipleTrailingClosureElementSyntax.label:
     return "label"
+  case \NamespaceDeclSyntax.attributes:
+    return "attributes"
+  case \NamespaceDeclSyntax.modifiers:
+    return "modifiers"
   case \ObjCSelectorPieceSyntax.name:
     return "name"
   case \OperatorDeclSyntax.fixitySpecifier:

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -296,6 +296,8 @@ extension SyntaxKind {
       return "trailing closure"
     case .namedOpaqueReturnType:
       return "named opaque return type"
+    case .namespaceDecl:
+      return "namespace"
     case .nonisolatedTypeSpecifier:
       return "'nonisolated' specifier"
     case .objCSelectorPieceList:

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -2398,6 +2398,28 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "type"
   case \NamedOpaqueReturnTypeSyntax.unexpectedAfterType:
     return "unexpectedAfterType"
+  case \NamespaceDeclSyntax.unexpectedBeforeAttributes:
+    return "unexpectedBeforeAttributes"
+  case \NamespaceDeclSyntax.attributes:
+    return "attributes"
+  case \NamespaceDeclSyntax.unexpectedBetweenAttributesAndModifiers:
+    return "unexpectedBetweenAttributesAndModifiers"
+  case \NamespaceDeclSyntax.modifiers:
+    return "modifiers"
+  case \NamespaceDeclSyntax.unexpectedBetweenModifiersAndNamespaceKeyword:
+    return "unexpectedBetweenModifiersAndNamespaceKeyword"
+  case \NamespaceDeclSyntax.namespaceKeyword:
+    return "namespaceKeyword"
+  case \NamespaceDeclSyntax.unexpectedBetweenNamespaceKeywordAndName:
+    return "unexpectedBetweenNamespaceKeywordAndName"
+  case \NamespaceDeclSyntax.name:
+    return "name"
+  case \NamespaceDeclSyntax.unexpectedBetweenNameAndMemberBlock:
+    return "unexpectedBetweenNameAndMemberBlock"
+  case \NamespaceDeclSyntax.memberBlock:
+    return "memberBlock"
+  case \NamespaceDeclSyntax.unexpectedAfterMemberBlock:
+    return "unexpectedAfterMemberBlock"
   case \NilLiteralExprSyntax.unexpectedBeforeNilKeyword:
     return "unexpectedBeforeNilKeyword"
   case \NilLiteralExprSyntax.nilKeyword:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -149,6 +149,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case mutableAddressWithNativeOwner
   case mutableAddressWithOwner
   case mutating
+  @_spi(ExperimentalLanguageFeatures)
+  case namespace
   case `nil`
   case noasync
   case noDerivative
@@ -618,6 +620,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
       self = .extension
     case "lowerThan":
       self = .lowerThan
+    case "namespace":
+      self = .namespace
     case "obsoleted":
       self = .obsoleted
     case "spiModule":
@@ -984,6 +988,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
     "mutableAddressWithNativeOwner",
     "mutableAddressWithOwner",
     "mutating",
+    "namespace",
     "nil",
     "noasync",
     "noDerivative",

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -1581,6 +1581,16 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
 
+  @_spi(ExperimentalLanguageFeatures)
+  override open func visit(_ node: NamespaceDeclSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  @_spi(ExperimentalLanguageFeatures)
+  override open func visitPost(_ node: NamespaceDeclSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+
   override open func visit(_ node: NilLiteralExprSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -215,7 +215,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public init?(_ node: __shared some SyntaxProtocol) {
     switch node.raw.kind {
-    case .accessorDecl, .actorDecl, .associatedTypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typeAliasDecl, .unexpectedCodeDecl, .usingDecl, .variableDecl:
+    case .accessorDecl, .actorDecl, .associatedTypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .namespaceDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typeAliasDecl, .unexpectedCodeDecl, .usingDecl, .variableDecl:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -256,6 +256,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       .node(MacroDeclSyntax.self),
       .node(MacroExpansionDeclSyntax.self),
       .node(MissingDeclSyntax.self),
+      .node(NamespaceDeclSyntax.self),
       .node(OperatorDeclSyntax.self),
       .node(PoundSourceLocationSyntax.self),
       .node(PrecedenceGroupDeclSyntax.self),
@@ -1703,6 +1704,7 @@ extension Syntax {
       .node(MultipleTrailingClosureElementListSyntax.self),
       .node(MultipleTrailingClosureElementSyntax.self),
       .node(NamedOpaqueReturnTypeSyntax.self),
+      .node(NamespaceDeclSyntax.self),
       .node(NilLiteralExprSyntax.self),
       .node(NonisolatedSpecifierArgumentSyntax.self),
       .node(NonisolatedTypeSpecifierSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -214,6 +214,8 @@ public enum SyntaxEnum: Sendable {
   case multipleTrailingClosureElementList(MultipleTrailingClosureElementListSyntax)
   case multipleTrailingClosureElement(MultipleTrailingClosureElementSyntax)
   case namedOpaqueReturnType(NamedOpaqueReturnTypeSyntax)
+  @_spi(ExperimentalLanguageFeatures)
+  case namespaceDecl(NamespaceDeclSyntax)
   case nilLiteralExpr(NilLiteralExprSyntax)
   case nonisolatedSpecifierArgument(NonisolatedSpecifierArgumentSyntax)
   case nonisolatedTypeSpecifier(NonisolatedTypeSpecifierSyntax)
@@ -705,6 +707,8 @@ extension Syntax {
       return .multipleTrailingClosureElement(MultipleTrailingClosureElementSyntax(self)!)
     case .namedOpaqueReturnType:
       return .namedOpaqueReturnType(NamedOpaqueReturnTypeSyntax(self)!)
+    case .namespaceDecl:
+      return .namespaceDecl(NamespaceDeclSyntax(self)!)
     case .nilLiteralExpr:
       return .nilLiteralExpr(NilLiteralExprSyntax(self)!)
     case .nonisolatedSpecifierArgument:
@@ -937,6 +941,8 @@ public enum DeclSyntaxEnum {
   case macroDecl(MacroDeclSyntax)
   case macroExpansionDecl(MacroExpansionDeclSyntax)
   case missingDecl(MissingDeclSyntax)
+  @_spi(ExperimentalLanguageFeatures)
+  case namespaceDecl(NamespaceDeclSyntax)
   case operatorDecl(OperatorDeclSyntax)
   case poundSourceLocation(PoundSourceLocationSyntax)
   case precedenceGroupDecl(PrecedenceGroupDeclSyntax)
@@ -986,6 +992,8 @@ extension DeclSyntax {
       return .macroExpansionDecl(MacroExpansionDeclSyntax(self)!)
     case .missingDecl:
       return .missingDecl(MissingDeclSyntax(self)!)
+    case .namespaceDecl:
+      return .namespaceDecl(NamespaceDeclSyntax(self)!)
     case .operatorDecl:
       return .operatorDecl(OperatorDeclSyntax(self)!)
     case .poundSourceLocation:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -214,6 +214,8 @@ public enum SyntaxKind: Sendable {
   case multipleTrailingClosureElementList
   case multipleTrailingClosureElement
   case namedOpaqueReturnType
+  @_spi(ExperimentalLanguageFeatures)
+  case namespaceDecl
   case nilLiteralExpr
   case nonisolatedSpecifierArgument
   case nonisolatedTypeSpecifier
@@ -830,6 +832,8 @@ public enum SyntaxKind: Sendable {
       return MultipleTrailingClosureElementSyntax.self
     case .namedOpaqueReturnType:
       return NamedOpaqueReturnTypeSyntax.self
+    case .namespaceDecl:
+      return NamespaceDeclSyntax.self
     case .nilLiteralExpr:
       return NilLiteralExprSyntax.self
     case .nonisolatedSpecifierArgument:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -1425,6 +1425,14 @@ open class SyntaxRewriter {
     return TypeSyntax(NamedOpaqueReturnTypeSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
   }
 
+  /// Visit a `NamespaceDeclSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  @_spi(ExperimentalLanguageFeatures)
+  open func visit(_ node: NamespaceDeclSyntax) -> DeclSyntax {
+    return DeclSyntax(NamespaceDeclSyntax(unsafeCasting: visitChildren(node._syntaxNode)))
+  }
+
   /// Visit a ``NilLiteralExprSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3143,6 +3151,11 @@ open class SyntaxRewriter {
   }
 
   @inline(never)
+  private func visitNamespaceDeclSyntaxImpl(_ node: Syntax) -> Syntax {
+    Syntax(visit(NamespaceDeclSyntax(unsafeCasting: node)))
+  }
+
+  @inline(never)
   private func visitNilLiteralExprSyntaxImpl(_ node: Syntax) -> Syntax {
     Syntax(visit(NilLiteralExprSyntax(unsafeCasting: node)))
   }
@@ -4071,6 +4084,8 @@ open class SyntaxRewriter {
       return self.visitMultipleTrailingClosureElementSyntaxImpl(_:)
     case .namedOpaqueReturnType:
       return self.visitNamedOpaqueReturnTypeSyntaxImpl(_:)
+    case .namespaceDecl:
+      return self.visitNamespaceDeclSyntaxImpl(_:)
     case .nilLiteralExpr:
       return self.visitNilLiteralExprSyntaxImpl(_:)
     case .nonisolatedSpecifierArgument:
@@ -4667,6 +4682,8 @@ open class SyntaxRewriter {
       return visitMultipleTrailingClosureElementSyntaxImpl(node)
     case .namedOpaqueReturnType:
       return visitNamedOpaqueReturnTypeSyntaxImpl(node)
+    case .namespaceDecl:
+      return visitNamespaceDeclSyntaxImpl(node)
     case .nilLiteralExpr:
       return visitNilLiteralExprSyntaxImpl(node)
     case .nonisolatedSpecifierArgument:

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -807,6 +807,8 @@ extension MissingSyntax: MissingNodeSyntax {}
 
 extension MissingTypeSyntax: MissingNodeSyntax {}
 
+extension NamespaceDeclSyntax: NamedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+
 extension NonisolatedSpecifierArgumentSyntax: ParenthesizedSyntax {}
 
 extension OperatorDeclSyntax: NamedDeclSyntax {}

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -2311,6 +2311,20 @@ open class SyntaxVisitor {
   open func visitPost(_ node: NamedOpaqueReturnTypeSyntax) {
   }
 
+  /// Visiting `NamespaceDeclSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  @_spi(ExperimentalLanguageFeatures)
+  open func visit(_ node: NamespaceDeclSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `NamespaceDeclSyntax` and its descendants.
+  ///   - node: the node we just finished visiting.
+  @_spi(ExperimentalLanguageFeatures)
+  open func visitPost(_ node: NamespaceDeclSyntax) {
+  }
+
   /// Visiting ``NilLiteralExprSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -5099,6 +5113,14 @@ open class SyntaxVisitor {
   }
 
   @inline(never)
+  private func visitNamespaceDeclSyntaxImpl(_ node: Syntax) {
+    if visit(NamespaceDeclSyntax(unsafeCasting: node)) == .visitChildren {
+      visitChildren(node)
+    }
+    visitPost(NamespaceDeclSyntax(unsafeCasting: node))
+  }
+
+  @inline(never)
   private func visitNilLiteralExprSyntaxImpl(_ node: Syntax) {
     if visit(NilLiteralExprSyntax(unsafeCasting: node)) == .visitChildren {
       visitChildren(node)
@@ -6342,6 +6364,8 @@ open class SyntaxVisitor {
       return self.visitMultipleTrailingClosureElementSyntaxImpl(_:)
     case .namedOpaqueReturnType:
       return self.visitNamedOpaqueReturnTypeSyntaxImpl(_:)
+    case .namespaceDecl:
+      return self.visitNamespaceDeclSyntaxImpl(_:)
     case .nilLiteralExpr:
       return self.visitNilLiteralExprSyntaxImpl(_:)
     case .nonisolatedSpecifierArgument:
@@ -6938,6 +6962,8 @@ open class SyntaxVisitor {
       self.visitMultipleTrailingClosureElementSyntaxImpl(node)
     case .namedOpaqueReturnType:
       self.visitNamedOpaqueReturnTypeSyntaxImpl(node)
+    case .namespaceDecl:
+      self.visitNamespaceDeclSyntaxImpl(node)
     case .nilLiteralExpr:
       self.visitNilLiteralExprSyntaxImpl(node)
     case .nonisolatedSpecifierArgument:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesD.swift
@@ -511,7 +511,7 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
 
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .accessorDecl, .actorDecl, .associatedTypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typeAliasDecl, .unexpectedCodeDecl, .usingDecl, .variableDecl:
+    case .accessorDecl, .actorDecl, .associatedTypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .namespaceDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typeAliasDecl, .unexpectedCodeDecl, .usingDecl, .variableDecl:
       return true
     default:
       return false

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesJKLMN.swift
@@ -3006,6 +3006,113 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol {
   }
 }
 
+@_spi(ExperimentalLanguageFeatures)
+@_spi(RawSyntax)
+public struct RawNamespaceDeclSyntax: RawDeclSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .namespaceDecl
+  }
+
+  public var raw: RawSyntax
+
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+
+  public init?(_ other: some RawSyntaxNodeProtocol) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? = nil,
+    attributes: RawAttributeListSyntax,
+    _ unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? = nil,
+    modifiers: RawDeclModifierListSyntax,
+    _ unexpectedBetweenModifiersAndNamespaceKeyword: RawUnexpectedNodesSyntax? = nil,
+    namespaceKeyword: RawTokenSyntax,
+    _ unexpectedBetweenNamespaceKeywordAndName: RawUnexpectedNodesSyntax? = nil,
+    name: RawTokenSyntax,
+    _ unexpectedBetweenNameAndMemberBlock: RawUnexpectedNodesSyntax? = nil,
+    memberBlock: RawMemberBlockSyntax,
+    _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil,
+    arena: __shared RawSyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .namespaceDecl, uninitializedCount: 11, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeAttributes?.raw
+      layout[1] = attributes.raw
+      layout[2] = unexpectedBetweenAttributesAndModifiers?.raw
+      layout[3] = modifiers.raw
+      layout[4] = unexpectedBetweenModifiersAndNamespaceKeyword?.raw
+      layout[5] = namespaceKeyword.raw
+      layout[6] = unexpectedBetweenNamespaceKeywordAndName?.raw
+      layout[7] = name.raw
+      layout[8] = unexpectedBetweenNameAndMemberBlock?.raw
+      layout[9] = memberBlock.raw
+      layout[10] = unexpectedAfterMemberBlock?.raw
+    }
+    self.init(unchecked: raw)
+  }
+
+  public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var attributes: RawAttributeListSyntax {
+    layoutView.children[1].map(RawAttributeListSyntax.init(raw:))!
+  }
+
+  public var unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var modifiers: RawDeclModifierListSyntax {
+    layoutView.children[3].map(RawDeclModifierListSyntax.init(raw:))!
+  }
+
+  public var unexpectedBetweenModifiersAndNamespaceKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var namespaceKeyword: RawTokenSyntax {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+
+  public var unexpectedBetweenNamespaceKeywordAndName: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var name: RawTokenSyntax {
+    layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+
+  public var unexpectedBetweenNameAndMemberBlock: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+
+  public var memberBlock: RawMemberBlockSyntax {
+    layoutView.children[9].map(RawMemberBlockSyntax.init(raw:))!
+  }
+
+  public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
 @_spi(RawSyntax)
 public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol {
   @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2167,6 +2167,20 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 3, verify(layout[3], as: RawTypeSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   }
+  func validateNamespaceDeclSyntax(kind: SyntaxKind, layout: RawSyntaxBuffer) {
+    assert(layout.count == 11)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawAttributeListSyntax.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawDeclModifierListSyntax.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [.keyword("namespace")]))
+    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
+    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 9, verify(layout[9], as: RawMemberBlockSyntax.self))
+    assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
+  }
   func validateNilLiteralExprSyntax(kind: SyntaxKind, layout: RawSyntaxBuffer) {
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -3556,6 +3570,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     validateMultipleTrailingClosureElementSyntax(kind: kind, layout: layout)
   case .namedOpaqueReturnType:
     validateNamedOpaqueReturnTypeSyntax(kind: kind, layout: layout)
+  case .namespaceDecl:
+    validateNamespaceDeclSyntax(kind: kind, layout: layout)
   case .nilLiteralExpr:
     validateNilLiteralExprSyntax(kind: kind, layout: layout)
   case .nonisolatedSpecifierArgument:

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -5647,6 +5647,278 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _
   ])
 }
 
+// MARK: - NamespaceDeclSyntax
+
+/// A declaration that introduces a namespace.
+///
+/// - Note: Requires experimental feature `namespaces`.
+///
+/// ### Children
+///
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``DeclModifierListSyntax``
+///  - `namespaceKeyword`: `namespace`
+///  - `name`: `<identifier>`
+///  - `memberBlock`: ``MemberBlockSyntax``
+@_spi(ExperimentalLanguageFeatures)
+public struct NamespaceDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
+  public let _syntaxNode: Syntax
+
+  public init?(_ node: __shared some SyntaxProtocol) {
+    guard node.raw.kind == .namespaceDecl else {
+      return nil
+    }
+    self._syntaxNode = node._syntaxNode
+  }
+
+  @_transparent
+  init(unsafeCasting node: Syntax) {
+    self._syntaxNode = node
+  }
+
+  /// - Parameters:
+  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - attributes: Attributes written before the namespace declaration. These are retained for diagnostics.
+  ///   - modifiers: Modifiers written before the namespace declaration. These are retained for diagnostics.
+  ///   - namespaceKeyword: The `namespace` keyword for this declaration.
+  ///   - name: The name of the namespace.
+  ///   - memberBlock: The declarations contained in the namespace.
+  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
+    attributes: AttributeListSyntax = [],
+    _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
+    modifiers: DeclModifierListSyntax = [],
+    _ unexpectedBetweenModifiersAndNamespaceKeyword: UnexpectedNodesSyntax? = nil,
+    namespaceKeyword: TokenSyntax = .keyword(.namespace),
+    _ unexpectedBetweenNamespaceKeywordAndName: UnexpectedNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ unexpectedBetweenNameAndMemberBlock: UnexpectedNodesSyntax? = nil,
+    memberBlock: MemberBlockSyntax,
+    _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    // Extend the lifetime of all parameters so their arenas don't get destroyed
+    // before they can be added as children of the new arena.
+    self = withExtendedLifetime((RawSyntaxArena(), (
+      unexpectedBeforeAttributes,
+      attributes,
+      unexpectedBetweenAttributesAndModifiers,
+      modifiers,
+      unexpectedBetweenModifiersAndNamespaceKeyword,
+      namespaceKeyword,
+      unexpectedBetweenNamespaceKeywordAndName,
+      name,
+      unexpectedBetweenNameAndMemberBlock,
+      memberBlock,
+      unexpectedAfterMemberBlock
+    ))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers.raw,
+        unexpectedBetweenModifiersAndNamespaceKeyword?.raw,
+        namespaceKeyword.raw,
+        unexpectedBetweenNamespaceKeywordAndName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndMemberBlock?.raw,
+        memberBlock.raw,
+        unexpectedAfterMemberBlock?.raw
+      ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.namespaceDecl,
+        from: layout,
+        arena: arena,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia
+      )
+      return Syntax.forRoot(raw, rawNodeArena: arena).cast(Self.self)
+    }
+  }
+
+  public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 0)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 0, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  /// Attributes written before the namespace declaration. These are retained for diagnostics.
+  public var attributes: AttributeListSyntax {
+    get {
+      return Syntax(self).child(at: 1)!.cast(AttributeListSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 1, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  /// Adds the provided `element` to the node's `attributes`
+  /// collection.
+  ///
+  /// - param element: The new `Attribute` to add to the node's
+  ///                  `attributes` collection.
+  /// - returns: A copy of the receiver with the provided `Attribute`
+  ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
+  public func addAttribute(_ element: Syntax) -> NamespaceDeclSyntax {
+    var collection: RawSyntax
+    let arena = RawSyntaxArena()
+    if let col = raw.layoutView!.children[1] {
+      collection = col.layoutView!.appending(element.raw, arena: arena)
+    } else {
+      collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
+                                        from: [element.raw], arena: arena)
+    }
+    return Syntax(self)
+      .replacingChild(
+        at: 1,
+        with: collection,
+        rawNodeArena: arena,
+        rawAllocationArena: arena
+      )
+      .cast(NamespaceDeclSyntax.self)
+  }
+
+  public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 2)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 2, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  /// Modifiers written before the namespace declaration. These are retained for diagnostics.
+  public var modifiers: DeclModifierListSyntax {
+    get {
+      return Syntax(self).child(at: 3)!.cast(DeclModifierListSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 3, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  /// Adds the provided `element` to the node's `modifiers`
+  /// collection.
+  ///
+  /// - param element: The new `Modifier` to add to the node's
+  ///                  `modifiers` collection.
+  /// - returns: A copy of the receiver with the provided `Modifier`
+  ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
+  public func addModifier(_ element: DeclModifierSyntax) -> NamespaceDeclSyntax {
+    var collection: RawSyntax
+    let arena = RawSyntaxArena()
+    if let col = raw.layoutView!.children[3] {
+      collection = col.layoutView!.appending(element.raw, arena: arena)
+    } else {
+      collection = RawSyntax.makeLayout(kind: SyntaxKind.declModifierList,
+                                        from: [element.raw], arena: arena)
+    }
+    return Syntax(self)
+      .replacingChild(
+        at: 3,
+        with: collection,
+        rawNodeArena: arena,
+        rawAllocationArena: arena
+      )
+      .cast(NamespaceDeclSyntax.self)
+  }
+
+  public var unexpectedBetweenModifiersAndNamespaceKeyword: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 4)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 4, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  /// The `namespace` keyword for this declaration.
+  ///
+  /// ### Tokens
+  ///
+  /// For syntax trees generated by the parser, this is guaranteed to be `namespace`.
+  public var namespaceKeyword: TokenSyntax {
+    get {
+      return Syntax(self).child(at: 5)!.cast(TokenSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 5, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  public var unexpectedBetweenNamespaceKeywordAndName: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 6)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 6, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  /// The name of the namespace.
+  ///
+  /// ### Tokens
+  ///
+  /// For syntax trees generated by the parser, this is guaranteed to be `<identifier>`.
+  public var name: TokenSyntax {
+    get {
+      return Syntax(self).child(at: 7)!.cast(TokenSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 7, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  public var unexpectedBetweenNameAndMemberBlock: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 8)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 8, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  /// The declarations contained in the namespace.
+  public var memberBlock: MemberBlockSyntax {
+    get {
+      return Syntax(self).child(at: 9)!.cast(MemberBlockSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 9, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  public var unexpectedAfterMemberBlock: UnexpectedNodesSyntax? {
+    get {
+      return Syntax(self).child(at: 10)?.cast(UnexpectedNodesSyntax.self)
+    }
+    set(value) {
+      self = Syntax(self).replacingChild(at: 10, with: Syntax(value), rawAllocationArena: RawSyntaxArena()).cast(NamespaceDeclSyntax.self)
+    }
+  }
+
+  public static let structure: SyntaxNodeStructure = .layout([
+    \Self.unexpectedBeforeAttributes,
+    \Self.attributes,
+    \Self.unexpectedBetweenAttributesAndModifiers,
+    \Self.modifiers,
+    \Self.unexpectedBetweenModifiersAndNamespaceKeyword,
+    \Self.namespaceKeyword,
+    \Self.unexpectedBetweenNamespaceKeywordAndName,
+    \Self.name,
+    \Self.unexpectedBetweenNameAndMemberBlock,
+    \Self.memberBlock,
+    \Self.unexpectedAfterMemberBlock
+  ])
+}
+
 // MARK: - NilLiteralExprSyntax
 
 /// ### Children

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -1201,6 +1201,41 @@ extension MemberBlockSyntax {
   }
 }
 
+extension NamespaceDeclSyntax {
+  /// A convenience initializer that allows initializing syntax collections using result builders
+  public init(
+    leadingTrivia: Trivia? = nil,
+    unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
+    attributes: AttributeListSyntax = [],
+    unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
+    modifiers: DeclModifierListSyntax = [],
+    unexpectedBetweenModifiersAndNamespaceKeyword: UnexpectedNodesSyntax? = nil,
+    namespaceKeyword: TokenSyntax = .keyword(.namespace),
+    unexpectedBetweenNamespaceKeywordAndName: UnexpectedNodesSyntax? = nil,
+    name: TokenSyntax,
+    unexpectedBetweenNameAndMemberBlock: UnexpectedNodesSyntax? = nil,
+    unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil,
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax,
+    trailingTrivia: Trivia? = nil
+  ) rethrows {
+    try self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeAttributes,
+      attributes: attributes,
+      unexpectedBetweenAttributesAndModifiers,
+      modifiers: modifiers,
+      unexpectedBetweenModifiersAndNamespaceKeyword,
+      namespaceKeyword: namespaceKeyword,
+      unexpectedBetweenNamespaceKeywordAndName,
+      name: name,
+      unexpectedBetweenNameAndMemberBlock,
+      memberBlock: MemberBlockSyntax(members: memberBlockBuilder()),
+      unexpectedAfterMemberBlock,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 extension ProtocolDeclSyntax {
   /// A convenience initializer that allows initializing syntax collections using result builders
   public init(

--- a/Tests/SwiftParserTest/NamespaceDeclarationTests.swift
+++ b/Tests/SwiftParserTest/NamespaceDeclarationTests.swift
@@ -63,6 +63,20 @@ final class NamespaceDeclarationTests: ParserTestCase {
     XCTAssertEqual(declarations[1].memberBlock.members.count, 1)
   }
 
+  func testConsecutiveTopLevelNamespaces() {
+    let source = """
+      namespace Empty {}
+      namespace `switch` {}
+      @available(*, deprecated)
+      public namespace Network {}
+      """
+
+    assertParse(source)
+
+    let declarations = namespaceDeclarations(in: source, languageFeatures: languageFeatures)
+    XCTAssertEqual(declarations.map(\.name.text), ["Empty", "`switch`", "Network"])
+  }
+
   func testNamespaceRemainsAnIdentifierOutsideDeclarationShape() {
     let source = """
       let namespace = 0

--- a/Tests/SwiftParserTest/NamespaceDeclarationTests.swift
+++ b/Tests/SwiftParserTest/NamespaceDeclarationTests.swift
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing) @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import XCTest
+
+final class NamespaceDeclarationTests: ParserTestCase {
+  override var languageFeatures: Parser.LanguageFeatures {
+    [.namespaces]
+  }
+
+  func testFileScopeNamespace() {
+    assertParse(
+      "namespace HTTP {}",
+      substructure: NamespaceDeclSyntax(
+        name: .identifier("HTTP"),
+        memberBlock: MemberBlockSyntax(members: [])
+      )
+    )
+  }
+
+  func testNamespaceMembers() {
+    let source = """
+      namespace HTTP {
+        struct Request {}
+        enum Method {}
+        static let defaultPort = 443
+        static func connect() {}
+      }
+      """
+
+    assertParse(source)
+
+    let declarations = namespaceDeclarations(in: source, languageFeatures: languageFeatures)
+    XCTAssertEqual(declarations.map(\.name.text), ["HTTP"])
+    XCTAssertEqual(declarations[0].memberBlock.members.count, 4)
+  }
+
+  func testNestedNamespace() {
+    let source = """
+      namespace Network {
+        namespace HTTP {
+          struct Request {}
+        }
+      }
+      """
+
+    assertParse(source)
+
+    let declarations = namespaceDeclarations(in: source, languageFeatures: languageFeatures)
+    XCTAssertEqual(declarations.map(\.name.text), ["Network", "HTTP"])
+    XCTAssertEqual(declarations[0].memberBlock.members.count, 1)
+    XCTAssertEqual(declarations[1].memberBlock.members.count, 1)
+  }
+
+  func testNamespaceRemainsAnIdentifierOutsideDeclarationShape() {
+    let source = """
+      let namespace = 0
+      func namespace() {}
+      namespace()
+      namespace(namespace)
+      namespace.member
+      namespace {}
+      """
+
+    assertParse(source)
+    XCTAssertTrue(namespaceDeclarations(in: source, languageFeatures: languageFeatures).isEmpty)
+
+    // Two adjacent identifiers aren't enough to claim a declaration in a
+    // mixed statement/declaration context; the member block must be present.
+    XCTAssertTrue(
+      namespaceDeclarations(
+        in: "func f() { namespace value }",
+        languageFeatures: languageFeatures
+      ).isEmpty
+    )
+  }
+
+  func testNamespaceDeclarationIsFeatureGated() {
+    let declarations = namespaceDeclarations(
+      in: "namespace HTTP {}",
+      languageFeatures: []
+    )
+
+    XCTAssertTrue(declarations.isEmpty)
+  }
+
+  func testAttributesAndModifiersAreRetainedForDiagnostics() {
+    let source = "@testable public namespace HTTP {}"
+
+    assertParse(source)
+
+    let declaration = namespaceDeclarations(in: source, languageFeatures: languageFeatures)[0]
+    XCTAssertEqual(declaration.attributes.count, 1)
+    XCTAssertEqual(declaration.modifiers.count, 1)
+    XCTAssertEqual(declaration.modifiers.first?.name.text, "public")
+  }
+
+  func testMissingMemberBlockAfterModifierEstablishesDeclarationIntent() {
+    let declaration = namespaceDeclarations(
+      in: "public namespace HTTP",
+      languageFeatures: languageFeatures
+    )[0]
+
+    XCTAssertEqual(declaration.memberBlock.leftBrace.presence, .missing)
+    XCTAssertEqual(declaration.memberBlock.rightBrace.presence, .missing)
+  }
+
+  func testMissingNameInDeclarationContext() {
+    let declaration = namespaceDeclarations(
+      in: "struct Container { namespace {} }",
+      languageFeatures: languageFeatures
+    )[0]
+
+    XCTAssertEqual(declaration.name.presence, .missing)
+    XCTAssertEqual(declaration.memberBlock.leftBrace.presence, .present)
+  }
+
+  func testMissingRightBrace() {
+    let declaration = namespaceDeclarations(
+      in: "namespace HTTP {",
+      languageFeatures: languageFeatures
+    )[0]
+
+    XCTAssertEqual(declaration.memberBlock.leftBrace.presence, .present)
+    XCTAssertEqual(declaration.memberBlock.rightBrace.presence, .missing)
+  }
+
+  func testUnsupportedNamespaceHeaderSyntaxIsRecovered() {
+    let sourcesAndNames = [
+      ("namespace Generic<T> {}", "Generic"),
+      ("namespace Inheriting: Protocol {}", "Inheriting"),
+      ("namespace Constrained where T: Protocol {}", "Constrained"),
+      ("namespace Network.HTTP {}", "Network"),
+    ]
+
+    for (source, expectedName) in sourcesAndNames {
+      let declaration = namespaceDeclarations(in: source, languageFeatures: languageFeatures)[0]
+      XCTAssertEqual(declaration.name.text, expectedName)
+      XCTAssertNotNil(declaration.unexpectedBetweenNameAndMemberBlock)
+    }
+  }
+
+  func testMalformedNamespaceNameIsRecovered() {
+    for source in ["namespace class {}", "namespace 123 {}"] {
+      let declaration = namespaceDeclarations(in: source, languageFeatures: languageFeatures)[0]
+      XCTAssertEqual(declaration.name.presence, .missing)
+      XCTAssertNotNil(declaration.unexpectedBetweenNamespaceKeywordAndName)
+      XCTAssertEqual(declaration.memberBlock.leftBrace.presence, .present)
+    }
+  }
+
+  /// Parses without asserting a particular diagnostic spelling. This is useful
+  /// for feature-gating and recovery tests, where the important contract is the
+  /// syntax shape and lossless round trip.
+  private func namespaceDeclarations(
+    in source: String,
+    languageFeatures: Parser.LanguageFeatures
+  ) -> [NamespaceDeclSyntax] {
+    var parser = Parser(source, languageFeatures: languageFeatures)
+    let tree = SourceFileSyntax.parse(from: &parser)
+    XCTAssertEqual(tree.description, source)
+
+    let collector = NamespaceDeclarationCollector(viewMode: .sourceAccurate)
+    collector.walk(tree)
+    return collector.declarations
+  }
+}
+
+private final class NamespaceDeclarationCollector: SyntaxVisitor {
+  var declarations: [NamespaceDeclSyntax] = []
+
+  override func visit(_ node: NamespaceDeclSyntax) -> SyntaxVisitorContinueKind {
+    declarations.append(node)
+    return .visitChildren
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/NamespaceDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/NamespaceDeclTests.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntaxBuilder
+import XCTest
+
+final class NamespaceDeclTests: XCTestCase {
+  func testNamespaceDeclBuilder() {
+    let declaration = NamespaceDeclSyntax(name: "HTTP") {
+      StructDeclSyntax(name: "Request") {}
+    }
+
+    assertBuildResult(
+      declaration,
+      """
+      namespace HTTP {
+          struct Request {
+          }
+      }
+      """
+    )
+  }
+
+  func testNestedNamespaceDeclBuilder() {
+    let declaration = NamespaceDeclSyntax(name: "Network") {
+      NamespaceDeclSyntax(name: "HTTP") {}
+    }
+
+    assertBuildResult(
+      declaration,
+      """
+      namespace Network {
+          namespace HTTP {
+          }
+      }
+      """
+    )
+  }
+
+  func testNamespaceDeclRewriterDispatch() {
+    final class NamespaceRenamer: SyntaxRewriter {
+      override func visit(_ node: NamespaceDeclSyntax) -> DeclSyntax {
+        DeclSyntax(node.with(\.name, .identifier("Transport")))
+      }
+    }
+
+    let declaration = NamespaceDeclSyntax(name: "HTTP") {}
+    let rewritten = NamespaceRenamer(viewMode: .sourceAccurate).rewrite(declaration)
+
+    assertBuildResult(
+      rewritten,
+      """
+      namespace Transport {
+      }
+      """
+    )
+  }
+}


### PR DESCRIPTION
Introduce experimental `namespace Name { ... }` syntax behind the `Namespaces` parser feature. `namespace` remains an ordinary identifier outside declaration intent, and the syntax tree represents a namespace directly with `NamespaceDeclSyntax`.

```swift
namespace BuildProof {
  static func answer() -> Int { 42 }
}
```

This draft is the SwiftSyntax part of a first-class namespace compiler experiment. There is no accepted Swift Evolution proposal associated with this draft; the API and language design remain subject to discussion.

- Add the syntax node and experimental feature through `CodeGeneration`, including generated raw/typed nodes, visitors, rewriters, builders, and diagnostics support.
- Recognize contextual namespace declarations, including consecutive declarations, escaped names, nested member blocks, and narrowly bounded malformed-declaration recovery.
- Preserve ordinary identifier, expression, label, and member-access uses of `namespace`.
- Add parser and builder/round-trip regression coverage.

Companion compiler implementation: https://github.com/swiftlang/swift/pull/92015. The two repositories must be used together for the executable compiler proof; syntax acceptance alone does not provide language semantics. The compiler currently supports direct `static func` members of a single namespace declaration. Reopening, nested types/properties, stable ABI, and complete tooling remain unfinished.

Local validation at `607256cf44a7d5d55e686851c4f5108e54c51964`, based on `d76992252d89c54454c6ed99477dc9f8305117cb`:

- `swift build` and the full `swift test` suite passed on macOS arm64 with Xcode 27 beta 6. The suite includes one intentional known issue and no unexpected failures.
- Integration with the companion compiler passed 35 focused compiler tests, including ASTGen/legacy parser parity and identifier compatibility.
- A two-file executable Swift package builds through `swift build`, prints `42`, and passes clean/no-op/body-edit/interface-edit/feature-off checks with both parser paths.
- `git diff --check` passed. A merge check against upstream `main` at `c37ede18b247338fb1b32b8aff7beed1ae35167a` was clean; the validation above is for the recorded topic commit, not a rebuilt merge result.

Full upstream CI and broader platform validation are pending.
