### PR TITLE
Add experimental _hasTargetFeature predicate for CPU/ISA feature query

### DIFF
--- a/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
+++ b/Sources/SwiftIfConfig/ActiveSyntaxRewriter.swift
@@ -411,7 +411,7 @@ private class FindFeatureCheckVisitor: SyntaxVisitor {
   override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
     if let calleeDeclRef = node.calledExpression.as(DeclReferenceExprSyntax.self),
       let calleeName = calleeDeclRef.simpleIdentifier?.name,
-      calleeName == "compiler" || calleeName == "_compiler_version"
+      calleeName == "compiler" || calleeName == "_compiler_version" || calleeName == "_hasTargetFeature"
     {
       foundFeatureCheck = true
     }

--- a/Sources/SwiftIfConfig/BuildConfiguration.swift
+++ b/Sources/SwiftIfConfig/BuildConfiguration.swift
@@ -243,6 +243,22 @@ public protocol BuildConfiguration {
   /// - Returns: Whether the target object file format matches the given name.
   func isActiveTargetObjectFormat(name: String) throws -> Bool
 
+  /// Determine whether the given ISA/CPU feature name (e.g., "avx2") is part of
+  /// the module codegen baseline.
+  ///
+  /// This can be queried by the experimental syntax
+  /// `_hasTargetFeature("<name>")`, e.g.,
+  ///
+  /// ```swift
+  /// #if _hasTargetFeature("avx2")
+  /// // AVX2-specific code
+  /// #endif
+  /// ```
+  /// - Parameters:
+  ///   - name: The name of the ISA feature to check.
+  /// - Returns: Whether the given feature is part of the target baseline.
+  func hasTargetFeature(name: String) throws -> Bool
+
   /// The bit width of a data pointer for the target architecture.
   ///
   /// The target's pointer bit width (which also corresponds to the number of
@@ -313,5 +329,10 @@ extension BuildConfiguration {
   @available(*, deprecated, message: "`BuildConfiguration` conformance must implement `isActiveTargetObjectFormat`")
   public func isActiveTargetObjectFormat(name: String) throws -> Bool {
     throw BuildConfigurationError.notImplemented(name: "isActiveTargetObjectFormat")
+  }
+
+  @available(*, deprecated, message: "`BuildConfiguration` conformance must implement `hasTargetFeature`")
+  public func hasTargetFeature(name: String) throws -> Bool {
+    throw BuildConfigurationError.notImplemented(name: "hasTargetFeature")
   }
 }

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -309,12 +309,42 @@ func evaluateIfConfig(
       }
     }
 
+    /// Perform a check for an operation that takes a single non-empty
+    /// string-literal argument.
+    func doSingleStringLiteralArgumentCheck(
+      _ body: (String) throws -> Bool,
+      role: String
+    ) -> (active: Bool, syntaxErrorsAllowed: Bool, diagnostics: [Diagnostic]) {
+      guard let argExpr = call.arguments.singleUnlabeledExpression,
+        let stringLiteral = argExpr.as(StringLiteralExprSyntax.self),
+        stringLiteral.segments.count == 1,
+        let segment = stringLiteral.segments.first,
+        case .stringSegment(let stringSegment) = segment,
+        !stringSegment.content.text.isEmpty
+      else {
+        return recordError(
+          .requiresUnlabeledArgument(name: fnName, role: role, syntax: ExprSyntax(call))
+        )
+      }
+      return checkConfiguration(at: argExpr) {
+        (active: try body(stringSegment.content.text), syntaxErrorsAllowed: fn.syntaxErrorsAllowed)
+      }
+    }
+
     switch fn {
     case .hasAttribute:
       return doSingleIdentifierArgumentCheck(configuration.hasAttribute, role: "attribute")
 
     case .hasFeature:
       return doSingleIdentifierArgumentCheck(configuration.hasFeature, role: "feature")
+
+    case ._hasTargetFeature:
+      // Gated behind an experimental feature flag; if it isn't enabled,
+      // treat the name as unrecognized.
+      guard (try? configuration.hasFeature(name: "TargetFeaturePredicate")) ?? false else {
+        return recordError(.unknownExpression(condition))
+      }
+      return doSingleStringLiteralArgumentCheck(configuration.hasTargetFeature, role: "target feature name")
 
     case .os:
       return doSingleIdentifierArgumentCheck(configuration.isActiveTargetOS, role: "operating system")
@@ -882,6 +912,10 @@ private struct CanImportSuppressingBuildConfiguration<Other: BuildConfiguration>
 
   func isActiveTargetObjectFormat(name: String) throws -> Bool {
     return try other.isActiveTargetObjectFormat(name: name)
+  }
+
+  func hasTargetFeature(name: String) throws -> Bool {
+    return try other.hasTargetFeature(name: name)
   }
 
   var targetPointerBitWidth: Int { return other.targetPointerBitWidth }

--- a/Sources/SwiftIfConfig/IfConfigFunctions.swift
+++ b/Sources/SwiftIfConfig/IfConfigFunctions.swift
@@ -60,6 +60,10 @@ enum IfConfigFunctions: String {
   /// via `_ptrauth(<name>)`.
   case _ptrauth
 
+  /// A check for a specific ISA/CPU feature in the module codegen target baseline (e.g., avx2) via
+  /// `_hasTargetFeature("<name>")`.
+  case _hasTargetFeature
+
   /// An unsupported function used by C preprocessor macros (e.g. `#if defined(FOO)`)
   case defined
 
@@ -72,7 +76,8 @@ enum IfConfigFunctions: String {
       return true
 
     case .hasAttribute, .hasFeature, .canImport, .os, .arch, .targetEnvironment,
-      ._hasAtomicBitWidth, ._endian, ._pointerBitWidth, .objectFormat, ._runtime, ._ptrauth, .defined:
+      ._hasAtomicBitWidth, ._endian, ._pointerBitWidth, .objectFormat, ._runtime, ._ptrauth,
+      ._hasTargetFeature, .defined:
       return false
     }
   }

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -211,6 +211,43 @@ public class EvaluateTests: XCTestCase {
     assertIfConfig("hasAttribute(unsafeUnavailable)", .inactive, configuration: buildConfig)
   }
 
+  func testTargetFeature() throws {
+    let buildConfig = TestingBuildConfiguration(
+      features: ["TargetFeaturePredicate"],
+      targetFeatures: ["avx2"]
+    )
+
+    assertIfConfig("_hasTargetFeature(\"avx2\")", .active, configuration: buildConfig)
+    assertIfConfig("_hasTargetFeature(\"avx512f\")", .inactive, configuration: buildConfig)
+    assertIfConfig(
+      "_hasTargetFeature(avx2)",
+      .unparsed,
+      configuration: buildConfig,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'_hasTargetFeature' requires a single unlabeled argument for the target feature name",
+          line: 1,
+          column: 1
+        )
+      ]
+    )
+
+    // TargetFeaturePredicate is disabled.
+    let disabledBuildConfig = TestingBuildConfiguration(targetFeatures: ["avx2"])
+    assertIfConfig(
+      "_hasTargetFeature(\"avx2\")",
+      .unparsed,
+      configuration: disabledBuildConfig,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "invalid conditional compilation expression",
+          line: 1,
+          column: 1
+        )
+      ]
+    )
+  }
+
   func testPlatform() throws {
     assertIfConfig("os(Linux)", .active)
     assertIfConfig("os(BeOS)", .inactive)

--- a/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
+++ b/Tests/SwiftIfConfigTest/TestingBuildConfiguration.swift
@@ -32,6 +32,7 @@ struct TestingBuildConfiguration: BuildConfiguration {
   var customConditions: Set<String> = []
   var features: Set<String> = []
   var attributes: Set<String> = []
+  var targetFeatures: Set<String> = []
 
   /// A set of attribute names that are "bad", causing the build configuration
   /// to throw an error if queried.
@@ -101,6 +102,10 @@ struct TestingBuildConfiguration: BuildConfiguration {
 
   func isActiveTargetObjectFormat(name: String) throws -> Bool {
     name == "ELF"
+  }
+
+  func hasTargetFeature(name: String) -> Bool {
+    targetFeatures.contains(name)
   }
 
   var targetPointerBitWidth: Int { 64 }


### PR DESCRIPTION
This allows conditional compiles (#if...) based on the target CPU/ISA features. This is guarded behind an experimental feature flag.

This is the swift-syntax part. There is a separate main swift repor part.