### PR TITLE
[Perf][SwiftParser] Ask a spec set for its cases once

### DIFF
--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -127,24 +127,28 @@ extension Parser.Lookahead {
     anyIn specSet: SpecSet.Type,
     overrideRecoveryPrecedence: TokenPrecedence? = nil
   ) -> (match: SpecSet, handle: RecoveryConsumptionHandle)? {
+    // `allCases` builds a fresh array on every call, so fetch it once.
+    let allCases = specSet.allCases
+
     #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
     if shouldRecordAlternativeTokenChoices {
-      recordAlternativeTokenChoice(for: self.currentToken, choices: specSet.allCases.map(\.spec))
+      recordAlternativeTokenChoice(for: self.currentToken, choices: allCases.map(\.spec))
     }
     #endif
 
-    if specSet.allCases.isEmpty {
+    if allCases.isEmpty {
       return nil
     }
 
     let recoveryPrecedence =
-      overrideRecoveryPrecedence ?? specSet.allCases.map({
+      overrideRecoveryPrecedence ?? allCases.lazy.map({
+        // FIXME: Use `\.spec.recoveryPrecedence` (rdar://186588859).
         return $0.spec.recoveryPrecedence
       }).min()!
 
     return self.canRecoverToImpl(
       recoveryPrecedence: recoveryPrecedence,
-      allowAtStartOfLine: specSet.allCases.allSatisfy(\.spec.allowAtStartOfLine),
+      allowAtStartOfLine: allCases.allSatisfy(\.spec.allowAtStartOfLine),
       recursionDepth: 1,
       matchesSpec: { lookahead in
         guard let (specSet, _) = lookahead.at(anyIn: specSet) else { return nil }


### PR DESCRIPTION
`canRecoverTo(anyIn:)` asked `specSet.allCases` three times, and each call builds a fresh array. Hoist it into a local.

1.3% - 2.0% instruction count reduction.
