### PR TITLE
[SwiftWarningControl] Consider code contained in active `#if` to be top-level code

### DIFF
--- a/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
@@ -147,12 +147,17 @@ extension SyntaxProtocol {
   /// Determines if this syntax node is top-level code (not contained in any declaration
   /// or other scoped source in top-level script code).
   func isTopLevelCode() -> Bool {
-    let current = Syntax(self)
-    if current.parent?.is(CodeBlockItemSyntax.self) ?? false,
-      current.parent?.parent?.is(CodeBlockItemListSyntax.self) ?? false,
-      current.parent?.parent?.parent?.is(SourceFileSyntax.self) ?? false
-    {
-      return true
+    var current = Syntax(self)
+    while let parent = current.parent {
+      switch parent.kind {
+      case .sourceFile:
+        return true
+      // Statement lists and active `#if` directives introduce no scope of their own.
+      case .codeBlockItem, .codeBlockItemList, .ifConfigDecl, .ifConfigClauseList, .ifConfigClause:
+        current = parent
+      default:
+        return false
+      }
     }
     return false
   }

--- a/Tests/SwiftWarningControlTest/WarningControlTests.swift
+++ b/Tests/SwiftWarningControlTest/WarningControlTests.swift
@@ -450,6 +450,129 @@ public class WarningGroupControlTests: XCTestCase {
     )
   }
 
+  /// A file-scoped `using @diagnose` nested in an active `#if` clause still
+  /// applies to the whole file.
+  func testFileScopeUsingInsideActiveIfConfig() throws {
+    try assertWarningGroupControl(
+      """
+      0️⃣let x = 1
+      #if STRICT
+      using @diagnose(GroupID, as: error)
+      #endif
+      1️⃣let k = 1
+      """,
+      customConditions: ["STRICT"],
+      languageFeatures: [.defaultIsolationPerFile],
+      diagnosticGroupID: "GroupID",
+      states: [
+        "0️⃣": .error,
+        "1️⃣": .error,
+      ]
+    )
+  }
+
+  /// A file-scoped `using @diagnose` in an inactive `#if` clause contributes nothing.
+  func testFileScopeUsingInsideInactiveIfConfig() throws {
+    try assertWarningGroupControl(
+      """
+      0️⃣let x = 1
+      #if STRICT
+      using @diagnose(GroupID, as: error)
+      #endif
+      1️⃣let k = 1
+      """,
+      languageFeatures: [.defaultIsolationPerFile],
+      diagnosticGroupID: "GroupID",
+      states: [
+        "0️⃣": .none,
+        "1️⃣": .none,
+      ]
+    )
+  }
+
+  /// Each `#if` clause may specify its own file-scoped `using @diagnose`.
+  func testFileScopeUsingIfConfigElseClause() throws {
+    let source =
+      """
+      #if STRICT
+      using @diagnose(GroupID, as: error)
+      #else
+      using @diagnose(GroupID, as: ignored)
+      #endif
+      0️⃣let x = 1
+      """
+
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["STRICT"],
+      languageFeatures: [.defaultIsolationPerFile],
+      diagnosticGroupID: "GroupID",
+      states: ["0️⃣": .error]
+    )
+
+    try assertWarningGroupControl(
+      source,
+      languageFeatures: [.defaultIsolationPerFile],
+      diagnosticGroupID: "GroupID",
+      states: ["0️⃣": .ignored]
+    )
+  }
+
+  /// Nested `#if` directives around a file-scoped `using @diagnose`: the whole
+  /// chain must be active.
+  func testFileScopeUsingInsideNestedIfConfig() throws {
+    let source =
+      """
+      #if OUTER
+      #if INNER
+      using @diagnose(GroupID, as: error)
+      #endif
+      #endif
+      0️⃣let x = 1
+      """
+
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["OUTER", "INNER"],
+      languageFeatures: [.defaultIsolationPerFile],
+      diagnosticGroupID: "GroupID",
+      states: ["0️⃣": .error]
+    )
+
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["INNER"],
+      languageFeatures: [.defaultIsolationPerFile],
+      diagnosticGroupID: "GroupID",
+      states: ["0️⃣": .none]
+    )
+  }
+
+  /// A `using @diagnose` inside an `#if` nested in a type body stays decl-scoped,
+  /// and so contributes no file-level default.
+  func testDeclScopeUsingInsideIfConfigIgnored() throws {
+    try assertWarningGroupControl(
+      """
+      0️⃣let x = 1
+      struct Foo {
+        #if STRICT
+        using @diagnose(GroupID, as: error)
+        #endif
+        var property: Int {
+          1️⃣return 11
+        }
+      }
+      """,
+      customConditions: ["STRICT"],
+      languageFeatures: [.defaultIsolationPerFile],
+      diagnosticGroupID: "GroupID",
+      states: [
+        "0️⃣": .none,
+        "1️⃣": .none,
+      ]
+    )
+  }
+
   func testWarnSpellingBackwardCompat() throws {
     // The old @warn spelling should continue to work as an alias
     try assertWarningGroupControl(


### PR DESCRIPTION
Otherwise, the following example was not respecting `@diagnose`:
```swift
#if COND
using @diagnose(…
#endif
```

Resolves rdar://186937485